### PR TITLE
feat: PgBouncer (CNPG Pooler) for all CNPG instances

### DIFF
--- a/kubernetes/platform/data/backstage-db/kustomization.yaml
+++ b/kubernetes/platform/data/backstage-db/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: backstage
 
 resources:
   - postgres-cluster.yaml
+  - pgbouncer-pooler.yaml
 
 commonAnnotations:
   argocd.argoproj.io/sync-wave: "12"

--- a/kubernetes/platform/data/backstage-db/pgbouncer-pooler.yaml
+++ b/kubernetes/platform/data/backstage-db/pgbouncer-pooler.yaml
@@ -1,0 +1,19 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: backstage-postgres-pooler
+  namespace: backstage
+  annotations:
+    argocd.argoproj.io/sync-wave: "13"
+spec:
+  cluster:
+    name: backstage-postgres
+  instances: 1
+  type: rw
+  pgbouncer:
+    poolMode: transaction
+    parameters:
+      max_client_conn: "200"
+      default_pool_size: "10"
+      reserve_pool_size: "2"
+      server_idle_timeout: "600"

--- a/kubernetes/platform/data/boutique-postgres/kustomization.yaml
+++ b/kubernetes/platform/data/boutique-postgres/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - postgres-cluster.yaml
   - init-db.yaml
+  - pgbouncer-pooler.yaml

--- a/kubernetes/platform/data/boutique-postgres/pgbouncer-pooler.yaml
+++ b/kubernetes/platform/data/boutique-postgres/pgbouncer-pooler.yaml
@@ -1,0 +1,19 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: boutique-postgres-pooler
+  namespace: boutique-dev
+  annotations:
+    argocd.argoproj.io/sync-wave: "13"
+spec:
+  cluster:
+    name: boutique-postgres
+  instances: 1
+  type: rw
+  pgbouncer:
+    poolMode: transaction
+    parameters:
+      max_client_conn: "200"
+      default_pool_size: "10"
+      reserve_pool_size: "2"
+      server_idle_timeout: "600"

--- a/kubernetes/platform/data/druid/cluster/kustomization.yaml
+++ b/kubernetes/platform/data/druid/cluster/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - tls-certificates.yaml
   # Database
   - postgres-cluster.yaml
+  - pgbouncer-pooler.yaml
   # Druid CR (Operator-based)
   - druid-cluster.yaml
   # OAuth2/OIDC

--- a/kubernetes/platform/data/druid/cluster/pgbouncer-pooler.yaml
+++ b/kubernetes/platform/data/druid/cluster/pgbouncer-pooler.yaml
@@ -1,0 +1,19 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: druid-postgres-pooler
+  namespace: druid
+  annotations:
+    argocd.argoproj.io/sync-wave: "13"
+spec:
+  cluster:
+    name: druid-postgres
+  instances: 2
+  type: rw
+  pgbouncer:
+    poolMode: transaction
+    parameters:
+      max_client_conn: "500"
+      default_pool_size: "20"
+      reserve_pool_size: "5"
+      server_idle_timeout: "600"

--- a/kubernetes/platform/data/infisical-db/kustomization.yaml
+++ b/kubernetes/platform/data/infisical-db/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: infisical
 
 resources:
   - postgres-cluster.yaml
+  - pgbouncer-pooler.yaml
 
 commonAnnotations:
   argocd.argoproj.io/sync-wave: "12"

--- a/kubernetes/platform/data/infisical-db/pgbouncer-pooler.yaml
+++ b/kubernetes/platform/data/infisical-db/pgbouncer-pooler.yaml
@@ -1,0 +1,19 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: infisical-postgres-pooler
+  namespace: infisical
+  annotations:
+    argocd.argoproj.io/sync-wave: "13"
+spec:
+  cluster:
+    name: infisical-postgres
+  instances: 2
+  type: rw
+  pgbouncer:
+    poolMode: transaction
+    parameters:
+      max_client_conn: "500"
+      default_pool_size: "20"
+      reserve_pool_size: "5"
+      server_idle_timeout: "600"

--- a/kubernetes/platform/data/keycloak-db/kustomization.yaml
+++ b/kubernetes/platform/data/keycloak-db/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - backup-obc.yaml
   - postgres-cluster.yaml
   - scheduled-backup.yaml
+  - pgbouncer-pooler.yaml
 
 commonAnnotations:
   argocd.argoproj.io/sync-wave: "12"

--- a/kubernetes/platform/data/keycloak-db/pgbouncer-pooler.yaml
+++ b/kubernetes/platform/data/keycloak-db/pgbouncer-pooler.yaml
@@ -1,0 +1,19 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: keycloak-db-pooler
+  namespace: keycloak
+  annotations:
+    argocd.argoproj.io/sync-wave: "13"
+spec:
+  cluster:
+    name: keycloak-db
+  instances: 2
+  type: rw
+  pgbouncer:
+    poolMode: transaction
+    parameters:
+      max_client_conn: "500"
+      default_pool_size: "20"
+      reserve_pool_size: "5"
+      server_idle_timeout: "600"

--- a/kubernetes/platform/data/lldap-db/kustomization.yaml
+++ b/kubernetes/platform/data/lldap-db/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: lldap
 
 resources:
   - postgres-cluster.yaml
+  - pgbouncer-pooler.yaml
 
 commonAnnotations:
   argocd.argoproj.io/sync-wave: "12"

--- a/kubernetes/platform/data/lldap-db/pgbouncer-pooler.yaml
+++ b/kubernetes/platform/data/lldap-db/pgbouncer-pooler.yaml
@@ -1,0 +1,19 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: lldap-postgres-pooler
+  namespace: lldap
+  annotations:
+    argocd.argoproj.io/sync-wave: "13"
+spec:
+  cluster:
+    name: lldap-postgres
+  instances: 1
+  type: rw
+  pgbouncer:
+    poolMode: transaction
+    parameters:
+      max_client_conn: "200"
+      default_pool_size: "10"
+      reserve_pool_size: "2"
+      server_idle_timeout: "600"

--- a/kubernetes/platform/data/n8n-dev-cnpg/kustomization.yaml
+++ b/kubernetes/platform/data/n8n-dev-cnpg/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 - backup-obc.yaml
 - postgres-cluster.yaml
 - scheduled-backup.yaml
+# - pgbouncer-pooler.yaml  # aktivieren wenn Staging-Cluster auf Raspberry Pis läuft
 
 commonLabels:
   app.kubernetes.io/name: n8n-postgres

--- a/kubernetes/platform/data/n8n-dev-cnpg/pgbouncer-pooler.yaml
+++ b/kubernetes/platform/data/n8n-dev-cnpg/pgbouncer-pooler.yaml
@@ -1,0 +1,19 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: n8n-postgres-pooler
+  namespace: n8n-dev
+  annotations:
+    argocd.argoproj.io/sync-wave: "13"
+spec:
+  cluster:
+    name: n8n-postgres
+  instances: 1
+  type: rw
+  pgbouncer:
+    poolMode: transaction
+    parameters:
+      max_client_conn: "200"
+      default_pool_size: "10"
+      reserve_pool_size: "2"
+      server_idle_timeout: "600"

--- a/kubernetes/platform/data/n8n-prod-cnpg/kustomization.yaml
+++ b/kubernetes/platform/data/n8n-prod-cnpg/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - backup-obc.yaml
   - cluster.yaml
   - scheduled-backup.yaml
+  - pgbouncer-pooler.yaml
 
 labels:
   - pairs:

--- a/kubernetes/platform/data/n8n-prod-cnpg/pgbouncer-pooler.yaml
+++ b/kubernetes/platform/data/n8n-prod-cnpg/pgbouncer-pooler.yaml
@@ -1,0 +1,19 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: n8n-postgres-pooler
+  namespace: n8n-prod
+  annotations:
+    argocd.argoproj.io/sync-wave: "13"
+spec:
+  cluster:
+    name: n8n-postgres
+  instances: 2
+  type: rw
+  pgbouncer:
+    poolMode: transaction
+    parameters:
+      max_client_conn: "1000"
+      default_pool_size: "25"
+      reserve_pool_size: "5"
+      server_idle_timeout: "600"

--- a/kubernetes/platform/data/quantlab-postgres/kustomization.yaml
+++ b/kubernetes/platform/data/quantlab-postgres/kustomization.yaml
@@ -20,6 +20,7 @@ helmCharts:
 resources:
 - namespace.yaml
 - postgres-cluster.yaml
+- pgbouncer-pooler.yaml
 
 labels:
   - pairs:

--- a/kubernetes/platform/data/quantlab-postgres/pgbouncer-pooler.yaml
+++ b/kubernetes/platform/data/quantlab-postgres/pgbouncer-pooler.yaml
@@ -1,0 +1,19 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: quantlab-postgres-pooler
+  namespace: quantlab-postgres
+  annotations:
+    argocd.argoproj.io/sync-wave: "13"
+spec:
+  cluster:
+    name: quantlab-postgres
+  instances: 2
+  type: rw
+  pgbouncer:
+    poolMode: transaction
+    parameters:
+      max_client_conn: "500"
+      default_pool_size: "20"
+      reserve_pool_size: "5"
+      server_idle_timeout: "600"


### PR DESCRIPTION
## Summary
Adds CNPG `Pooler` (PgBouncer transaction mode) for all active CNPG clusters:
- `n8n-postgres` (n8n-prod) — 2 instances
- `infisical-postgres` — 2 instances
- `lldap-postgres` — 1 instance
- `keycloak-db` — 2 instances
- `boutique-postgres` — 1 instance
- `quantlab-postgres` — 2 instances
- `druid-postgres` — 2 instances
- `backstage-postgres` — 1 instance

n8n-dev pooler file exists but is **commented out** — activate when Raspberry Pi staging cluster is ready.

## Action required after merge
Each app whose DB_URL points to `{cluster}-rw` must be re-sealed to use `{cluster}-pooler-rw:5432`.

## Test plan
- [ ] ArgoCD syncs all Pooler Deployments
- [ ] `kubectl get pooler -A` shows all entries as Ready
- [ ] Apps reconnect via pooler after secret re-seal