### PR TITLE
chore(deps): update keycloak

### DIFF
--- a/kubernetes/infrastructure/controllers/operators/base/keycloak-operator/operator.yaml
+++ b/kubernetes/infrastructure/controllers/operators/base/keycloak-operator/operator.yaml
@@ -330,7 +330,7 @@ spec:
                   fieldPath: metadata.namespace
             - name: RELATED_IMAGE_KEYCLOAK
               value: quay.io/keycloak/keycloak:25.0.6
-          image: quay.io/keycloak/keycloak-operator:25.0.6
+          image: quay.io/keycloak/keycloak-operator:25.0.6@sha256:6e4abe4b1e020da4cca47272d18800fe2a72d1a08956e45fd6a64ea2ce8f6ac7
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 3

--- a/kubernetes/platform/identity/keycloak/base/keycloak-cr.yaml
+++ b/kubernetes/platform/identity/keycloak/base/keycloak-cr.yaml
@@ -24,7 +24,7 @@ metadata:
     secret.reloader.stakater.com/reload: keycloak-db-credentials,keycloak-admin
 spec:
   instances: 3                              # HA: 3 Replicas + Sticky-Session via BackendTrafficPolicy + Infinispan
-  image: quay.io/keycloak/keycloak:25.0.6
+  image: quay.io/keycloak/keycloak:25.0.6@sha256:82c5b7a110456dbd42b86ea572e728878549954cc8bd03cd65410d75328095d2
   startOptimized: false                     # JIT optimization for first start
 
   db:


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/keycloak`
Filter passed: <24h old, <5 commits ahead.