### PR TITLE
chore(deps): update rook-ceph

### DIFF
--- a/kubernetes/infrastructure/storage/rook-ceph/base/ceph-crash-archive.yaml
+++ b/kubernetes/infrastructure/storage/rook-ceph/base/ceph-crash-archive.yaml
@@ -26,7 +26,7 @@ spec:
           restartPolicy: OnFailure
           initContainers:
             - name: config-init
-              image: quay.io/ceph/ceph:v19.2.3
+              image: quay.io/ceph/ceph:v19.2.3@sha256:af0c5903e901e329adabe219dfc8d0c3efc1f05102a753902f33ee16c26b6cee
               command:
                 - /bin/bash
                 - -c
@@ -48,7 +48,7 @@ spec:
                   mountPath: /etc/ceph-keyring
           containers:
             - name: ceph-crash-archiver
-              image: quay.io/ceph/ceph:v19.2.3
+              image: quay.io/ceph/ceph:v19.2.3@sha256:af0c5903e901e329adabe219dfc8d0c3efc1f05102a753902f33ee16c26b6cee
               command:
                 - /bin/bash
                 - -c

--- a/kubernetes/infrastructure/storage/rook-ceph/base/cluster.yaml
+++ b/kubernetes/infrastructure/storage/rook-ceph/base/cluster.yaml
@@ -14,7 +14,7 @@ spec:
     # Ceph Squid v19.2.3 - Latest stable (December 2025)
     # Ceph Tentacle v20.2.0 available but Squid is more stable for homelab
     # https://docs.ceph.com/en/latest/releases/
-    image: quay.io/ceph/ceph:v19.2.3
+    image: quay.io/ceph/ceph:v19.2.3@sha256:af0c5903e901e329adabe219dfc8d0c3efc1f05102a753902f33ee16c26b6cee
     allowUnsupported: false
 
   # SECURITY UPGRADES (Optional - for Production/Finance/Healthcare):

--- a/kubernetes/infrastructure/storage/rook-ceph/base/toolbox.yaml
+++ b/kubernetes/infrastructure/storage/rook-ceph/base/toolbox.yaml
@@ -20,7 +20,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
         - name: config-init
-          image: quay.io/ceph/ceph:v19.2.3
+          image: quay.io/ceph/ceph:v19.2.3@sha256:af0c5903e901e329adabe219dfc8d0c3efc1f05102a753902f33ee16c26b6cee
           command:
             - /bin/bash
             - -c
@@ -45,7 +45,7 @@ spec:
               name: ceph-admin-keyring
       containers:
         - name: rook-ceph-tools
-          image: quay.io/ceph/ceph:v19.2.3
+          image: quay.io/ceph/ceph:v19.2.3@sha256:af0c5903e901e329adabe219dfc8d0c3efc1f05102a753902f33ee16c26b6cee
           command:
             - /bin/bash
             - -c

--- a/kubernetes/infrastructure/storage/velero/base/create-rgw-users-job.yaml
+++ b/kubernetes/infrastructure/storage/velero/base/create-rgw-users-job.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: rook-ceph-system
       containers:
         - name: create-users
-          image: rook/ceph:v1.18.7
+          image: rook/ceph:v1.19.5@sha256:f1d114a3edba5eb735250a1a56f4ebe6688cbb2f9c1f51fc67b1c28df88a6e7b
           command:
             - /bin/bash
             - -c


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/rook-ceph`
Filter passed: <24h old, <5 commits ahead.