### PR TITLE
chore(deps): update alpine-k8s to v1.33

### DIFF
--- a/kubernetes/infrastructure/storage/velero-schedules/restore-verify-cronjob.yaml
+++ b/kubernetes/infrastructure/storage/velero-schedules/restore-verify-cronjob.yaml
@@ -69,7 +69,7 @@ spec:
             seccompProfile: { type: RuntimeDefault }
           containers:
             - name: verify
-              image: alpine/k8s:1.33.0@sha256:60333a52c38e9a8df0a9b93a5a24a4870f0db2c7ea3266b185386bd0a500d7dc
+              image: alpine/k8s:1.33.11@sha256:829736ec633e58b18b3ea91567a738429540d1112b9e0e58edd295ba476dad8d
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/alpine-k8s-1.33.x`
Filter passed: <24h old, <5 commits ahead.