### PR TITLE
chore(deps): update dbeaver-cloudbeaver to v25.0

### DIFF
--- a/kubernetes/platform/data/cloudbeaver/base/deployment.yaml
+++ b/kubernetes/platform/data/cloudbeaver/base/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: cloudbeaver
-        image: dbeaver/cloudbeaver:25.0.0@sha256:18617b182ebed2fdcaecf6af99951284b1f916e668eb00d680cba6781ae3bbb8
+        image: dbeaver/cloudbeaver:25.0.5@sha256:4a6835d07ae8f3e9ff3bcc03d7efe1ab0552a93d57e761951109b8193d20701c
         ports:
         - containerPort: 8978
           name: http


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/dbeaver-cloudbeaver-25.0.x`
Filter passed: <24h old, <5 commits ahead.