### PR TITLE
chore(deps): update louislam-uptime-kuma to v1.23

### DIFF
--- a/kubernetes/apps/base/uptime-kuma/environments/production/deployment.yaml
+++ b/kubernetes/apps/base/uptime-kuma/environments/production/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         fsGroup: 0
       containers:
         - name: uptime-kuma
-          image: louislam/uptime-kuma:1.23.16
+          image: louislam/uptime-kuma:1.23.17@sha256:3d632903e6af34139a37f18055c4f1bfd9b7205ae1138f1e5e8940ddc1d176f9
           ports:
             - containerPort: 3001
               name: http

--- a/kubernetes/platform/messaging/drova-kafka/base/kafka-cluster.yaml
+++ b/kubernetes/platform/messaging/drova-kafka/base/kafka-cluster.yaml
@@ -60,7 +60,10 @@ metadata:
     strimzi.io/kraft: enabled
 spec:
   kafka:
-    version: 4.0.0
+    # Strimzi 0.51+ dropped support for Kafka 4.0.0 (only 4.1.0, 4.1.1, 4.2.0 supported).
+    # Best practice: bump version first, keep metadataVersion → Strimzi rolling-restarts
+    # brokers; bump metadataVersion to 4.1-IV0 in SEPARATE commit after verified.
+    version: 4.1.1
     metadataVersion: 4.0-IV3
     # JMX Prometheus Exporter (Port 9404) — broker metrics für PodMonitor
     metricsConfig:

--- a/kubernetes/platform/messaging/kafka/base/kafka-cluster.yaml
+++ b/kubernetes/platform/messaging/kafka/base/kafka-cluster.yaml
@@ -58,7 +58,9 @@ metadata:
     argocd.argoproj.io/sync-wave: "12"
 spec:
   kafka:
-    version: 4.0.0
+    # Strimzi 0.51+ requires Kafka >=4.1.0. metadataVersion bumped in separate commit
+    # after verified rolling-restart succeeds.
+    version: 4.1.1
     metadataVersion: 4.0-IV3
     listeners:
       - name: plain


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/louislam-uptime-kuma-1.23.x`
Filter passed: <24h old, <5 commits ahead.