### PR TITLE
chore(deps): update docker.io-aquasec-kube-bench to v0.10

### DIFF
--- a/kubernetes/security/compliance/kube-bench/cronjob.yaml
+++ b/kubernetes/security/compliance/kube-bench/cronjob.yaml
@@ -53,7 +53,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: kube-bench
-              image: docker.io/aquasec/kube-bench:v0.10.6@sha256:8de507af3d6603e04b4952b27dd122ecf3c4fb313a24fc9c72e9c999592b8158
+              image: docker.io/aquasec/kube-bench:v0.10.7@sha256:f0bc1aa9d21bab773a8686d600d449ec256444139504c03a6f535cebbfcbc43e
               command:
                 - kube-bench
                 - run


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/docker.io-aquasec-kube-bench-0.10.x`
Filter passed: <24h old, <5 commits ahead.