### PR TITLE
chore(deps): update docker.io-bitnamilegacy-kubectl to v1.33

### DIFF
--- a/kubernetes/platform/data/drova-postgres/base/dr-verify-cronjob.yaml
+++ b/kubernetes/platform/data/drova-postgres/base/dr-verify-cronjob.yaml
@@ -72,7 +72,7 @@ spec:
             seccompProfile: { type: RuntimeDefault }
           containers:
             - name: verify
-              image: docker.io/bitnamilegacy/kubectl:1.33.0
+              image: docker.io/bitnamilegacy/kubectl:1.33.4@sha256:ed0b31a0508da84ee655c5c6e01bd3897fc56ad6cf69debb27fa1893a06d2246
               command: [/bin/bash, -c]
               args:
                 - |


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/docker.io-bitnamilegacy-kubectl-1.33.x`
Filter passed: <24h old, <5 commits ahead.