### PR TITLE
cronjob ttl autocleanup + mise debug tasks

### DIFF
--- a/kubernetes/infrastructure/observability/elasticsearch/base/cluster/jaeger-retention-cleanup.yaml
+++ b/kubernetes/infrastructure/observability/elasticsearch/base/cluster/jaeger-retention-cleanup.yaml
@@ -29,6 +29,7 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 600
       backoffLimit: 2
       template:
         metadata:

--- a/kubernetes/infrastructure/storage/rook-ceph/base/ceph-crash-archive.yaml
+++ b/kubernetes/infrastructure/storage/rook-ceph/base/ceph-crash-archive.yaml
@@ -17,6 +17,7 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 600
       template:
         metadata:
           labels:

--- a/kubernetes/infrastructure/storage/rook-ceph/base/csi-orphan-cleanup.yaml
+++ b/kubernetes/infrastructure/storage/rook-ceph/base/csi-orphan-cleanup.yaml
@@ -40,6 +40,7 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 600
       backoffLimit: 1
       template:
         spec:

--- a/kubernetes/infrastructure/storage/rook-ceph/base/released-pv-cleanup.yaml
+++ b/kubernetes/infrastructure/storage/rook-ceph/base/released-pv-cleanup.yaml
@@ -38,6 +38,7 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 600
       backoffLimit: 1
       template:
         spec:

--- a/kubernetes/platform/gitops/renovate/base/orphan-pr-opener.yaml
+++ b/kubernetes/platform/gitops/renovate/base/orphan-pr-opener.yaml
@@ -25,6 +25,7 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 600
       backoffLimit: 1
       template:
         spec:

--- a/kubernetes/platform/identity/keycloak/base/2fa-enforce-existing-users.yaml
+++ b/kubernetes/platform/identity/keycloak/base/2fa-enforce-existing-users.yaml
@@ -36,6 +36,7 @@ spec:
   startingDeadlineSeconds: 600
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 600
       backoffLimit: 3
       template:
         metadata:

--- a/kubernetes/platform/identity/keycloak/base/cluster-health-cronjob.yaml
+++ b/kubernetes/platform/identity/keycloak/base/cluster-health-cronjob.yaml
@@ -58,12 +58,12 @@ metadata:
 spec:
   schedule: "*/30 * * * *"    # every 30 min
   concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 7
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       backoffLimit: 1
-      ttlSecondsAfterFinished: 86400
+      ttlSecondsAfterFinished: 600
       activeDeadlineSeconds: 600
       template:
         spec:

--- a/kubernetes/platform/identity/lldap/base/bootstrap-job.yaml
+++ b/kubernetes/platform/identity/lldap/base/bootstrap-job.yaml
@@ -14,11 +14,12 @@ spec:
   schedule: "0 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 1
-  failedJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
   startingDeadlineSeconds: 600
   jobTemplate:
     spec:
       backoffLimit: 3
+      ttlSecondsAfterFinished: 600
       template:
         spec:
           restartPolicy: OnFailure

--- a/kubernetes/security/compliance/kube-bench/cronjob.yaml
+++ b/kubernetes/security/compliance/kube-bench/cronjob.yaml
@@ -47,6 +47,7 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 600
       template:
         spec:
           serviceAccountName: kube-bench

--- a/mise.toml
+++ b/mise.toml
@@ -52,9 +52,9 @@ experimental = true
 #
 # ════════════════════════════════════════════════════════════════════════
 [env]
-# Default beim `cd`: Break-Glass (X.509 Admin) — funktioniert auf frischem Cluster.
-# TODO: zurueck auf config-oidc sobald Keycloak via GitOps-Bootstrap deployt ist.
-KUBECONFIG = "{{ env.HOME }}/.kube/config-break-glass"
+# Default beim `cd`: aktuelle Admin-Kubeconfig (X.509, post-rebuild CA).
+# config-break-glass war stale (pre-2026-05-22-rebuild CA) → ECDSA failure.
+KUBECONFIG = "{{ env.HOME }}/.kube/homelab-admin.yaml"
 
 # Aliases via mise tasks (siehe unten):
 #   mise run kube-oidc        → zeigt OIDC-Pfad an
@@ -73,7 +73,7 @@ description = "Show cluster information"
 run = """
 echo " Talos Cluster Info:"
 kubectl get nodes -o wide
-kubectl get pods -A --field-selector=status.phase!=Running
+kubectl get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded
 """
 
 [tasks.cluster-status]
@@ -85,9 +85,10 @@ CP_IPS=$(talosctl get members -n $ENDPOINT -o json 2>/dev/null | \
   jq -r '[.items[] | select(.spec.machineType=="controlplane") | .spec.addresses[0]] | join(",")' 2>/dev/null || echo "$ENDPOINT")
 WORKER_IPS=$(talosctl get members -n $ENDPOINT -o json 2>/dev/null | \
   jq -r '[.items[] | select(.spec.machineType=="worker") | .spec.addresses[0]] | join(",")' 2>/dev/null || echo "")
-talosctl health \
+talosctl -n "$ENDPOINT" health \
   --control-plane-nodes "$CP_IPS" \
-  --worker-nodes "$WORKER_IPS"
+  --worker-nodes "$WORKER_IPS" \
+  --wait-timeout 1m
 
 echo ""
 echo "☸️ Kubernetes Nodes:"
@@ -95,7 +96,7 @@ kubectl get nodes -o wide
 
 echo ""
 echo "⚠️ Not Running Pods:"
-kubectl get pods -A --field-selector=status.phase!=Running
+kubectl get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded
 """
 
 [tasks.apply-manifests]
@@ -123,7 +124,7 @@ tofu apply
 
 # ─── Kubeconfig-Switcher ────────────────────────────────────────────────
 [tasks.kube-oidc]
-description = "🔑 Switch to OIDC kubeconfig (Daily-Driver via Keycloak)"
+description = "🔑 ZEIGT den OIDC-export-Befehl (Task kann Parent-Shell nicht ändern → selbst ausführen)"
 run = """
 echo "export KUBECONFIG=$HOME/.kube/config-oidc"
 echo ""
@@ -134,7 +135,7 @@ echo "   • Permissions: cluster-admin via group cluster-admins"
 """
 
 [tasks.kube-break-glass]
-description = "🚨 Switch to Break-Glass kubeconfig (X.509 admin, KC bypassen)"
+description = "🚨 ZEIGT den Break-Glass-export-Befehl (Task kann Parent-Shell nicht ändern → selbst ausführen)"
 run = """
 echo "export KUBECONFIG=$HOME/.kube/config-break-glass"
 echo ""
@@ -157,6 +158,37 @@ kubectl config current-context 2>/dev/null
 kubectl auth whoami 2>/dev/null || true
 """
 
+# ─── Network / Cilium Debugging ─────────────────────────────────────────
+[tasks.cilium-health]
+description = "🌐 Cilium Node-zu-Node Datapath-Matrix (DAS Tool für Netzwerk-Outages)"
+run = "kubectl exec -n kube-system ds/cilium -c cilium-agent -- cilium-health status"
+
+[tasks.cilium-status]
+description = "🌐 Cilium Agent-Status (Encryption/WireGuard/Controller)"
+run = "kubectl exec -n kube-system ds/cilium -c cilium-agent -- cilium-dbg status"
+
+# ─── Rook-Ceph ──────────────────────────────────────────────────────────
+[tasks.ceph-status]
+description = "💾 Rook-Ceph Cluster-Status (via Toolbox)"
+run = "kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status"
+
+[tasks.ceph-health]
+description = "💾 Rook-Ceph health detail + OSD-Status + Auslastung"
+run = """
+echo '-- ceph health detail --'; kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph health detail
+echo '-- osd status --';         kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd status
+echo '-- df --';                 kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph df
+"""
+
+# ─── Kafka / Strimzi (namespace drova) ──────────────────────────────────
+[tasks.kafka-status]
+description = "📨 Kafka/Strimzi Status — Cluster + NodePools + Topics + Pods (drova)"
+run = """
+echo '-- kafka cluster + nodepools --'; kubectl get kafka,kafkanodepool -n drova
+echo '-- topics --';                    kubectl get kafkatopic -n drova
+echo '-- broker/controller pods --';    kubectl get pods -n drova -l strimzi.io/cluster=drova-kafka -o wide
+"""
+
 [hooks]
 enter = """
 mise trust --quiet 2>/dev/null || true
@@ -171,7 +203,7 @@ echo '════════════════════════�
 echo '🐧 TALOSCTL'
 echo '══════════════════════════════════════════════════════════════════'
 echo '  mise run cluster-status                  # Cluster Health Check (auto-discover IPs)'
-echo '  talosctl health --control-plane-nodes <cp-ip> --worker-nodes <w1-ip>,<w2-ip>  # Direkt'
+echo '  talosctl -n <cp-ip> health --control-plane-nodes <cp-ip> --worker-nodes <w1>,<w2>  # single -n!'
 echo '  talosctl get members -n 192.168.0.101   # Alle Nodes + IPs anzeigen'
 echo '  talosctl version                         # Talos Version (client + server)'
 echo '  talosctl dashboard                       # Live Node Dashboard (TUI)'
@@ -211,7 +243,7 @@ echo '════════════════════════�
 echo '⚓ KUBECTL — PODS & WORKLOADS'
 echo '══════════════════════════════════════════════════════════════════'
 echo '  kubectl get pods -A                     # Alle Pods aller Namespaces'
-echo '  kubectl get pods -A --field-selector=status.phase!=Running  # Nicht-Running Pods'
+echo '  kubectl get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded  # Nicht-Running Pods'
 echo '  kubectl get pods -n <ns> -o wide        # Pods mit Node-Zuweisung'
 echo '  kubectl describe pod <name> -n <ns>     # Pod Details + Events'
 echo '  kubectl logs <pod> -n <ns> -f           # Logs live verfolgen'
@@ -244,6 +276,48 @@ echo '  kubectl get httproute -A               # Gateway API Routes'
 echo '  kubectl get crd                        # Alle installierten CRDs'
 echo ''
 echo '══════════════════════════════════════════════════════════════════'
+echo '🌐 CILIUM / NETWORK DEBUGGING'
+echo '══════════════════════════════════════════════════════════════════'
+echo '  mise run cilium-health                  # ⭐ Node-zu-Node Datapath-Matrix — DER Outage-Check'
+echo '  mise run cilium-status                  # Agent-Status (Encryption/WireGuard/Controller)'
+echo '  POD=$(kubectl get pod -n kube-system -l k8s-app=cilium --field-selector spec.nodeName=worker-2 -o name|head -1)'
+echo '  kubectl exec -n kube-system $POD -c cilium-agent -- cilium-health status   # Sicht EINES Nodes'
+echo '  kubectl exec -n kube-system ds/cilium -c cilium-agent -- cilium-dbg bpf ct flush global  # conntrack flushen'
+echo '  hubble observe --verdict DROPPED -f     # Live: gedroppte Pakete'
+echo ''
+echo '  🔍 Diagnose-Leiter bei "Pod kann nicht connecten":'
+echo '   1. cilium-health → welcher Node-Pfad ist 0/1?  (der Ausreißer = das Problem)'
+echo '   2. Symptom-Pod + Ziel-Pod: auf welchen NODES?   (kubectl get pod -o wide)'
+echo '   3. Test-Pod auf Quell-Node pinnen → nc zur AKTUELLEN Ziel-Pod-IP (nie stale!)'
+echo '   4. Cross-host? → SSH Proxmox: pve-firewall (NIEMALS an!) + nft list ruleset'
+echo '   5. Node stuck trotz fix? → cordon+drain+delete ciliumnode → reboot'
+echo ''
+echo '══════════════════════════════════════════════════════════════════'
+echo '💾 ROOK-CEPH'
+echo '══════════════════════════════════════════════════════════════════'
+echo '  mise run ceph-status                    # Cluster-Status (HEALTH_OK?)'
+echo '  mise run ceph-health                    # health detail + osd status + df'
+echo '  kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph <cmd>   # beliebiger ceph-Befehl:'
+echo '     ceph osd tree        # OSD-Baum (welche OSD auf welchem Node)'
+echo '     ceph osd df          # Auslastung pro OSD'
+echo '     ceph pg stat         # Placement-Group-Status'
+echo '  kubectl get cephcluster -n rook-ceph    # Cluster-CR Status'
+echo '  kubectl -n rook-ceph get pods           # Rook-Pods (mon/osd/mgr/mds/rgw)'
+echo ''
+echo '══════════════════════════════════════════════════════════════════'
+echo '📨 KAFKA / STRIMZI (namespace drova)'
+echo '══════════════════════════════════════════════════════════════════'
+echo '  mise run kafka-status                   # Cluster + NodePools + Topics + Pods'
+echo '  kubectl get kafka,kafkanodepool,kafkatopic -n drova   # Strimzi-CRs (Ready-Spalte!)'
+echo '  kubectl get pods -n drova -l strimzi.io/cluster=drova-kafka -o wide   # broker[0-2]+ctrl[3-5]'
+echo '  kubectl describe kafka drova-kafka -n drova           # Conditions/Warnings'
+echo '  kubectl logs -n drova drova-kafka-controller-3 -c kafka -f   # KRaft-Quorum/Leader (Ctrl-Log)'
+echo '  kubectl logs -n drova drova-kafka-broker-0 -c kafka -f       # Broker-Log'
+echo '  kubectl get kafkatopic <topic> -n drova -o yaml       # Topic-Detail (Partitions/ISR)'
+echo '  ⚠ rohe kafka-*.sh CLI geht NICHT direkt: Listener=SASL+TLS (9095). Für'
+echo '     Quorum/Lag → Controller-Logs oben + Grafana (kafka-exporter), nicht kafka-topics.sh'
+echo ''
+echo '══════════════════════════════════════════════════════════════════'
 echo '🔒 SEALED SECRETS'
 echo '══════════════════════════════════════════════════════════════════'
 echo '  kubeseal --fetch-cert --controller-name=sealed-secrets --controller-namespace=sealed-secrets > pub-cert.pem'
@@ -252,7 +326,9 @@ echo ''
 echo '══════════════════════════════════════════════════════════════════'
 echo '🔑 ARGOCD'
 echo '══════════════════════════════════════════════════════════════════'
-echo '  argocd app list                         # Alle Apps + Sync Status'
+echo '  ⚠ erst login: argocd login <argocd-host> --sso   (sonst TLS/connection-refused)'
+echo '  ODER ohne CLI: kubectl get applications -n argocd        # Apps + Sync/Health direkt'
+echo '  argocd app list                         # Alle Apps + Sync Status (nach login)'
 echo '  argocd app sync <app>                   # App manuell syncen'
 echo '  argocd app diff <app>                   # Was würde sich ändern?'
 echo '  argocd app get <app>                    # App Details'
@@ -274,6 +350,11 @@ echo '  mise run cluster-status   # Talos Health + K8s Nodes'
 echo '  mise run cluster-info     # Nodes + nicht-Running Pods'
 echo '  mise run tofu-plan        # Infrastructure Plan'
 echo '  mise run tofu-apply       # Infrastructure Apply'
+echo '  mise run cilium-health    # 🌐 Node-Datapath-Matrix (Netzwerk-Outage-Check)'
+echo '  mise run cilium-status    # 🌐 Cilium Agent-Status'
+echo '  mise run ceph-status      # 💾 Rook-Ceph Status'
+echo '  mise run ceph-health      # 💾 Rook-Ceph health + osd + df'
+echo '  mise run kafka-status     # 📨 Kafka/Strimzi Cluster + Topics + Pods'
 echo '══════════════════════════════════════════════════════════════════'
 echo ''
 """


### PR DESCRIPTION
## CronJob TTL auto-cleanup
ttlSecondsAfterFinished: 600 auf 9 CronJobs → fertige/failed Jobs loeschen sich nach 10min selbst → kein KubeJobFailed-Alert-Spam durch Job-Leichen mehr (heute 13 stale Leichen manuell geloescht).
keycloak-cluster-health: ttl 86400->600 + failedJobsHistoryLimit 7->1 (war der 7-Leichen-Offender).

## mise.toml
- neue Tasks: cilium-health/cilium-status/ceph-status/ceph-health/kafka-status
- KUBECONFIG -> homelab-admin.yaml (config-break-glass war stale post-rebuild)
- cluster-status talosctl -n single + wait-timeout, cluster-info Filter +Succeeded
- Network/Ceph/Kafka Cheatsheet-Sektionen + argocd-login-note