### PR TITLE
fix realm-export admin secret

### DIFF
--- a/kubernetes/platform/identity/keycloak/base/realm-export-cronjob.yaml
+++ b/kubernetes/platform/identity/keycloak/base/realm-export-cronjob.yaml
@@ -64,7 +64,7 @@ spec:
                 - name: KC_ADMIN_PASSWORD
                   valueFrom:
                     secretKeyRef:
-                      name: keycloak-admin
+                      name: keycloak-initial-admin
                       key: password
                 - name: REALM
                   value: kubernetes


### PR DESCRIPTION
keycloak-realm-export CronJob authentifizierte mit Secret keycloak-admin (pw mismatch nach Rebuild) → invalid_grant → KubeJobFailed jede 30min. Fix: KC_ADMIN_PASSWORD aus keycloak-initial-admin (das Secret das keycloak selbst nutzt, username=admin verifiziert). Live getestet: Export laeuft durch (69KB realm.json + Rotation).