### PR TITLE
rightsize prepareosd memory to 64Mi

### DIFF
--- a/kubernetes/infrastructure/storage/rook-ceph/base/cluster.yaml
+++ b/kubernetes/infrastructure/storage/rook-ceph/base/cluster.yaml
@@ -175,7 +175,7 @@ spec:
     prepareosd:
       requests:
         cpu: "100m"   # Reduced from 250m - worker-1 CPU saturated, prepare jobs are light
-        memory: "256Mi"
+        memory: "64Mi"   # Reduced from 256Mi - fits packed msa2 worker headroom, prepare only scans disks
     crashcollector:
       requests:
         cpu: "50m"


### PR DESCRIPTION
osd-prepare-worker-4 stuck Pending 9h: worker-4 RAM-requests 99% (Outage-rebalancing), 256Mi prepare passte nicht. prepareosd ist ein leichter Disk-Scanner → 256Mi->64Mi. Live verifiziert: nach Entlastung + 64Mi laeuft osd-prepare durch (Completed). Ceph HEALTH_OK durchgehend.