### PR TITLE
fix renovate no-run alert false-positive (4h->13h)

### DIFF
--- a/kubernetes/platform/gitops/renovate/base/prometheusrule.yaml
+++ b/kubernetes/platform/gitops/renovate/base/prometheusrule.yaml
@@ -44,16 +44,16 @@ spec:
     - name: renovate.runs
       interval: 5m
       rules:
-        - alert: RenovateNoSuccessfulRunIn4h
+        - alert: RenovateNoSuccessfulRunIn13h
           expr: |
-            (time() - max by (renovatejob) (kube_job_status_completion_time{namespace="renovate-operator", job_name=~"renovate-(drova|talos-homelab).*"})) > 14400
+            (time() - max by (renovatejob) (kube_job_status_completion_time{namespace="renovate-operator", job_name=~"renovate-(drova|talos-homelab).*"})) > 46800
           for: 30m
           labels:
             severity: warning
             priority: P2
             component: renovate
           annotations:
-            summary: "Renovate hat kein erfolgreichen Run in >4h für RenovateJob {{ $labels.renovatejob }}"
+            summary: "Renovate hat kein erfolgreichen Run in >13h für RenovateJob {{ $labels.renovatejob }} (2 Läufe verpasst bei 6h-Schedule)"
             description: "PAT-Expiry, GitHub-Rate-Limit, Repo-Unreachable möglich. Dashboard-Issue checken."
             action: "kubectl get jobs -n renovate-operator | grep renovate ; kubectl logs -n renovate-operator <last-job-pod>"
 


### PR DESCRIPTION
RenovateNoSuccessfulRunIn4h feuerte jeden Zyklus: Threshold 4h < Renovate-Schedule 6h → garantierter False-Positive im 4-6h-Fenster. Fix: 14400->46800 (13h) → feuert nur bei 2 verpassten Laeufen (echt kaputt).