### PR TITLE
renovate recreateWhen always

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,7 @@
 
   "internalChecksAsSuccess": true,
   "rebaseWhen": "behind-base-branch",
+  "recreateWhen": "always",
   "rebaseLabel": "rebase",
   "stopUpdatingLabel": "stop-updating",
   "semanticCommits": "enabled",


### PR DESCRIPTION
Nach dem History-Rewrite wurden alle PRs geschlossen → Renovate ignoriert geschlossene PRs (recreateWhen=auto default). recreateWhen=always → recreated alle Updates frisch. Passt zum Auto-Merger-Flow (nie close-to-reject).