### PR TITLE
chore(deps): update docker.io-aquasec-kube-bench to v0.15 - abandoned

### DIFF
--- a/kubernetes/security/compliance/kube-bench/cronjob.yaml
+++ b/kubernetes/security/compliance/kube-bench/cronjob.yaml
@@ -54,7 +54,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: kube-bench
-              image: docker.io/aquasec/kube-bench:v0.15.4@sha256:f523fcb5776c0852d83e157f15c39adbec90db112170eb6aa7b5fff41827e5b0
+              image: docker.io/aquasec/kube-bench:v0.15.5@sha256:c8d202e3725ad046dd427f2a3aa3c0000c3c10657cda9482c9e015664d31e5df
               command:
                 - kube-bench
                 - run


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/docker.io-aquasec-kube-bench-0.15.x`
Filter passed: <24h old, <5 commits ahead.