### PR TITLE
add CiliumNodeUnreachable alert

### DIFF
--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/cilium.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/cilium.yaml
@@ -75,3 +75,16 @@ spec:
           annotations:
             summary: "High NetworkPolicy denial rate ({{ $value | humanize }}/s)"
             description: "Many flows dropped by NetworkPolicies — misconfigured policy or attempted lateral movement."
+
+        - alert: CiliumNodeUnreachable
+          expr: max(cilium_unreachable_nodes) > 0
+          for: 15m
+          keep_firing_for: 5m
+          labels:
+            severity: warning
+            component: network
+            priority: P2
+          annotations:
+            summary: "Cilium: {{ $value }} node(s) unreachable in datapath (>15m)"
+            description: "Node-to-node Cilium health-probe failing though agents are UP — datapath/WireGuard/identity broken (not a process crash). This is the gap that hid the 2026-05-24/25 cross-host outages behind PrometheusTargetDown-noise."
+            action: "kubectl exec -n kube-system ds/cilium -c cilium-agent -- cilium-health status → finde 0/1-Node → cilium-agent dort neustarten (Identity-Resync). Cross-host? pve-firewall auf Proxmox-Hosts prüfen."


### PR DESCRIPTION
Lücke: keine Alerts auf cilium_node_connectivity (Node-Datapath). Beide cross-host-Outages (24/25 Mai) waren unsichtbar (Agents UP, nur Pfad tot) → nur TargetDown-Noise. Neu: CiliumNodeUnreachable auf cilium_unreachable_nodes>0, for:15m (kein Reboot-Noise) + Diagnose-Action.