### PR TITLE
networking alert gaps: cilium bpf/endpoints + coredns errors

### DIFF
--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/kubernetes/cluster.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/kubernetes/cluster.yaml
@@ -61,6 +61,41 @@ spec:
     - name: kubernetes-ticket
       interval: 60s
       rules:
+        - alert: CoreDNSForwardUnhealthy
+          expr: rate(coredns_forward_healthcheck_broken_total[5m]) > 0
+          for: 5m
+          labels:
+            severity: warning
+            component: dns
+            priority: P2
+          annotations:
+            summary: "CoreDNS upstream-forward unhealthy"
+            description: "CoreDNS erreicht seine Upstream-DNS (forward zum Gateway) nicht → EXTERNE Auflösung bricht (interne svc-DNS evtl. noch ok). Das SERVFAIL-extern-Szenario nach Netz/upgrade-k8s-Changes."
+            action: "kubectl logs -n kube-system -l k8s-app=kube-dns ; Node resolv.conf/Gateway prüfen"
+
+        - alert: CoreDNSHighSERVFAIL
+          expr: |
+            sum(rate(coredns_dns_responses_total{rcode="SERVFAIL"}[5m]))
+            / clamp_min(sum(rate(coredns_dns_responses_total[5m])), 1) > 0.05
+          for: 10m
+          labels:
+            severity: warning
+            component: dns
+            priority: P2
+          annotations:
+            summary: "CoreDNS SERVFAIL-Rate hoch ({{ $value | humanizePercentage }})"
+            description: ">5% der DNS-Antworten sind SERVFAIL — Auflösung schlägt fehl (Upstream tot, Policy-Drop Pod→CoreDNS, oder Misconfig)."
+
+        - alert: CoreDNSPanics
+          expr: increase(coredns_panics_total[10m]) > 0
+          labels:
+            severity: warning
+            component: dns
+            priority: P2
+          annotations:
+            summary: "CoreDNS plugin panic ({{ $value }})"
+            description: "CoreDNS-Plugin gepanict — DNS instabil. kubectl logs -n kube-system -l k8s-app=kube-dns"
+
         - alert: ImagePullBackoff
           expr: kube_pod_container_status_waiting_reason{reason=~"ImagePullBackOff|ErrImagePull"} == 1
           for: 5m

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/cilium.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/cilium.yaml
@@ -88,3 +88,26 @@ spec:
             summary: "Cilium: {{ $value }} node(s) unreachable in datapath (>15m)"
             description: "Node-to-node Cilium health-probe failing though agents are UP — datapath/WireGuard/identity broken (not a process crash). This is the gap that hid the 2026-05-24/25 cross-host outages behind PrometheusTargetDown-noise."
             action: "kubectl exec -n kube-system ds/cilium -c cilium-agent -- cilium-health status → finde 0/1-Node → cilium-agent dort neustarten (Identity-Resync). Cross-host? pve-firewall auf Proxmox-Hosts prüfen."
+
+        - alert: CiliumBPFMapPressure
+          expr: max(cilium_bpf_map_pressure) > 0.8
+          for: 5m
+          labels:
+            severity: warning
+            component: network
+            priority: P2
+          annotations:
+            summary: "Cilium eBPF map >80% full ({{ $value | humanizePercentage }})"
+            description: "Eine eBPF-Map nähert sich der Kapazität. Bei 100% scheitern neue Pods/Connections/Policies/Services LAUTLOS zu programmieren. Welche Map: cilium_bpf_map_pressure by (map_name) im Grafana."
+
+        - alert: CiliumEndpointsNotReady
+          expr: sum(cilium_endpoint_state{endpoint_state!="ready"}) > 0
+          for: 15m
+          keep_firing_for: 5m
+          labels:
+            severity: warning
+            component: network
+            priority: P2
+          annotations:
+            summary: "Cilium endpoints stuck not-ready ({{ $value }})"
+            description: "Pods deren Cilium-Networking >15m nicht programmiert ist (regenerating/disconnecting/restoring) — der Pod hat kein funktionierendes Netz. Check: cilium-dbg endpoint list (im Agent-Pod)."


### PR DESCRIPTION
Cilium: +CiliumBPFMapPressure (eBPF-map voll → silent fail), +CiliumEndpointsNotReady. CoreDNS: +ForwardUnhealthy (SERVFAIL-extern-Szenario), +HighSERVFAIL, +Panics. Alle Metriken live verifiziert. Bewusst NICHT: genereller drop-rate (L3-protocol-baseline noise), ipcache-errors (benign churn).