### PR TITLE
drop CiliumEndpointsNotReady (rollout-noise/overlap)

### DIFF
--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/cilium.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/cilium.yaml
@@ -99,15 +99,3 @@ spec:
           annotations:
             summary: "Cilium eBPF map >80% full ({{ $value | humanizePercentage }})"
             description: "Eine eBPF-Map nähert sich der Kapazität. Bei 100% scheitern neue Pods/Connections/Policies/Services LAUTLOS zu programmieren. Welche Map: cilium_bpf_map_pressure by (map_name) im Grafana."
-
-        - alert: CiliumEndpointsNotReady
-          expr: sum(cilium_endpoint_state{endpoint_state!="ready"}) > 0
-          for: 15m
-          keep_firing_for: 5m
-          labels:
-            severity: warning
-            component: network
-            priority: P2
-          annotations:
-            summary: "Cilium endpoints stuck not-ready ({{ $value }})"
-            description: "Pods deren Cilium-Networking >15m nicht programmiert ist (regenerating/disconnecting/restoring) — der Pod hat kein funktionierendes Netz. Check: cilium-dbg endpoint list (im Agent-Pod)."


### PR DESCRIPTION
Lean: überlappt mit Pod-Level-Alerts + Rollout-Noise. Signal-vor-Volumen.