### PR TITLE
pin kustomize (CI flake) + ReleasedPVs threshold 3->25

### DIFF
--- a/.github/workflows/kustomize-validate.yml
+++ b/.github/workflows/kustomize-validate.yml
@@ -23,8 +23,10 @@ jobs:
 
       - name: Install kustomize
         run: |
-          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
-          sudo mv kustomize /usr/local/bin/
+          VERSION="5.5.0"
+          curl -sL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${VERSION}/kustomize_v${VERSION}_linux_amd64.tar.gz" -o /tmp/kustomize.tar.gz
+          tar xzf /tmp/kustomize.tar.gz -C /tmp kustomize
+          sudo mv /tmp/kustomize /usr/local/bin/
           kustomize version
 
       - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/csi.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/csi.yaml
@@ -55,7 +55,7 @@ spec:
             description: "PVC creation/deletion blocked cluster-wide while provisioner is down."
 
         - alert: ReleasedPVsAccumulating
-          expr: count(kube_persistentvolume_status_phase{phase="Released"}) > 3
+          expr: count(kube_persistentvolume_status_phase{phase="Released"}) > 25
           for: 30m
           labels:
             severity: warning


### PR DESCRIPTION
CI: kustomize von master-script (flaky, tar-fail) -> pinned 5.5.0 direct-download. Alert: ReleasedPVsAccumulating >3 (Normal-Baseline!) -> >25 (nur echter Backlog, kein Flap).