### PR TITLE
fix cilium staging build

### DIFF
--- a/kubernetes/infrastructure/network/cilium/overlays/staging/kustomization.yaml
+++ b/kubernetes/infrastructure/network/cilium/overlays/staging/kustomization.yaml
@@ -3,7 +3,6 @@
 # Resources: kein single-replica nötig (Cilium = DaemonSet, 1 Pod pro Node).
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: kube-system
 
 resources:
   - ../../base


### PR DESCRIPTION
Staging-Overlay setzte `namespace: kube-system` → der Namespace-Transformer benannte die base-Namespaces `cilium-secrets` + `cilium-spire` BEIDE zu `kube-system` um → ID-Konflikt. kustomize 5.5.0 (gepinnt in #153) ist da strenger; vorher hat der Install-Flake den Build-Fehler maskiert. Prod-Overlay hat die Zeile nicht und baute fine → Zeile entfernt (base targetet eh kube-system, redundant). Fixt den roten validate-Check auf main.