### PR TITLE
ci skip cluster health

### DIFF
--- a/.github/workflows/tofu-plan.yml
+++ b/.github/workflows/tofu-plan.yml
@@ -85,6 +85,8 @@ jobs:
       - name: tofu plan (no refresh — config vs state only)
         id: plan
         working-directory: tofu
+        env:
+          TF_VAR_skip_cluster_health: "true"
         run: |
           set +e
           tofu plan -refresh=false -lock=false -input=false -no-color -out=tfplan 2>&1 | tee plan.txt

--- a/tofu/main.tofu
+++ b/tofu/main.tofu
@@ -5,9 +5,10 @@ module "talos" {
     proxmox = proxmox
   }
 
-  image   = var.talos_image
-  cluster = var.talos_cluster_config
-  nodes   = var.talos_nodes
+  image               = var.talos_image
+  cluster             = var.talos_cluster_config
+  nodes               = var.talos_nodes
+  skip_cluster_health = var.skip_cluster_health
 }
 
 module "sealed-secrets" {

--- a/tofu/talos/config.tofu
+++ b/tofu/talos/config.tofu
@@ -110,6 +110,7 @@ resource "talos_machine_bootstrap" "this" {
 }
 
 data "talos_cluster_health" "this" {
+  count = var.skip_cluster_health ? 0 : 1
   depends_on = [
     talos_machine_configuration_apply.this,
     talos_machine_bootstrap.this

--- a/tofu/talos/variables.tofu
+++ b/tofu/talos/variables.tofu
@@ -52,3 +52,9 @@ variable "nodes" {
     ceph_disk_datastore = optional(string)
   }))
 }
+
+variable "skip_cluster_health" {
+  description = "Skip the live talos_cluster_health data source — set true in CI where the cluster API is unreachable"
+  type        = bool
+  default     = false
+}

--- a/tofu/variables.tofu
+++ b/tofu/variables.tofu
@@ -1,3 +1,9 @@
+variable "skip_cluster_health" {
+  description = "Skip the live talos_cluster_health check — set true in CI where the cluster API is unreachable"
+  type        = bool
+  default     = false
+}
+
 variable "proxmox" {
   description = "Proxmox provider configuration"
   type = object({


### PR DESCRIPTION
tofu-plan im CI failte immer am `talos_cluster_health` data source: macht einen Live-Check gegen die Talos-API (192.168.0.101:50000, Home-LAN) → von GitHub-Runnern unerreichbar → i/o timeout → 'cluster health check failed'. Data sources werden beim plan IMMER gelesen (auch mit -refresh=false), Resources nicht → nur dieser Check brach.

Fix: `count = var.skip_cluster_health ? 0 : 1` auf dem health-Check + neue bool-Variable (default false → lokales apply unverändert). CI setzt `TF_VAR_skip_cluster_health=true` nur im plan-Step. Nur `depends_on` referenziert den Check (kein Attribut), daher keine weiteren Anpassungen. Macht den tofu-plan-Gate erstmals funktionsfähig (vorher dauer-rot / admin-bypass nötig).