### PR TITLE
fix releasedpv alert query

### DIFF
--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/csi.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/csi.yaml
@@ -55,7 +55,7 @@ spec:
             description: "PVC creation/deletion blocked cluster-wide while provisioner is down."
 
         - alert: ReleasedPVsAccumulating
-          expr: count(kube_persistentvolume_status_phase{phase="Released"}) > 25
+          expr: sum(kube_persistentvolume_status_phase{phase="Released"}) > 15
           for: 30m
           labels:
             severity: warning


### PR DESCRIPTION
ReleasedPVsAccumulating nutzte `count(kube_persistentvolume_status_phase{phase="Released"})` — das zählt die Anzahl Time-Series, nicht die mit Wert==1. kube-state-metrics emittiert für JEDES PV eine phase=Released-Series (Wert 0/1), also = PV-Gesamtzahl (~41), unabhängig vom echten Released-Count (3). Daher feuerte es exakt bei '41' = total PVs.

Fix: `count` → `sum` (summiert die Werte → echte Released-Zahl) + Threshold 25→15 (real-Released-Baseline ist ~3, 15 = echter Cleanup-Backlog ohne false-positives). Empirisch: total=41, echt Released=3.