### PR TITLE
wire proxmox host scrape + backup alert

### DIFF
--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/infrastructure/proxmox.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/infrastructure/proxmox.yaml
@@ -90,3 +90,14 @@ spec:
           annotations:
             summary: "Proxmox PVE exporter down"
             description: "Cannot scrape Proxmox API — VM/cluster state not visible in Grafana."
+
+        - alert: ProxmoxBackupStale
+          expr: time() - max by (host) (pve_vzdump_last_backup_timestamp_seconds) > 93600
+          for: 1h
+          labels:
+            severity: warning
+            component: hypervisor
+            priority: P2
+          annotations:
+            summary: "Proxmox VM-backup on {{ $labels.host }} is stale"
+            description: "Newest vzdump archive on {{ $labels.host }} older than 26h — nightly job (02:00) missed or failed."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
@@ -12,6 +12,13 @@ prometheus:
     # Pod-Restart oder Eviction = NO scrape gap.
     replicas: 2
 
+    # Bare-metal hypervisor scrape jobs (node_exporter :9100 + smartctl :9633 on
+    # msa2/nipogi). Secret defined in pve-exporter/base/scrape-config.yaml.
+    additionalScrapeConfigsSecret:
+      enabled: true
+      name: additional-scrape-configs-proxmox
+      key: prometheus-additional.yaml
+
     externalLabels:
       cluster: prod-talos
       environment: prod


### PR DESCRIPTION
Zwei zusammenhängende Fixes:

**1. Proxmox-Host-Scrape verdrahtet.** Das Secret `additional-scrape-configs-proxmox` (Jobs `proxmox-host-node` :9100 + `proxmox-smart` :9633) existierte seit 2d, war aber NIE in der Prometheus-CR referenziert (`additionalScrapeConfigs` leer). Folge: das komplette Proxmox-Host-Alert-Set (ProxmoxHostDown, ZfsPoolCritical/Degraded, DiskSmartFailure, RootDiskFull, HostMemoryPressure) lief ins Leere — alle nutzen `job=proxmox-host-node`. Fix: `additionalScrapeConfigsSecret` in values-prod.yaml referenziert das Secret → Jobs aktiv.

**2. ProxmoxBackupStale-Alert.** Neuer vzdump-Backup-Monitoring: feuert wenn das jüngste Backup eines Hosts >26h alt ist (nightly job 02:00 verpasst/failed). Metrik `pve_vzdump_last_backup_timestamp_seconds` kommt vom node_exporter textfile-collector auf beiden Hosts (Cron-Script schreibt sie).

Host-seitig bereits erledigt (bare-metal): vzdump-cron 02:00 cluster-weit, dediziertes rpool/backup-Dataset, Ceph-Disks via backup=0 ausgeschlossen (nur OS-Disks), node_exporter auf nipogi installiert+systemd-managed (lief vorher gar nicht), textfile-collector-Flag auf beiden. Test-Backups ctrl-0 (fs-freeze konsistent) + worker-3 (Ceph excluded, 8GB) verifiziert.