### PR TITLE
n8n postgres ha 2 instances

### DIFF
--- a/kubernetes/tenants/n8n-prod/postgres/base/cluster.yaml
+++ b/kubernetes/tenants/n8n-prod/postgres/base/cluster.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: '3'
 spec:
-  instances: 1
+  instances: 2
   imageName: ghcr.io/cloudnative-pg/postgresql:16.1
   plugins:
   - name: barman-cloud.cloudnative-pg.io


### PR DESCRIPTION
n8n-prod Postgres `instances: 1` → `2` (Primary + 1 Replica = CNPG-Auto-Failover). +256Mi RAM (~0.3% Host, vernachlässigbar) + 8Gi Ceph. podAntiAffinity preferred → Replica landet auf anderem Host. n8n ist der echte Prod-Workload → DB-HA sinnvoll.