### PR TITLE
chore(deps): update opentelemetry-operator to v0 - abandoned

### DIFF
--- a/kubernetes/infrastructure/operators/opentelemetry/base/kustomization.yaml
+++ b/kubernetes/infrastructure/operators/opentelemetry/base/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 helmCharts:
   - name: opentelemetry-operator
     repo: https://open-telemetry.github.io/opentelemetry-helm-charts
-    version: "0.107.2"
+    version: "0.113.1"
     releaseName: opentelemetry-operator
     namespace: opentelemetry
     includeCRDs: true


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/opentelemetry-operator-0.x`
Filter passed: <24h old, <5 commits ahead.