### PR TITLE
chore(deps): update otel-opentelemetry-collector-contrib to v0

### DIFF
--- a/kubernetes/infrastructure/observability/opentelemetry/base/collector.yaml
+++ b/kubernetes/infrastructure/observability/opentelemetry/base/collector.yaml
@@ -36,7 +36,7 @@ metadata:
     prometheus.io/scrape: "false"
 spec:
   mode: daemonset
-  image: otel/opentelemetry-collector-contrib:0.150.1@sha256:a516c26968aa1feb5e5fc0562e3338ea13755cb4f373603226bcc4e276374ad0
+  image: otel/opentelemetry-collector-contrib:0.152.0@sha256:f41d7995565df3733b7568702073a9c490792f9c6ac60684fe6a4da21a313f8d
   podAnnotations:
     prometheus.io/scrape: "false"
   resources:

--- a/kubernetes/infrastructure/observability/opentelemetry/base/gateway.yaml
+++ b/kubernetes/infrastructure/observability/opentelemetry/base/gateway.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   mode: deployment
   replicas: 3
-  image: otel/opentelemetry-collector-contrib:0.150.1
+  image: otel/opentelemetry-collector-contrib:0.152.0@sha256:f41d7995565df3733b7568702073a9c490792f9c6ac60684fe6a4da21a313f8d
   resources:
     requests:
       memory: 512Mi


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/otel-opentelemetry-collector-contrib-0.x`
Filter passed: <24h old, <5 commits ahead.