### PR TITLE
right-size ceph osd ram

### DIFF
--- a/kubernetes/infrastructure/storage/rook-ceph/base/cluster.yaml
+++ b/kubernetes/infrastructure/storage/rook-ceph/base/cluster.yaml
@@ -39,7 +39,7 @@ spec:
       osd_pool_default_pg_autoscale_mode: "off"
 
       # CRITICAL: Explicit memory target (SUSE recommends minimum 4GB)
-      osd_memory_target: "4294967296"     # 4GB in bytes - never go below this!
+      osd_memory_target: "2147483648"     # 2GB - right-sized auf echte Nutzung (~2Gi); Ceph-Minimum. War 4GB (überreserviert).
       osd_memory_target_autotune: "true"  # Auto-adjust based on available memory
       bluestore_cache_autotune: "true"    # Auto-tune BlueStore cache
 
@@ -171,7 +171,7 @@ spec:
       # Request MUST be osd_memory_target + ~25% overhead (threads/processes)
       requests:
         cpu: "500m"
-        memory: "5Gi"
+        memory: "2.5Gi"   # 2Gi target + 25%; war 5Gi (reservierte ~30Gi, real ~10Gi)
     prepareosd:
       requests:
         cpu: "100m"   # Reduced from 250m - worker-1 CPU saturated, prepare jobs are light
@@ -193,8 +193,8 @@ spec:
       # Encryption at rest: OSDs are LUKS-encrypted, keys in k8s secrets (no KMS).
       # Applies to OSDs at provision time → takes effect on a fresh cluster/rebuild.
       encryptedDevice: "true"
-      osd_memory_target: "4294967296"
-      bluestore_cache_size: "2147483648"
+      osd_memory_target: "2147483648"
+      bluestore_cache_size: "1073741824"
       bluestore_min_alloc_size_hdd: "65536"
       bluestore_rocksdb_options: "compression=kNoCompression,max_write_buffer_number=4,min_write_buffer_number_to_merge=1,recycle_log_file_num=4"
     nodes:

--- a/kubernetes/infrastructure/storage/rook-ceph/base/cluster.yaml
+++ b/kubernetes/infrastructure/storage/rook-ceph/base/cluster.yaml
@@ -39,7 +39,7 @@ spec:
       osd_pool_default_pg_autoscale_mode: "off"
 
       # CRITICAL: Explicit memory target (SUSE recommends minimum 4GB)
-      osd_memory_target: "2147483648"     # 2GB - right-sized auf echte Nutzung (~2Gi); Ceph-Minimum. War 4GB (überreserviert).
+      osd_memory_target: "3221225472"     # 3GB - right-sized (~2Gi real + Recovery-Headroom). War 4GB (überreserviert).
       osd_memory_target_autotune: "true"  # Auto-adjust based on available memory
       bluestore_cache_autotune: "true"    # Auto-tune BlueStore cache
 
@@ -171,7 +171,7 @@ spec:
       # Request MUST be osd_memory_target + ~25% overhead (threads/processes)
       requests:
         cpu: "500m"
-        memory: "2.5Gi"   # 2Gi target + 25%; war 5Gi (reservierte ~30Gi, real ~10Gi)
+        memory: "3840Mi"  # 3Gi target + 25%; war 5Gi (reservierte ~30Gi, real ~10Gi)
     prepareosd:
       requests:
         cpu: "100m"   # Reduced from 250m - worker-1 CPU saturated, prepare jobs are light
@@ -193,7 +193,7 @@ spec:
       # Encryption at rest: OSDs are LUKS-encrypted, keys in k8s secrets (no KMS).
       # Applies to OSDs at provision time → takes effect on a fresh cluster/rebuild.
       encryptedDevice: "true"
-      osd_memory_target: "2147483648"
+      osd_memory_target: "3221225472"
       bluestore_cache_size: "1073741824"
       bluestore_min_alloc_size_hdd: "65536"
       bluestore_rocksdb_options: "compression=kNoCompression,max_write_buffer_number=4,min_write_buffer_number_to_merge=1,recycle_log_file_num=4"


### PR DESCRIPTION
OSD-RAM right-sized auf echte Nutzung (resource-capacity zeigte 74% reserviert vs 36% genutzt, OSDs Haupt-Ueberreservierer). osd_memory_target 4Gi→2Gi (Ceph-Minimum), OSD request 5Gi→2.5Gi (target+25%), bluestore_cache_size 2Gi→1Gi. Frei: ~15Gi reservierter RAM. Kein OSD-Limit → kein OOM. OSDs rollen-restarten einzeln (Rook wartet auf HEALTH_OK).