### PR TITLE
chore(deps): update lldap-lldap to v2026.5

### DIFF
--- a/kubernetes/platform/identity/lldap/base/deployment.yaml
+++ b/kubernetes/platform/identity/lldap/base/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: lldap
-          image: lldap/lldap:2026-05-05-alpine
+          image: lldap/lldap:2026-05-25-alpine
           imagePullPolicy: Always
           ports:
             - name: ldap


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/lldap-lldap-2026.5.x`
Filter passed: <24h old, <5 commits ahead.