### PR TITLE
fix velero udmrepo mount

### DIFF
--- a/kubernetes/infrastructure/operators/keycloak/base/operator.yaml
+++ b/kubernetes/infrastructure/operators/keycloak/base/operator.yaml
@@ -331,7 +331,7 @@ spec:
             - name: RELATED_IMAGE_KEYCLOAK
               value: quay.io/keycloak/keycloak:25.0.6
           image: quay.io/keycloak/keycloak-operator:25.0.6@sha256:6e4abe4b1e020da4cca47272d18800fe2a72d1a08956e45fd6a64ea2ce8f6ac7
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/kubernetes/infrastructure/storage/velero/base/kustomization.yaml
+++ b/kubernetes/infrastructure/storage/velero/base/kustomization.yaml
@@ -123,6 +123,12 @@ helmCharts:
             - ALL
         # readOnlyRootFilesystem: true  # Disabled - Velero/Kopia needs write access to /udmrepo
         runAsNonRoot: true
+      extraVolumes:
+        - name: udmrepo-cache
+          emptyDir: {}
+      extraVolumeMounts:
+        - name: udmrepo-cache
+          mountPath: /udmrepo
       serviceAccount:
         server:
           create: true

--- a/kubernetes/platform/identity/lldap/base/deployment.yaml
+++ b/kubernetes/platform/identity/lldap/base/deployment.yaml
@@ -35,7 +35,7 @@ spec:
       containers:
         - name: lldap
           image: lldap/lldap:2026-05-25-alpine
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           ports:
             - name: ldap
               containerPort: 3890


### PR DESCRIPTION
mount udmrepo emptyDir on velero server (non-root uid 1000 cannot mkdir /udmrepo)