### PR TITLE
fix velero kopia cache dir

### DIFF
--- a/kubernetes/infrastructure/storage/velero/base/kustomization.yaml
+++ b/kubernetes/infrastructure/storage/velero/base/kustomization.yaml
@@ -126,9 +126,13 @@ helmCharts:
       extraVolumes:
         - name: udmrepo-cache
           emptyDir: {}
+        - name: kopia-cache
+          emptyDir: {}
       extraVolumeMounts:
         - name: udmrepo-cache
           mountPath: /udmrepo
+        - name: kopia-cache
+          mountPath: /.cache
       serviceAccount:
         server:
           create: true


### PR DESCRIPTION
mount /.cache emptyDir on velero server - non-root uid 1000 cannot create kopia cache dir. Verified: test backup Completed 0 err 0 warn, repo Ready, audiobookshelf PVB Completed.