### PR TITLE
fix audiobookshelf rollout

### DIFF
--- a/kubernetes/apps/audiobookshelf/base/deployment.yaml
+++ b/kubernetes/apps/audiobookshelf/base/deployment.yaml
@@ -9,6 +9,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "25"
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: audiobookshelf

--- a/kubernetes/apps/n8n/environments/production/deployment.yaml
+++ b/kubernetes/apps/n8n/environments/production/deployment.yaml
@@ -45,22 +45,6 @@ spec:
           limits:
             memory: "256Mi"  # Reduced from 512Mi to save memory
             cpu: "250m"      # Reduced from 500m
-        readinessProbe:
-          httpGet:
-            path: /healthz/readiness
-            port: 3008
-          initialDelaySeconds: 15
-          periodSeconds: 10
-          timeoutSeconds: 5
-          failureThreshold: 3
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 3008
-          initialDelaySeconds: 30
-          periodSeconds: 20
-          timeoutSeconds: 5
-          failureThreshold: 6
       volumes:
       - name: data
         persistentVolumeClaim:


### PR DESCRIPTION
audiobookshelf: strategy Recreate (RWO volume multi-attach on RollingUpdate). revert n8n probe in apps/ (dead reference copy; real n8n-main already has /healthz probes).