### PR TITLE
dr-verify ephemeral storage

### DIFF
--- a/kubernetes/tenants/drova/postgres/base/dr-verify-cronjob.yaml
+++ b/kubernetes/tenants/drova/postgres/base/dr-verify-cronjob.yaml
@@ -124,7 +124,7 @@ spec:
                     imageName: ghcr.io/cloudnative-pg/postgresql:16.4-22
                     storage:
                       size: 5Gi
-                      storageClass: rook-ceph-block-enterprise-retain
+                      storageClass: rook-ceph-block-enterprise
                     bootstrap:
                       recovery:
                         source: drova-postgres-source


### PR DESCRIPTION
DR-verify restore PVC uses Retain storageclass -> leaks 1 Released PV/day. Switch to rook-ceph-block-enterprise (Delete) so ephemeral restore auto-cleans on teardown.