### PR TITLE
enable tetragon agent (tracefs fix)

### DIFF
--- a/kubernetes/security/compliance/kustomization.yaml
+++ b/kubernetes/security/compliance/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
   - kube-bench
   - kyverno-policies.yaml
   # - kubescape   # disabled 2026-05-18 — OOMKill-loop on worker-1
-  # - tetragon
+  - tetragon   # re-enabled 2026-06-08: tracefs-mount-fix; agent-first ohne TracingPolicy

--- a/kubernetes/security/compliance/tetragon/kustomization.yaml
+++ b/kubernetes/security/compliance/tetragon/kustomization.yaml
@@ -4,7 +4,7 @@ namespace: kube-system
 
 resources:
   - policy-exception.yaml
-  - tracingpolicy-essentials.yaml
+  # - tracingpolicy-essentials.yaml   # agent-first: Policy erst nach cluster-weitem Soak, einzeln (setuid-syscall-Hook zuletzt)
 
 helmCharts:
   - name: tetragon

--- a/kubernetes/security/compliance/tetragon/values.yaml
+++ b/kubernetes/security/compliance/tetragon/values.yaml
@@ -1,7 +1,16 @@
+# Talos: host-tracefs muss in den Agent gemountet werden — ohne das gingen
+# am 2026-05-13 4 Nodes NotReady. Fix verifiziert 2026-06-08 (worker-3).
+extraHostPathMounts:
+  - name: sys-kernel-tracing
+    mountPath: /sys/kernel/tracing
+    readOnly: false
+
 tetragon:
   image:
     repository: quay.io/cilium/tetragon
     tag: v1.4.1
+  enableProcessCred: true
+  enableProcessNs: true
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
Re-enable Tetragon after 2026-05-13 tracefs disaster. Root cause: missing /sys/kernel/tracing host mount (Talos requires it). Fix verified one-node on worker-3 (4min stable). Agent-first: NO TracingPolicy yet (the custom syscall policy caused the incident); policies added incrementally after cluster-wide soak.