### PR TITLE
tetragon metrics servicemonitor

### DIFF
--- a/kubernetes/security/compliance/tetragon/kustomization.yaml
+++ b/kubernetes/security/compliance/tetragon/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: kube-system
 resources:
   - policy-exception.yaml
   - tracingpolicy-essentials.yaml   # 2026-06-08: 2 sichere LSM-Hooks (file/process); setuid-syscall-Hook entfernt
+  - servicemonitor.yaml             # 2026-06-08: tetragon-Metriken (:2112) in Prometheus/Grafana
 
 helmCharts:
   - name: tetragon

--- a/kubernetes/security/compliance/tetragon/servicemonitor.yaml
+++ b/kubernetes/security/compliance/tetragon/servicemonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: tetragon
+  namespace: kube-system
+  labels:
+    release: kube-prometheus-stack   # Pflicht, sonst ignoriert Prometheus den SM
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tetragon
+      app.kubernetes.io/instance: tetragon
+  namespaceSelector:
+    matchNames:
+      - kube-system
+  endpoints:
+    - port: metrics
+      interval: 30s


### PR DESCRIPTION
Add ServiceMonitor for tetragon (:2112) with release=kube-prometheus-stack label so Prometheus scrapes it. Chart did not create one. Enables tetragon metrics in Prometheus/Grafana (prerequisite for detection alerting + dashboards).