### PR TITLE
add pgaudit drova

### DIFF
--- a/kubernetes/tenants/drova/postgres/base/postgres-cluster.yaml
+++ b/kubernetes/tenants/drova/postgres/base/postgres-cluster.yaml
@@ -22,9 +22,13 @@ spec:
     size: 10Gi
     storageClass: rook-ceph-block-enterprise-retain
   postgresql:
+    shared_preload_libraries:
+      - pgaudit
     parameters:
       max_connections: '100'
       shared_buffers: 128MB
+      pgaudit.log: "ddl,write,role"
+      pgaudit.log_parameter: "on"
   plugins:
   - name: barman-cloud.cloudnative-pg.io
     parameters:


### PR DESCRIPTION
Enable pgAudit session-level auditing on drova-postgres (HA 3-instance). Audits DDL, writes (INSERT/UPDATE/DELETE), and role/grant changes — NOT reads (too noisy). Session-level needs only shared_preload_libraries, no CREATE EXTENSION. Audit events go to postgres logs → Vector → Loki/ES. Triggers a CNPG rolling restart (graceful switchover on HA).