### PR TITLE
allow tetragon metrics port

### DIFF
--- a/kubernetes/infrastructure/network/cilium/base/host-firewall.yaml
+++ b/kubernetes/infrastructure/network/cilium/base/host-firewall.yaml
@@ -72,6 +72,8 @@ spec:
               protocol: TCP  # Cilium envoy metrics
             - port: "9965"
               protocol: TCP  # Hubble metrics
+            - port: "2112"
+              protocol: TCP  # Tetragon agent metrics
             - port: "9926"
               protocol: TCP  # Rook-Ceph exporter
             - port: "9283"


### PR DESCRIPTION
Add port 2112 (tetragon agent metrics) to the Cilium host-firewall CCNP cluster-ingress allow-list. Root cause of tetragon TargetDown: host-firewall is enabled and allowed all metric ports (9962 cilium, 9965 hubble, 9100 node-exporter, etc.) EXCEPT tetragon 2112 → prometheus scrape timed out. cilium/hubble metrics always worked; only tetragon was blocked.