### PR TITLE
add honeytoken canary

### DIFF
--- a/kubernetes/security/compliance/honeytoken/honeypot.yaml
+++ b/kubernetes/security/compliance/honeytoken/honeypot.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: honeytoken
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: honeypot
+  namespace: honeytoken
+  labels:
+    app.kubernetes.io/name: honeypot
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: honeypot
+  template:
+    metadata:
+      labels:
+        app: honeypot
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: seed-decoy
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - printf '[default]\naws_access_key_id = AKIAIOSFODNN7DECOY00\naws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYDECOYKEY\n' > /seed/credentials
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          volumeMounts:
+            - name: decoy
+              mountPath: /seed
+      containers:
+        - name: honeypot
+          image: busybox:1.36
+          command: [sh, -c, sleep infinity]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          resources:
+            requests: { cpu: 10m, memory: 16Mi }
+            limits: { cpu: 50m, memory: 32Mi }
+          volumeMounts:
+            - name: decoy
+              mountPath: /var/run/secrets/aws-prod
+              readOnly: true
+      volumes:
+        - name: decoy
+          emptyDir: {}

--- a/kubernetes/security/compliance/honeytoken/kustomization.yaml
+++ b/kubernetes/security/compliance/honeytoken/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - honeypot.yaml
+  - tracingpolicy.yaml

--- a/kubernetes/security/compliance/honeytoken/tracingpolicy.yaml
+++ b/kubernetes/security/compliance/honeytoken/tracingpolicy.yaml
@@ -1,0 +1,30 @@
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: honeytoken-access-detection
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true,ServerSideApply=true
+spec:
+  kprobes:
+    - call: security_file_permission
+      syscall: false
+      return: true
+      args:
+        - index: 0
+          type: file
+        - index: 1
+          type: int
+      returnArg:
+        index: 0
+        type: int
+      returnArgAction: Post
+      selectors:
+        - matchArgs:
+            - index: 0
+              operator: Equal
+              values:
+                - /var/run/secrets/aws-prod/credentials
+            - index: 1
+              operator: Equal
+              values:
+                - "4"

--- a/kubernetes/security/compliance/kustomization.yaml
+++ b/kubernetes/security/compliance/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - kyverno-policies.yaml
   # - kubescape   # disabled 2026-05-18 — OOMKill-loop on worker-1
   - tetragon   # re-enabled 2026-06-08: tracefs-mount-fix; agent-first ohne TracingPolicy
+  - honeytoken   # 2026-06-08: Decoy-Pod + Tetragon-Canary auf Fake-AWS-Creds


### PR DESCRIPTION
Honey-token tripwire: a decoy pod (honeytoken ns) hosting fake AWS credentials at /var/run/secrets/aws-prod/credentials, plus a Tetragon TracingPolicy that fires on any read of that file. No legit process ever reads it → any hit = high-signal intrusion indicator. Events export to logs (honeytoken ns not in tetragon denylist). Decoy seeded via initContainer (real file, no secret-symlink path issues).