### PR TITLE
match active audit log

### DIFF
--- a/kubernetes/infrastructure/observability/vector/base/vector-agent.toml
+++ b/kubernetes/infrastructure/observability/vector/base/vector-agent.toml
@@ -60,7 +60,7 @@ contains(to_string(.level) ?? "", "warn")
 # Kubernetes API server audit logs (control plane nodes only)
 [sources.kube_audit_logs]
 type = "file"
-include = ["/var/log/audit/kube/kube-apiserver-*.log"]
+include = ["/var/log/audit/kube/kube-apiserver*.log"]
 read_from = "end"
 
 [transforms.parse_kube_audit]


### PR DESCRIPTION
Glob kube-apiserver-*.log matched only ROTATED files; the ACTIVE audit log is kube-apiserver.log (no timestamp). Remove the dash so kube-apiserver*.log matches both active + rotated. This was why audit never reached ES despite the source/filter being correct.