### PR TITLE
fix link-lost alert + readme cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,6 @@ End-user applications deployed via Argo CD across dev / staging / production ove
         <td>Ride-sharing microservices showcase — api-gateway, user, trip, driver, chat, payment services with Kafka, CNPG Postgres, Redis, OpenTelemetry tracing, Cilium-SPIRE mTLS, tiered backups</td>
     </tr>
     <tr>
-        <td><img width="32" src="https://www.vectorlogo.zone/logos/apache_kafka/apache_kafka-icon.svg"></td>
-        <td><a href="https://strimzi.io/">Kafka (Strimzi)</a></td>
-        <td>Event streaming clusters — KafkaCluster CR, Topics, Users, Schema-Registry. Used by Drova services</td>
-    </tr>
-    <tr>
         <td><img width="32" src="https://dbeaver.io/wp-content/uploads/2015/09/beaver-head.png"></td>
         <td><a href="https://dbeaver.io/docs/cloudbeaver/">CloudBeaver</a></td>
         <td>Web-based database management UI for Postgres, MongoDB and more</td>
@@ -98,11 +93,6 @@ Lifecycle, scaling, and HA management for stateful workloads:
         <td><img width="32" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/redis/redis-original.svg"></td>
         <td><a href="https://redis-operator.opstree.dev/">Redis Operator</a></td>
         <td>Redis Standalone / Replication / Sentinel / Cluster</td>
-    </tr>
-    <tr>
-        <td><img width="32" src="https://tailscale.com/files/press/tailscale-symbol-color.svg"></td>
-        <td><a href="https://tailscale.com/kb/1236/kubernetes-operator">Tailscale Operator</a></td>
-        <td>SaaS-coordinated Mesh-VPN for kubectl + cluster-internal access</td>
     </tr>
     <tr>
         <td><img width="32" src="https://raw.githubusercontent.com/netbirdio/netbird/main/docs/media/logo-full.png"></td>

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/host-network.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/host-network.yaml
@@ -28,9 +28,9 @@ spec:
       rules:
         - alert: HostNetworkErrors
           expr: |
-            rate(node_network_receive_errs_total{device!~"lo|veth.*|cni.*|tap.*|fwbr.*|fwln.*|fwpr.*|cilium.*|lxc.*"}[5m]) > 0
+            rate(node_network_receive_errs_total{device!~"lo|veth.*|cni.*|tap.*|fwbr.*|fwln.*|fwpr.*|cilium.*|lxc.*|wt.*|wg.*|tailscale.*|nb-.*"}[5m]) > 0
             or
-            rate(node_network_transmit_errs_total{device!~"lo|veth.*|cni.*|tap.*|fwbr.*|fwln.*|fwpr.*|cilium.*|lxc.*"}[5m]) > 0
+            rate(node_network_transmit_errs_total{device!~"lo|veth.*|cni.*|tap.*|fwbr.*|fwln.*|fwpr.*|cilium.*|lxc.*|wt.*|wg.*|tailscale.*|nb-.*"}[5m]) > 0
           for: 5m
           labels:
             severity: warning
@@ -42,7 +42,7 @@ spec:
 
         - alert: HostActiveLinkLost
           expr: |
-            node_network_up{device!~"lo|veth.*|cni.*|tap.*|fwbr.*|fwln.*|fwpr.*|cilium.*|lxc.*|vmbr.*"} == 0
+            node_network_up{device!~"lo|veth.*|cni.*|tap.*|fwbr.*|fwln.*|fwpr.*|cilium.*|lxc.*|wt.*|wg.*|tailscale.*|nb-.*|vmbr.*"} == 0
             and on (instance, device) (node_network_receive_bytes_total offset 1h > 0)
           for: 5m
           labels:


### PR DESCRIPTION
HostActiveLinkLost: virtuelle Interfaces (wt/wg/tailscale) ausschliessen (wt0=NetBird-WG, kein physischer NIC). README: Kafka-App + Tailscale-Operator raus (nicht deployed/redundant mit NetBird).