### PR TITLE
verify image signatures

### DIFF
--- a/kubernetes/security/policies/kyverno/policies/kustomization.yaml
+++ b/kubernetes/security/policies/kyverno/policies/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - require-run-as-non-root.yaml
   - require-probe-timeouts.yaml      # Audit-only: warns when probe.timeoutSeconds<3 (K8s default 1s kills under load)
   - restrict-image-registries.yaml
+  - verify-drova-image-signatures.yaml  # Audit-only: cosign keyless verification for drova images

--- a/kubernetes/security/policies/kyverno/policies/verify-drova-image-signatures.yaml
+++ b/kubernetes/security/policies/kyverno/policies/verify-drova-image-signatures.yaml
@@ -1,0 +1,40 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: verify-drova-image-signatures
+  annotations:
+    policies.kyverno.io/title: Verify Drova Image Signatures
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Verifies cosign keyless signatures (GitHub Actions OIDC) on all
+      ghcr.io/tim275/drova images. Audit-only: unsigned or tampered images
+      are reported via PolicyReports, not blocked. Switch to Enforce after
+      a clean soak period.
+spec:
+  validationFailureAction: Audit
+  background: false
+  webhookTimeoutSeconds: 30
+  failurePolicy: Ignore
+  rules:
+    - name: verify-cosign-keyless
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              namespaces:
+                - drova
+      verifyImages:
+        - imageReferences:
+            - "ghcr.io/tim275/drova/*"
+          mutateDigest: false
+          verifyDigest: false
+          required: true
+          attestors:
+            - entries:
+                - keyless:
+                    subject: "https://github.com/Tim275/drova/.github/workflows/docker-build-push.yaml@*"
+                    issuer: "https://token.actions.githubusercontent.com"
+                    rekor:
+                      url: https://rekor.sigstore.dev


### PR DESCRIPTION
Kyverno verify-images (Audit-Mode) für ghcr.io/tim275/drova/* — cosign keyless (GitHub-OIDC, docker-build-push-Workflow-Identity). Blockt nichts; Violations via PolicyReports. Enforce nach Soak.