### PR TITLE
fix: drova rollout drift + auto sync

### DIFF
--- a/kubernetes/applicationsets/tenants/drova-tenant.yaml
+++ b/kubernetes/applicationsets/tenants/drova-tenant.yaml
@@ -106,10 +106,24 @@ spec:
           kind: Application
           jqPathExpressions:
             - .status
+        # Argo Rollouts controller mutates these during canary — without the
+        # ignores every rollout leaves the app permanently OutOfSync.
+        - group: argoproj.io
+          kind: Rollout
+          jsonPointers:
+            - /spec/replicas
+        - kind: Service
+          name: api-gateway-canary
+          jsonPointers:
+            - /spec/selector
+        - kind: Service
+          name: api-gateway-stable
+          jsonPointers:
+            - /spec/selector
       syncPolicy:
-        # automated:
-        #   prune: true
-        #   selfHeal: true
+        automated:
+          prune: true
+          selfHeal: true
         syncOptions:
           - CreateNamespace=false
           - PrunePropagationPolicy=foreground


### PR DESCRIPTION
## Problem 1 — Permanenter OutOfSync nach jedem Canary
Argo Rollouts mutiert während des Canary die Selector-Hashes der canary/stable-Services + HPA die Rollout-Replicas. ArgoCD sieht das als Drift → drova-prod dauerhaft OutOfSync.

Fix: ignoreDifferences für Rollout /spec/replicas + Service /spec/selector (nur canary/stable).

## Problem 2 — Manual-Sync-Pflicht
syncPolicy.automated war auskommentiert → jeder Deploy brauchte manuellen Sync (heute 3× von Hand getriggert). Mit den neuen Ignores ist automated+selfHeal jetzt safe — kein Fight zwischen ArgoCD und Rollouts-Controller mehr.

Damit ist der GitOps-Flow erstmals komplett hands-off: Release-PR merge → Image-Bump → Auto-Sync → Canary → live.