### PR TITLE
fix es log pipelines

### DIFF
--- a/kubernetes/infrastructure/network/netbird-operator/base/audit-export-cronjob.yaml
+++ b/kubernetes/infrastructure/network/netbird-operator/base/audit-export-cronjob.yaml
@@ -1,0 +1,53 @@
+# NetBird audit trail -> SIEM. The cloud API holds login/peer/policy events;
+# this job prints them as JSON lines to stdout, where the Vector agent picks
+# them up (netbird ns is ES-allowlisted) -> logs-netbird.* data stream.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: netbird-audit-export
+  namespace: netbird
+spec:
+  schedule: "15 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 2
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 120
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: export
+              image: badouralix/curl-jq:alpine
+              env:
+                - name: NB_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: netbird-mgmt-api-key
+                      key: NB_API_KEY
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eu
+                  SINCE=$(date -u -d "-65 minutes" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-65M +%Y-%m-%dT%H:%M:%SZ)
+                  curl -sf -H "Authorization: Token ${NB_API_KEY}" \
+                    "https://api.netbird.io/api/events/audit" \
+                    | jq -c --arg since "$SINCE" \
+                        '.[] | select(.timestamp >= $since) + {source: "netbird-audit"}'
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 50m
+                  memory: 64Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsNonRoot: true
+                runAsUser: 100
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault

--- a/kubernetes/infrastructure/network/netbird-operator/base/kustomization.yaml
+++ b/kubernetes/infrastructure/network/netbird-operator/base/kustomization.yaml
@@ -17,3 +17,4 @@ resources:
   - gateway-vpn-service.yaml
   - split-dns.yaml
   - networkresources.yaml
+  - audit-export-cronjob.yaml

--- a/kubernetes/infrastructure/observability/vector/base/vector-agent.toml
+++ b/kubernetes/infrastructure/observability/vector/base/vector-agent.toml
@@ -46,15 +46,17 @@ if err == null {
 '''
 
 # Filter out noisy logs
+# Tetragon runs in kube-system but its runtime-security events must pass (SIEM).
 [transforms.filter_noise]
 type = "filter"
 inputs = ["parse_json"]
 condition = '''
-!contains(to_string(.message) ?? "", "GET /healthz") &&
+(!contains(to_string(.message) ?? "", "GET /healthz") &&
 !contains(to_string(.message) ?? "", "GET /readyz") &&
-!contains(to_string(.kubernetes.namespace) ?? "", "kube-system") ||
+!contains(to_string(.kubernetes.namespace) ?? "", "kube-system")) ||
 contains(to_string(.level) ?? "", "error") ||
-contains(to_string(.level) ?? "", "warn")
+contains(to_string(.level) ?? "", "warn") ||
+starts_with(to_string(.kubernetes.pod_name) ?? "", "tetragon")
 '''
 
 # Kubernetes API server audit logs (control plane nodes only)
@@ -109,10 +111,20 @@ source = '''
 .cluster = "talos-homelab"
 '''
 
+# Security-relevant flows only. FORWARDED/TRACED flooded the pipeline
+# (every TCP packet event) and starved the sampler — Hubble UI/metrics
+# already cover healthy traffic; logs only need verdicts that matter.
+[transforms.filter_hubble_security]
+type = "filter"
+inputs = ["parse_hubble"]
+condition = '''
+includes(["DROPPED", "ERROR", "AUDIT", "POLICY_DENIED"], to_string(.flow.verdict) ?? to_string(.verdict) ?? "")
+'''
+
 # Forward to Vector Aggregator
 [sinks.vector_aggregator]
 type = "vector"
-inputs = ["filter_noise", "parse_kube_audit", "parse_hubble"]
+inputs = ["filter_noise", "parse_kube_audit", "filter_hubble_security"]
 address = "vector-aggregator.elastic-system.svc.cluster.local:6000"
 version = "2"
 

--- a/kubernetes/infrastructure/observability/vector/base/vector-aggregator.toml
+++ b/kubernetes/infrastructure/observability/vector/base/vector-aggregator.toml
@@ -196,6 +196,12 @@ pod_name = to_string(.kubernetes.pod_name) ?? ""
   "cloudnative-pg"
 } else if exists(.source) && .source == "kubernetes-audit" {
   "kube-audit"
+} else if exists(.source) && .source == "hubble" {
+  "hubble-drops"
+} else if starts_with(to_string(.kubernetes.pod_name) ?? "", "tetragon") {
+  "tetragon"
+} else if .namespace == "gateway" {
+  "envoy-access"
 } else {
   # Fallback: use namespace as service_name
   .namespace
@@ -284,10 +290,14 @@ if exists(.error) {
 '''
 
 # Sample logs to reduce volume (optional)
+# Vector semantics: rate = N keeps 1 out of every N events.
+# rate=100 silently dropped 99% of all logs (drova/lldap/spire never reached
+# ES or Loki). rate=1 keeps everything — the Hubble flood that motivated
+# sampling is now filtered at the agent (security verdicts only).
 [transforms.sample_logs]
 type = "sample"
 inputs = ["enrich_logs"]
-rate = 100  # Keep all logs (set lower to sample, e.g. 10 = 10%)
+rate = 1
 key_field = ".kubernetes.pod"  # Sample per pod
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -302,7 +312,7 @@ inputs = ["sample_logs"]
 # Fix 2026-05-17: stricter VRL parser in newer Vector versions rejects
 # `||` line-continuation inside `(...)`. Use `includes()` with array literal
 # (set-membership check). Same semantics, parser-stable.
-condition = '(exists(.kubernetes.pod_namespace) && includes(["drova","drova-prod","keycloak","lldap","argocd","kyverno","security","cilium-spire","cnpg-system","velero"], .kubernetes.pod_namespace)) || (exists(.source) && .source == "kubernetes-audit")'
+condition = '(exists(.kubernetes.pod_namespace) && includes(["drova","drova-prod","keycloak","lldap","argocd","kyverno","security","cilium-spire","cnpg-system","velero","gateway","netbird"], .kubernetes.pod_namespace)) || (exists(.source) && .source == "kubernetes-audit") || (exists(.source) && .source == "hubble") || (exists(.kubernetes.pod_name) && starts_with(string!(.kubernetes.pod_name), "tetragon"))'
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # ELASTICSEARCH SINK - DATA STREAMS + ECS (sensitive NS only)

--- a/tofu/talos/machine-config/control-plane.yaml.tftpl
+++ b/tofu/talos/machine-config/control-plane.yaml.tftpl
@@ -40,6 +40,7 @@ cluster:
     extraArgs:
       max-requests-inflight: "400"
       max-mutating-requests-inflight: "200"
+      audit-log-path: /var/log/audit/kube/kube-apiserver.log
       audit-log-maxsize: "100"
       audit-log-maxbackup: "10"
       audit-log-maxage: "30"


### PR DESCRIPTION
Root-Causes: (1) sample rate=100 = Vector keep-1-of-100 → 99% aller Logs verworfen (drova/lldap/spire nie in ES/Loki) → rate=1. (2) Hubble FORWARDED-Flows fluteten Pipeline → Agent-Filter nur Security-Verdicts (DROPPED/ERROR/AUDIT/POLICY_DENIED). (3) apiserver audit-log-path fehlte → /var/log/audit/kube leer → tftpl-Fix (live via talosctl). (4) Tetragon (kube-system) vom Noise-Filter gedroppt → Ausnahme. Neu verdrahtet: gateway (Envoy-Access-Logs), netbird (+Audit-Export-CronJob), tetragon, hubble-drops → ES-Allowlist + Datasets.