### PR TITLE
stage coraza waf infra structure

### DIFF
--- a/kubernetes/infrastructure/ingress/gateway/base/kustomization.yaml
+++ b/kubernetes/infrastructure/ingress/gateway/base/kustomization.yaml
@@ -27,7 +27,7 @@ resources:
   - http-redirect-to-https.yaml
   - clienttraffic-policy.yaml
   - pdb.yaml  # PodDisruptionBudgets — Talos-upgrade-resilience
-  # - coraza-waf.yaml  # DISABLED: WASM filter blocks WebSocket upgrades — needs per-route targeting first
+  # - waf  # Coraza WAF, gateway-wide (base/waf/). Phase 2: uncomment to activate (DetectionOnly). Test WS-bypass via test-rig/ FIRST. See notes/CLAUDE-PLANNING.md
   # rate-limit-policies.yaml moved to kubernetes/security/foundation/rate-limiting/
   # envoy-patch-ceph-tls.yaml: NOT NEEDED - Ceph Dashboard uses HTTP backend now
 labels:

--- a/kubernetes/infrastructure/ingress/gateway/base/waf/coraza-waf.yaml
+++ b/kubernetes/infrastructure/ingress/gateway/base/waf/coraza-waf.yaml
@@ -1,3 +1,19 @@
+# Coraza WAF (OWASP CRS) — gateway-wide Envoy WASM filter. INFRA, not app.
+#
+# targetRef: Gateway -> covers EVERY HTTPRoute through this gateway with one
+# policy that lives entirely here (an EnvoyExtensionPolicy is namespace-scoped
+# and can only target routes in its own namespace, so per-route targeting would
+# force the policy into each app's namespace/repo — gateway-wide is the only
+# clean infra-only option).
+#
+# WebSocket/gRPC are bypassed by header (Upgrade:websocket / application/grpc ->
+# ruleEngine=Off). This is correct by design, not a workaround: after the upgrade
+# the stream is raw frames (not HTTP), which a WAF physically cannot inspect.
+#
+# ROLLOUT (see notes/CLAUDE-PLANNING.md "CORAZA WAF"):
+#   Phase 1  validate WS-bypass on the throwaway test-rig FIRST (../../test-rig/)
+#   Phase 2  enable here (DetectionOnly), soak, tune FPs via Kibana (logs-envoy-access.*)
+#   Phase 3  flip SecRuleEngine -> On. failOpen:true keeps traffic flowing if Coraza crashes.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyExtensionPolicy
 metadata:
@@ -13,7 +29,6 @@ spec:
   wasm:
     - name: coraza
       rootID: coraza
-      # failOpen: if Coraza crashes traffic passes through (no downtime)
       failOpen: true
       code:
         type: Image

--- a/kubernetes/infrastructure/ingress/gateway/base/waf/kustomization.yaml
+++ b/kubernetes/infrastructure/ingress/gateway/base/waf/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - coraza-waf.yaml
+  # - coraza-exclusions.yaml  # Phase 2: per-host/path false-positive exclusions (added during soak)

--- a/kubernetes/infrastructure/ingress/gateway/test-rig/README.md
+++ b/kubernetes/infrastructure/ingress/gateway/test-rig/README.md
@@ -1,0 +1,32 @@
+# Coraza WAF — Phase 1 test rig (throwaway)
+
+Not part of any kustomization / ArgoCD app — applied **manually** to prove the
+WebSocket bypass survives the Coraza WASM filter **before** the gateway-wide WAF
+(`../base/waf/`) is ever enabled on the real gateway.
+
+A dedicated `coraza-test-gw` Gateway gets its own Envoy proxy → the production
+gateway is untouched.
+
+## Run
+```sh
+kubectl apply -f waf-test.yaml
+
+# port-forward the test gateway's envoy
+SVC=$(kubectl -n gateway get svc -l gateway.envoyproxy.io/owning-gateway-name=coraza-test-gw -o name | head -1)
+kubectl -n gateway port-forward "$SVC" 8888:80
+
+# in another shell — all must pass:
+curl -s localhost:8888/ -H 'Host: waf-test.local'                       # HTTP echo works
+websocat ws://localhost:8888/ -H 'Host: waf-test.local'                 # WS upgrade + echo works  <-- the proof
+curl -s "localhost:8888/?id=1%27%20OR%201=1" -H 'Host: waf-test.local'  # passes (DetectionOnly)...
+kubectl -n gateway logs -l gateway.envoyproxy.io/owning-gateway-name=coraza-test-gw | grep -i coraza  # ...but is logged
+
+kubectl delete -f waf-test.yaml
+```
+
+## Pass criteria → proceed to Phase 2
+- HTTP echo: 200
+- **WebSocket: upgrades and echoes** (if this fails, the header bypass doesn't save WS → use Plan B: separate WS listener, see `notes/CLAUDE-PLANNING.md`)
+- SQLi probe: returns normally **and** appears as a Coraza detection in the logs
+
+Then enable `../base/waf/` (uncomment `- waf` in `../base/kustomization.yaml`), still `DetectionOnly`, and soak.


### PR DESCRIPTION
WAF als Infra (gateway-wide), INERT gestaged: base/waf/coraza-waf.yaml (EnvoyExtensionPolicy targetRef Gateway, DetectionOnly, failOpen, WS/gRPC-Bypass) + waf/kustomization. base referenziert waf/ NUR als Kommentar = ArgoCD deployt nichts. test-rig/ (throwaway WS-Test, Phase 1). Alte flat coraza-waf.yaml entfernt. Aktivierung: Phase 1 Test -> uncomment - waf -> Soak -> Enforce.