### PR TITLE
fix audit export date

### DIFF
--- a/kubernetes/infrastructure/network/netbird-operator/base/audit-export-cronjob.yaml
+++ b/kubernetes/infrastructure/network/netbird-operator/base/audit-export-cronjob.yaml
@@ -31,7 +31,7 @@ spec:
                 - -c
                 - |
                   set -eu
-                  SINCE=$(date -u -d "-65 minutes" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-65M +%Y-%m-%dT%H:%M:%SZ)
+                  SINCE=$(date -u -d "@$(( $(date -u +%s) - 3900 ))" +%Y-%m-%dT%H:%M:%SZ)
                   curl -sf -H "Authorization: Token ${NB_API_KEY}" \
                     "https://api.netbird.io/api/events/audit" \
                     | jq -c --arg since "$SINCE" \


### PR DESCRIPTION
netbird-audit-export CronJob failte jeden Lauf: BusyBox-date kennt weder GNU -d relative noch BSD -v. Fix: epoch-Arithmetik date -d @epoch (busybox-kompatibel). API+Token+jq-Pipeline lokal verifiziert (HTTP 200, Events kommen sauber).