### PR TITLE
activate waf detectiononly

### DIFF
--- a/kubernetes/infrastructure/ingress/gateway/base/kustomization.yaml
+++ b/kubernetes/infrastructure/ingress/gateway/base/kustomization.yaml
@@ -27,7 +27,7 @@ resources:
   - http-redirect-to-https.yaml
   - clienttraffic-policy.yaml
   - pdb.yaml  # PodDisruptionBudgets — Talos-upgrade-resilience
-  # - waf  # Coraza WAF, gateway-wide (base/waf/). Phase 2: uncomment to activate (DetectionOnly). Test WS-bypass via test-rig/ FIRST. See notes/CLAUDE-PLANNING.md
+  - waf  # Coraza WAF, gateway-wide, DetectionOnly. Phase 1 verified 2026-06-10 (CRS 4.14.0 loads, SQLi detected, WS survives). Soak -> tune FPs -> Enforce.
   # rate-limit-policies.yaml moved to kubernetes/security/foundation/rate-limiting/
   # envoy-patch-ceph-tls.yaml: NOT NEEDED - Ceph Dashboard uses HTTP backend now
 labels:


### PR DESCRIPTION
Phase 2: Coraza WAF gateway-wide scharf in DetectionOnly (blockt nichts, loggt Detections -> logs-envoy-access). Phase-1-verifiziert: CRS 4.14.0, SQLi-detection, WS-101. failOpen:true. Rollback = - waf wieder auskommentieren.