### PR TITLE
disable waf

### DIFF
--- a/kubernetes/infrastructure/ingress/gateway/base/kustomization.yaml
+++ b/kubernetes/infrastructure/ingress/gateway/base/kustomization.yaml
@@ -27,7 +27,7 @@ resources:
   - http-redirect-to-https.yaml
   - clienttraffic-policy.yaml
   - pdb.yaml  # PodDisruptionBudgets — Talos-upgrade-resilience
-  - waf  # Coraza WAF, gateway-wide, DetectionOnly. Phase 1 verified 2026-06-10 (CRS 4.14.0 loads, SQLi detected, WS survives). Soak -> tune FPs -> Enforce.
+  # - waf  # Coraza WAF (base/waf/) — DEACTIVATED: gateway-wide breaks drova (520) even in DetectionOnly. Needs per-route scoping. Config itself verified working (CRS 4.14.0, SQLi detection). See notes/CLAUDE-PLANNING.md.
   # rate-limit-policies.yaml moved to kubernetes/security/foundation/rate-limiting/
   # envoy-patch-ceph-tls.yaml: NOT NEEDED - Ceph Dashboard uses HTTP backend now
 labels:


### PR DESCRIPTION
gateway-wide coraza breaks drova 520 even detectiononly; remove from git so argocd prunes