### PR TITLE
waf response body off

### DIFF
--- a/kubernetes/infrastructure/ingress/gateway/base/waf/coraza-waf.yaml
+++ b/kubernetes/infrastructure/ingress/gateway/base/waf/coraza-waf.yaml
@@ -43,6 +43,10 @@ spec:
             - "Include @recommended-conf"
             - "Include @crs-setup-conf"
             - "SecRuleEngine DetectionOnly"
+            # @recommended-conf turns response-body access On with a 512KB limit; drova's SPA
+            # response exceeds it -> "response_payload_too_large" -> empty 520. Off keeps the
+            # request-side SQLi/XSS protection (a WAF's real job). Verified drova-safe in rig 2026-06-11.
+            - "SecResponseBodyAccess Off"
             - 'SecRule REQUEST_HEADERS:Upgrade "@streq websocket" "id:1000,phase:1,pass,nolog,ctl:ruleEngine=Off"'
             - 'SecRule REQUEST_HEADERS:Content-Type "@beginsWith application/grpc" "id:1001,phase:1,pass,nolog,ctl:ruleEngine=Off"'
             - "Include @owasp_crs/*.conf"


### PR DESCRIPTION
drova-safe verified in rig: SecResponseBodyAccess Off. SPA response exceeded 512KB resp-body-limit then rejected to 520. Request-side SQLi/XSS intact. Stays inert.