### PR TITLE
es tetragon stream more retention

### DIFF
--- a/kubernetes/infrastructure/observability/elasticsearch/base/cluster/elasticsearch-cluster.yaml
+++ b/kubernetes/infrastructure/observability/elasticsearch/base/cluster/elasticsearch-cluster.yaml
@@ -145,7 +145,7 @@ spec:
             storageClassName: rook-ceph-block-enterprise-retain
             resources:
               requests:
-                storage: 50Gi
+                storage: 100Gi
   # HTTP service configuration
   http:
     service:

--- a/kubernetes/infrastructure/observability/elasticsearch/base/cluster/ilm-policies.yaml
+++ b/kubernetes/infrastructure/observability/elasticsearch/base/cluster/ilm-policies.yaml
@@ -172,12 +172,12 @@ spec:
               echo " - Created!"
 
               # ─────────────────────────────────────────────────────────
-              # POLICY 3: logs-operational (30 days)
+              # POLICY 3: logs-operational (90 days)
               # For: Infrastructure logs, info level, n8n
-              # Phases: Hot(3d) Warm(7d) Delete(30d)
+              # Phases: Hot(3d) Warm(7d) Delete(90d)
               # ─────────────────────────────────────────────────────────
               echo ""
-              echo "[3/5] Creating ILM policy: logs-operational (30 days)"
+              echo "[3/5] Creating ILM policy: logs-operational (90 days)"
               curl -sk -X PUT -u "elastic:${ES_PASSWORD}" \
                 "${ES_URL}/_ilm/policy/logs-operational" \
                 -H 'Content-Type: application/json' \
@@ -203,7 +203,7 @@ spec:
                         }
                       },
                       "delete": {
-                        "min_age": "30d",
+                        "min_age": "90d",
                         "actions": { "delete": {} }
                       }
                     }

--- a/kubernetes/infrastructure/observability/vector/base/vector-aggregator.toml
+++ b/kubernetes/infrastructure/observability/vector/base/vector-aggregator.toml
@@ -172,6 +172,11 @@ pod_name = to_string(.kubernetes.pod_name) ?? ""
     # Fallback for other OMS pods (mongodb, rabbitmq, etc.)
     "oms-infra"
   }
+# Tetragon runs IN kube-system — this pod-name check MUST precede the kube-system
+# namespace branch, else tetragon events get filed under "kube-system" instead of
+# their own "tetragon" stream (was muddling ~1.4GB of runtime-security into kube-system).
+} else if starts_with(to_string(.kubernetes.pod_name) ?? "", "tetragon") {
+  "tetragon"
 } else if .namespace == "kube-system" {
   "kube-system"
 } else if .namespace == "rook-ceph" {
@@ -198,8 +203,6 @@ pod_name = to_string(.kubernetes.pod_name) ?? ""
   "kube-audit"
 } else if exists(.source) && .source == "hubble" {
   "hubble-drops"
-} else if starts_with(to_string(.kubernetes.pod_name) ?? "", "tetragon") {
-  "tetragon"
 } else if .namespace == "gateway" {
   "envoy-access"
 } else {


### PR DESCRIPTION
tetragon own stream (routing-order fix de-muddles 1.4GB from kube-system), ES storage 50 to 100Gi, logs-operational ILM 30 to 90d. Note: argocd was NOT missing (911k docs), earlier cat listing was truncated.