### PR TITLE
activate waf drova-safe

### DIFF
--- a/kubernetes/infrastructure/ingress/gateway/base/kustomization.yaml
+++ b/kubernetes/infrastructure/ingress/gateway/base/kustomization.yaml
@@ -27,7 +27,7 @@ resources:
   - http-redirect-to-https.yaml
   - clienttraffic-policy.yaml
   - pdb.yaml  # PodDisruptionBudgets — Talos-upgrade-resilience
-  # - waf  # Coraza WAF (base/waf/) — DEACTIVATED: gateway-wide breaks drova (520) even in DetectionOnly. Needs per-route scoping. Config itself verified working (CRS 4.14.0, SQLi detection). See notes/CLAUDE-PLANNING.md.
+  - waf  # Coraza WAF, gateway-wide, DetectionOnly. drova-safe via SecResponseBodyAccess Off (rig-verified 2026-06-11: drova frontend 200 through Coraza, SQLi 942100 detected, WS 101). failOpen. Rollback: re-comment + merge -> ArgoCD prunes.
   # rate-limit-policies.yaml moved to kubernetes/security/foundation/rate-limiting/
   # envoy-patch-ceph-tls.yaml: NOT NEEDED - Ceph Dashboard uses HTTP backend now
 labels:


### PR DESCRIPTION
Phase 2: Coraza gateway-wide DetectionOnly with the rig-verified drova-safe config (SecResponseBodyAccess Off fixes the 520). failOpen. Rollback = re-comment + merge.