### PR TITLE
waf enforce

### DIFF
--- a/kubernetes/infrastructure/ingress/gateway/base/waf/coraza-waf.yaml
+++ b/kubernetes/infrastructure/ingress/gateway/base/waf/coraza-waf.yaml
@@ -27,7 +27,7 @@ spec:
             - "Include @recommended-conf"
             - "Include @crs-setup-conf"
             # - 'SecAction "id:9000001,phase:1,nolog,pass,t:none,setvar:tx.blocking_paranoia_level=2"'  # PL2 — activate after FP-soak
-            - "SecRuleEngine DetectionOnly"  # → On to enforce (after soak)
+            - "SecRuleEngine On"  # enforcing — revert to DetectionOnly if legit traffic gets 403'd
             - "SecResponseBodyAccess Off"  # drova SPA > 512KB → empty 520; Off keeps request-side protection
             - 'SecRule REQUEST_HEADERS:Upgrade "@streq websocket" "id:1000,phase:1,pass,nolog,ctl:ruleEngine=Off"'
             - 'SecRule REQUEST_HEADERS:Content-Type "@beginsWith application/grpc" "id:1001,phase:1,pass,nolog,ctl:ruleEngine=Off"'


### PR DESCRIPTION
Flip SecRuleEngine DetectionOnly → On (PL1). FPs tuned during soak (Kibana 942220/911100 excluded), no drova/n8n FPs observed. failOpen:true stays. PL2 remains staged. Rollback = revert to DetectionOnly.