### PR TITLE
waf alert tune

### DIFF
--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/compliance/waf.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/compliance/waf.yaml
@@ -19,13 +19,13 @@ spec:
           annotations:
             summary: "Coraza WAF detection spike ({{ $value | humanize }} in 10m)"
             description: "CRS rule-matches above baseline — new false-positive source or a real probe. Triage in Kibana (KQL `message:\"Coraza\"`), then add an exclusion or treat as attack."
-        - alert: CorazaWAFBlockingRequests
-          expr: sum(increase(waf_coraza_detections_total{action="denied"}[10m])) > 0
-          for: 0m
+        - alert: CorazaWAFBlockingSpike
+          expr: sum(increase(waf_coraza_detections_total{action="denied"}[10m])) > 50
+          for: 10m
           labels:
             severity: warning
             component: security
             priority: P2
           annotations:
-            summary: "Coraza WAF is blocking requests ({{ $value | humanize }} in 10m)"
-            description: "action=denied means SecRuleEngine is On and traffic is blocked. Verify blocks are real attacks, not false-positives — revert to DetectionOnly if legit traffic breaks."
+            summary: "Coraza WAF blocking spike ({{ $value | humanize }} 403s in 10m)"
+            description: "Sustained 403s above baseline — an attack wave, or a false-positive hitting real users. Triage in Kibana (KQL `message:\"Coraza\"`): if legit traffic is blocked, add an exclusion or revert to DetectionOnly. Routine bot-scans below 50/10m stay silent."


### PR DESCRIPTION
CorazaWAFBlockingRequests (denied>0, fired on every bot-scan) → CorazaWAFBlockingSpike (denied>50/10m). Routine SQLi-scans stay silent; only sustained 403s (attack wave or FP hitting real users) page. DetectionSpike unchanged.