### PR TITLE
netbird k8s-svc policy

### DIFF
--- a/kubernetes/infrastructure/network/netbird-operator/base/kustomization.yaml
+++ b/kubernetes/infrastructure/network/netbird-operator/base/kustomization.yaml
@@ -17,4 +17,5 @@ resources:
   - gateway-vpn-service.yaml
   - split-dns.yaml
   - networkresources.yaml
+  - nbpolicy.yaml
   - audit-export-cronjob.yaml

--- a/kubernetes/infrastructure/network/netbird-operator/base/nbpolicy.yaml
+++ b/kubernetes/infrastructure/network/netbird-operator/base/nbpolicy.yaml
@@ -1,0 +1,19 @@
+# Access-Policy: homelab-users → k8s-svc. Without this the NetworkResources are
+# Ready but no client gets a route to them (the group exists, nothing reaches it).
+# homelab-users is the tofu-managed user group (the Mac is in it — it has the LAN route).
+apiVersion: netbird.io/v1alpha1
+kind: NBPolicy
+metadata:
+  name: users-to-k8s-svc
+  namespace: netbird
+spec:
+  name: homelab-users-to-k8s-svc
+  description: VPN clients may reach the internal k8s services behind the Envoy gateway
+  sourceGroups:
+    - homelab-users
+  destinationGroups:
+    - k8s-svc
+  bidirectional: true
+  protocols:
+    - tcp
+    - udp

--- a/kubernetes/infrastructure/network/netbird-operator/base/networkresources.yaml
+++ b/kubernetes/infrastructure/network/netbird-operator/base/networkresources.yaml
@@ -1,6 +1,6 @@
 # VPN-only Exposure via explizite NetworkResources (statt HTTPRoutes).
 # Vorteil: groups-Feld → Resources persistent in k8s-svc Gruppe (Operator-managed,
-# kein Revert). NBPolicy "admins -> k8s-svc" greift dann stabil. Least-Privilege.
+# kein Revert). NBPolicy "homelab-users -> k8s-svc" (nbpolicy.yaml) greift dann stabil.
 # Erreichbar: <serviceRef>.<namespace>.k8s.timourhomelab.org
 ---
 apiVersion: netbird.io/v1alpha1


### PR DESCRIPTION
Missing NBPolicy homelab-users -> k8s-svc. The 10 NetworkResources (grafana/argocd/gateway/split-dns/...) were Ready but no policy granted access, so clients got no route -> VPN-only apps unreachable. This was a Dashboard-only (non-GitOps) policy that vanished. Now codified -> ArgoCD selfHeal keeps it permanent.