### PR TITLE
fix nbpolicy apiversion

### DIFF
--- a/kubernetes/infrastructure/network/netbird-operator/base/nbpolicy.yaml
+++ b/kubernetes/infrastructure/network/netbird-operator/base/nbpolicy.yaml
@@ -1,7 +1,7 @@
 # Access-Policy: homelab-users → k8s-svc. Without this the NetworkResources are
 # Ready but no client gets a route to them (the group exists, nothing reaches it).
 # homelab-users is the tofu-managed user group (the Mac is in it — it has the LAN route).
-apiVersion: netbird.io/v1alpha1
+apiVersion: netbird.io/v1
 kind: NBPolicy
 metadata:
   name: users-to-k8s-svc


### PR DESCRIPTION
NBPolicy CRD is netbird.io/v1, not v1alpha1 (NetworkResource is v1alpha1). Wrong version made the sync hang with 'no matches for kind NBPolicy'.