### PR TITLE
netbird wireguard port

### DIFF
--- a/kubernetes/infrastructure/network/cilium/base/host-firewall.yaml
+++ b/kubernetes/infrastructure/network/cilium/base/host-firewall.yaml
@@ -32,6 +32,24 @@ spec:
         - ports:
             - port: "51871"
               protocol: UDP  # Cilium WireGuard Port
+    # NetBird WireGuard (P2P VPN-Mesh) — LAN-Clients + Cluster/Nodes.
+    # Ohne diese Rule landen NetBird-Routing-Peers (networkrouter) auf Relay,
+    # und Subnet-Routing zu den ClusterIP-Resources (gateway-vpn 10.101.57.12 /
+    # split-dns .13) funktioniert nicht → interne Apps via VPN unerreichbar.
+    - fromCIDR:
+        - "192.168.0.0/24"
+      toPorts:
+        - ports:
+            - port: "51820"
+              protocol: UDP
+    - fromEntities:
+        - cluster
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "51820"
+              protocol: UDP
     # Pods im Cluster kube-apiserver + Hubble peer + Ceph MON + Monitoring
     - fromEntities:
         - cluster


### PR DESCRIPTION
Cilium host-firewall blocked NetBird WireGuard (51820/UDP) → routing-peers stuck on Relay → ClusterIP subnet-routing (gateway-vpn/split-dns) failed. Allow 51820/UDP from LAN + cluster/host/remote-node.