### PR TITLE
lan access envoy lb

### DIFF
--- a/kubernetes/infrastructure/network/cilium/base/host-firewall.yaml
+++ b/kubernetes/infrastructure/network/cilium/base/host-firewall.yaml
@@ -18,6 +18,13 @@ spec:
               protocol: TCP  # Talos API
             - port: "6443"
               protocol: TCP  # Kubernetes API
+            # Envoy-Gateway LoadBalancer (Cilium-L2, 192.168.0.152) — LAN/VPN-Clients
+            # erreichen die internen Apps über die echte LB-IP (echtes Cert + SSO).
+            # Ohne diese Rule blockt die Host-Firewall LAN→443/80 (nur cluster-Entity).
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP
     # Tailscale VPN — von überall (VPN-Traffic)
     - fromCIDR:
         - "100.64.0.0/10"  # Tailscale CGNAT Range


### PR DESCRIPTION
Host-firewall blocked LAN/VPN clients from the Envoy LoadBalancer (192.168.0.152:443/80) — only cluster-entity was allowed. This is why internal apps were unreachable over the VPN. Allow 443/80 from 192.168.0.0/24 so clients reach apps via the real LB-IP (real cert + SSO) over the working LAN route — no pod-router/ClusterIP/split-DNS needed.