### PR TITLE
envoy etp cluster

### DIFF
--- a/kubernetes/infrastructure/ingress/gateway/base/envoy-proxy-config.yaml
+++ b/kubernetes/infrastructure/ingress/gateway/base/envoy-proxy-config.yaml
@@ -24,4 +24,9 @@ spec:
                         gateway.envoyproxy.io/owning-gateway-name: envoy-gateway
                     topologyKey: kubernetes.io/hostname
       envoyService:
-        externalTrafficPolicy: Local  # preserve client-IP
+        # MUSS Cluster sein: mit Local announced Cilium-L2 die LB-IP (192.168.0.152) auf
+        # einem Node OHNE Envoy-Pod (Pods laufen nur auf Workern, IP landete auf ctrl-0)
+        # → externer Zugriff (LAN/VPN) läuft ins Leere (Timeout, kein Drop). Cluster macht
+        # cross-node-LB → LB-IP von überall erreichbar. Client-IP nur für den direkten
+        # LB-Zugang (LAN/VPN-Admin) nicht erhalten; Public-Traffic via cloudflared nutzt XFF.
+        externalTrafficPolicy: Cluster


### PR DESCRIPTION
EnvoyProxy externalTrafficPolicy Local → Cluster. With Local, Cilium-L2 announced the LB-IP (192.168.0.152) on ctrl-0 which has no Envoy pod (pods are on workers) → external (LAN/VPN) access dead-ended (timeout, no drop). Cluster does cross-node LB so the LB-IP is reachable from LAN/VPN. This is what makes internal apps reachable over the NetBird LAN route.