### PR TITLE
cloudflare wildcard internal dns

### DIFF
--- a/tofu/cloudflare/main.tofu
+++ b/tofu/cloudflare/main.tofu
@@ -36,6 +36,22 @@ resource "cloudflare_dns_record" "apex" {
   comment = "apex via tunnel — managed by tofu/cloudflare"
 }
 
+# ── Wildcard → Envoy-LB-IP (VPN-only, DNS-only/grau) ─────────────────────────
+# "Gilt für ALLES": jede Subdomain, die NICHT in public_hosts steht, löst auf die
+# private Envoy-LB-IP auf. DoH-Browser bekommen sie übers echte DNS (umgehen
+# /etc/hosts), aber 192.168.0.152 ist nur im VPN/LAN erreichbar. Neue interne App
+# = einfach HTTPRoute anlegen, DNS passt automatisch — KEINE Liste pflegen.
+# public_hosts (explizite CNAME) haben Vorrang (DNS-Spezifität schlägt Wildcard).
+resource "cloudflare_dns_record" "wildcard_internal" {
+  zone_id = var.zone_id
+  name    = "*.${var.zone_name}"
+  type    = "A"
+  content = var.envoy_lb_ip
+  proxied = false # grau = DNS-only, private IP NICHT durch Cloudflare-Proxy
+  ttl     = 300
+  comment = "wildcard → envoy LB (VPN-only, DoH-safe) — managed by tofu/cloudflare"
+}
+
 # ── Zero Trust Access (optional, auskommentiert) ─────────────────────────────
 # Falls du public Apps zusätzlich mit SSO-Gate schützen willst (statt nur App-Auth):
 #

--- a/tofu/cloudflare/variables.tofu
+++ b/tofu/cloudflare/variables.tofu
@@ -23,12 +23,18 @@ variable "tunnel_id" {
 
 variable "public_hosts" {
   type        = list(string)
-  default     = ["drova", "n8n", "iam", "status"]
-  description = "NUR diese Subdomains sind public (resolven zum Tunnel). Alles andere (grafana, argocd, ...) = NICHT public → nur via NetBird-VPN."
+  default     = ["drova", "n8n", "iam", "status", "netbird"]
+  description = "NUR diese Subdomains sind public (explizite CNAME → cloudflared-Tunnel, Vorrang vor dem Wildcard). netbird = gRPC-Endpoint MUSS public. Alles andere fällt automatisch auf den Wildcard → Envoy-LB (VPN-only)."
 }
 
 variable "publish_apex" {
   type        = bool
   default     = false
   description = "true wenn timourhomelab.org (apex) auch public sein soll (Landing-Page)."
+}
+
+variable "envoy_lb_ip" {
+  type        = string
+  default     = "192.168.0.152"
+  description = "Cilium-L2 LoadBalancer-IP des Envoy-Gateway (im Heim-LAN). VPN-Clients erreichen sie über die NetBird-LAN-Route."
 }


### PR DESCRIPTION
Wildcard *.timourhomelab.org → A 192.168.0.152 (Envoy-LB, DNS-only). Every internal app resolves automatically to the LB-IP — no per-app list. DoH-browsers get the IP via real DNS (bypass /etc/hosts), reachable only in VPN/LAN. public_hosts (drova/n8n/iam/status/netbird) keep explicit CNAME→tunnel (more specific = wins). Replaces the /etc/hosts hack + the manual dashboard wildcard.