### PR TITLE
firewall comment cleanup

### DIFF
--- a/kubernetes/infrastructure/network/cilium/base/host-firewall.yaml
+++ b/kubernetes/infrastructure/network/cilium/base/host-firewall.yaml
@@ -39,10 +39,8 @@ spec:
         - ports:
             - port: "51871"
               protocol: UDP  # Cilium WireGuard Port
-    # NetBird WireGuard (P2P VPN-Mesh) — LAN-Clients + Cluster/Nodes.
-    # Ohne diese Rule landen NetBird-Routing-Peers (networkrouter) auf Relay,
-    # und Subnet-Routing zu den ClusterIP-Resources (gateway-vpn 10.101.57.12 /
-    # split-dns .13) funktioniert nicht → interne Apps via VPN unerreichbar.
+    # NetBird WireGuard (P2P) — clusterproxy-Peer (kubectl-über-VPN) + Host-Router-Mesh.
+    # Ohne 51820 fällt der Peer auf Relay statt P2P.
     - fromCIDR:
         - "192.168.0.0/24"
       toPorts:


### PR DESCRIPTION
host-firewall.yaml-Kommentar verwies auf die in #251 gelöschten Pod-Router-Ressourcen (gateway-vpn 10.101.57.12 / split-dns .13 / networkrouter). Die 51820/UDP-Rule bleibt (clusterproxy-P2P), nur der Kommentar wird korrigiert.