### PR TITLE
iam vpn-only

### DIFF
--- a/kubernetes/infrastructure/ingress/cloudflared/base/config.yaml
+++ b/kubernetes/infrastructure/ingress/cloudflared/base/config.yaml
@@ -14,14 +14,6 @@ warp-routing:
   enabled: true
 
 ingress:
-  # NetBird-spezifisch: HTTP/2 zu Origin (gRPC braucht HTTP/2 Ende-zu-Ende).
-  # MUSS vor der *.timourhomelab.org Wildcard kommen (Match-Reihenfolge).
-  - hostname: netbird.timourhomelab.org
-    service: https://envoy-gateway-envoy-gateway-ee418b6e.gateway.svc.cluster.local:443
-    originRequest:
-      originServerName: netbird.timourhomelab.org
-      http2Origin: true
-
   # Public-Allowlist: NUR drova + n8n (für externe Nutzer). iam (Keycloak) = VPN-only —
   # nur Mitarbeiter-Login; In-Cluster-Apps erreichen Keycloak via Cluster-DNS-Override → Gateway.
   # VPN-only: grafana, argocd, kibana, jaeger, hubble, lldap, renovate, ceph, status, iam.

--- a/tofu/cloudflare/variables.tofu
+++ b/tofu/cloudflare/variables.tofu
@@ -23,8 +23,8 @@ variable "tunnel_id" {
 
 variable "public_hosts" {
   type        = list(string)
-  default     = ["drova", "n8n", "iam", "status", "netbird"]
-  description = "NUR diese Subdomains sind public (explizite CNAME → cloudflared-Tunnel, Vorrang vor dem Wildcard). netbird = gRPC-Endpoint MUSS public. Alles andere fällt automatisch auf den Wildcard → Envoy-LB (VPN-only)."
+  default     = ["drova", "n8n", "netbird"]
+  description = "NUR diese Subdomains sind public (explizite CNAME → cloudflared, Vorrang vor Wildcard). iam (Keycloak) + status sind bewusst NICHT hier → fallen auf den Wildcard → Envoy-LB = VPN/LAN-only. NetBird ist der ZTNA-Perimeter, der IdP wird nicht internet-exponiert. netbird = legacy gRPC-Endpoint (warp-routing), bleibt vorerst."
 }
 
 variable "publish_apex" {

--- a/tofu/cloudflare/variables.tofu
+++ b/tofu/cloudflare/variables.tofu
@@ -23,8 +23,8 @@ variable "tunnel_id" {
 
 variable "public_hosts" {
   type        = list(string)
-  default     = ["drova", "n8n", "netbird"]
-  description = "NUR diese Subdomains sind public (explizite CNAME → cloudflared, Vorrang vor Wildcard). iam (Keycloak) + status sind bewusst NICHT hier → fallen auf den Wildcard → Envoy-LB = VPN/LAN-only. NetBird ist der ZTNA-Perimeter, der IdP wird nicht internet-exponiert. netbird = legacy gRPC-Endpoint (warp-routing), bleibt vorerst."
+  default     = ["drova", "n8n"]
+  description = "NUR diese Subdomains sind public (explizite CNAME → cloudflared-Tunnel, Vorrang vor Wildcard). Alles andere (iam/Keycloak, status, grafana, argo, …) fällt auf den Wildcard → Envoy-LB = VPN/LAN-only. NetBird ist der ZTNA-Perimeter, interne Apps + IdP werden nicht internet-exponiert."
 }
 
 variable "publish_apex" {


### PR DESCRIPTION
Fix SSO-404: iam (Keycloak) + status aus public_hosts entfernt → fallen auf den Wildcard → Envoy-LB (192.168.0.152) = VPN/LAN-only. Der IdP ist bewusst nicht internet-exponiert (NetBird = ZTNA-Perimeter). Vorher: iam hatte CNAME → cloudflared, aber cloudflared hat keine iam-Ingress-Regel → 404 → SSO kaputt. netbird bleibt (legacy gRPC/warp-routing, separat). Applied via tofu (2 CNAMEs destroyed, state clean).