### PR TITLE
external-dns phase1

### DIFF
--- a/kubernetes/applicationsets/infrastructure/network-stack.yaml
+++ b/kubernetes/applicationsets/infrastructure/network-stack.yaml
@@ -27,6 +27,7 @@ spec:
                 - { component: cloudflared,   appName: cloudflared,   path: kubernetes/infrastructure/ingress/cloudflared/overlays/prod,   namespace: cloudflared,  wave: "70" }
                 - { component: redis-gateway, appName: redis-gateway, path: kubernetes/infrastructure/ingress/redis-gateway,               namespace: gateway,      wave: "70" }
                 - { component: netbird-operator, appName: netbird-operator, path: kubernetes/infrastructure/network/netbird-operator/overlays/prod, namespace: netbird, wave: "70" }
+                - { component: external-dns,  appName: external-dns,  path: kubernetes/infrastructure/ingress/external-dns/overlays/prod,  namespace: external-dns, wave: "71" }
   template:
     metadata:
       name: '{{.appName}}'

--- a/kubernetes/infrastructure/ingress/cloudflared/base/config.yaml
+++ b/kubernetes/infrastructure/ingress/cloudflared/base/config.yaml
@@ -14,14 +14,6 @@ warp-routing:
   enabled: true
 
 ingress:
-  # NetBird-spezifisch: HTTP/2 zu Origin (gRPC braucht HTTP/2 Ende-zu-Ende).
-  # MUSS vor der *.timourhomelab.org Wildcard kommen (Match-Reihenfolge).
-  - hostname: netbird.timourhomelab.org
-    service: https://envoy-gateway-envoy-gateway-ee418b6e.gateway.svc.cluster.local:443
-    originRequest:
-      originServerName: netbird.timourhomelab.org
-      http2Origin: true
-
   # Public-Allowlist: NUR drova + n8n (für externe Nutzer). iam (Keycloak) = VPN-only —
   # nur Mitarbeiter-Login; In-Cluster-Apps erreichen Keycloak via Cluster-DNS-Override → Gateway.
   # VPN-only: grafana, argocd, kibana, jaeger, hubble, lldap, renovate, ceph, status, iam.

--- a/kubernetes/infrastructure/ingress/external-dns/base/cloudflare-api-token-sealed.yaml
+++ b/kubernetes/infrastructure/ingress/external-dns/base/cloudflare-api-token-sealed.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: cloudflare-api-token
+  namespace: external-dns
+spec:
+  encryptedData:
+    api-token: AgBnN/tk/F1g6gG2x/68UiKM3URV+F3+D0+58PDqgCH5WOZQ3qtVXXJ2H8zSTVZkUowf1xYt1xOUBEvTkREyDjo0pjvl1Ds+o8MxCLSfvm0/gJpZWV16qHauiQvaa8gumEczL/sBbhQUuSH1MjFp0JxDrl/qjuP3QR/n+Pa0DM9w2S7zlnZS754HA9n10f+RL+f6Hef17WCPOOqvoz+f1twoqTSKLXOrhWUPA7TgJqn53GiKk7fgn6C8Oq2m6vtgQp4VuXjaIAT69pXdrU1P+jpGGP7+s9A5LO+7AFykQolNWQPYBWBWtx562dVAfepQQ4AKRWT99zgKWjxcfTZPVOvSeiAhuM80+iZiwMmDZI3hbQQ+dxFCOeATRMjqb6SNehv6dVb4ciqaH4/2O7rYEJXnQbAjcGrmqCeflexctBVBn/ospiiIByc6U2ozRXdRhkqyRLjOaunMl6dvp88LMGnfEN2T0GjQyjtqA6dpNsE4BRC8g7ytTyNLXREkBSNMLyD3OGCshdSIuAKg+BRX7fNxGIyTz0PEI4/7PaFxVYpff4PGYmkfH22mfbla4R9DI8ymN0KA6Dfz9gbiqlsFhOY5lxVKRAGLI/aVtZP2cgj3fEimuTd1CqoiyTFtsj6tbCzN1N67qyzvUqYslvzLWkO7grU5NnoWhHKj82J0Wj2G4KmpoapkCGI4yNEx2t0MHNfMZzkJVVlT/6pe3eGFz3WreV8pIFH38PKHEDg148GraMCB3wRrWA7h
+  template:
+    metadata:
+      name: cloudflare-api-token
+      namespace: external-dns

--- a/kubernetes/infrastructure/ingress/external-dns/base/kustomization.yaml
+++ b/kubernetes/infrastructure/ingress/external-dns/base/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: external-dns
+
+resources:
+  - namespace.yaml
+  - cloudflare-api-token-sealed.yaml
+
+helmCharts:
+  - name: external-dns
+    repo: https://kubernetes-sigs.github.io/external-dns/
+    version: 1.15.0
+    releaseName: external-dns
+    namespace: external-dns
+    valuesFile: values.yaml

--- a/kubernetes/infrastructure/ingress/external-dns/base/namespace.yaml
+++ b/kubernetes/infrastructure/ingress/external-dns/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-dns

--- a/kubernetes/infrastructure/ingress/external-dns/base/values.yaml
+++ b/kubernetes/infrastructure/ingress/external-dns/base/values.yaml
@@ -1,0 +1,31 @@
+provider:
+  name: cloudflare
+
+env:
+  - name: CF_API_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: cloudflare-api-token
+        key: api-token
+
+sources:
+  - gateway-httproute
+
+domainFilters:
+  - timourhomelab.org
+
+policy: upsert-only
+
+registry: txt
+txtOwnerId: talos-homelab
+txtPrefix: _extdns-.
+
+extraArgs:
+  - --cloudflare-dns-records-per-page=100
+
+resources:
+  requests:
+    cpu: 25m
+    memory: 64Mi
+  limits:
+    memory: 128Mi

--- a/kubernetes/infrastructure/ingress/external-dns/overlays/prod/kustomization.yaml
+++ b/kubernetes/infrastructure/ingress/external-dns/overlays/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base

--- a/kubernetes/projects/infrastructure.yaml
+++ b/kubernetes/projects/infrastructure.yaml
@@ -16,6 +16,7 @@ spec:
     - 'https://helm.otwld.com/'  # OTWLD Velero UI Helm Repository
     - 'https://pkgs.tailscale.com/helmcharts'  # Tailscale Operator Helm Repository
     - 'https://ot-container-kit.github.io/helm-charts/'  # OpsTree Redis Operator
+    - 'https://kubernetes-sigs.github.io/external-dns/'  # external-dns Helm Repository
 
   destinations:
     # Pure Kustomize Control - Kustomize determines namespaces

--- a/tofu/cloudflare/variables.tofu
+++ b/tofu/cloudflare/variables.tofu
@@ -23,8 +23,8 @@ variable "tunnel_id" {
 
 variable "public_hosts" {
   type        = list(string)
-  default     = ["drova", "n8n", "iam", "status", "netbird"]
-  description = "NUR diese Subdomains sind public (explizite CNAME → cloudflared-Tunnel, Vorrang vor dem Wildcard). netbird = gRPC-Endpoint MUSS public. Alles andere fällt automatisch auf den Wildcard → Envoy-LB (VPN-only)."
+  default     = ["drova", "n8n", "netbird"]
+  description = "NUR diese Subdomains sind public (explizite CNAME → cloudflared, Vorrang vor Wildcard). iam (Keycloak) + status sind bewusst NICHT hier → fallen auf den Wildcard → Envoy-LB = VPN/LAN-only. NetBird ist der ZTNA-Perimeter, der IdP wird nicht internet-exponiert. netbird = legacy gRPC-Endpoint (warp-routing), bleibt vorerst."
 }
 
 variable "publish_apex" {

--- a/tofu/cloudflare/variables.tofu
+++ b/tofu/cloudflare/variables.tofu
@@ -23,8 +23,8 @@ variable "tunnel_id" {
 
 variable "public_hosts" {
   type        = list(string)
-  default     = ["drova", "n8n", "netbird"]
-  description = "NUR diese Subdomains sind public (explizite CNAME → cloudflared, Vorrang vor Wildcard). iam (Keycloak) + status sind bewusst NICHT hier → fallen auf den Wildcard → Envoy-LB = VPN/LAN-only. NetBird ist der ZTNA-Perimeter, der IdP wird nicht internet-exponiert. netbird = legacy gRPC-Endpoint (warp-routing), bleibt vorerst."
+  default     = ["drova", "n8n"]
+  description = "NUR diese Subdomains sind public (explizite CNAME → cloudflared-Tunnel, Vorrang vor Wildcard). Alles andere (iam/Keycloak, status, grafana, argo, …) fällt auf den Wildcard → Envoy-LB = VPN/LAN-only. NetBird ist der ZTNA-Perimeter, interne Apps + IdP werden nicht internet-exponiert."
 }
 
 variable "publish_apex" {


### PR DESCRIPTION
Phase 1 von 'per-App-DNS raus aus tofu → GitOps'. external-dns als GitOps-App (ingress/, neben gateway+cloudflared — gehört zur Ingress/DNS-Schicht, nicht L3-network).

**SAFE by design:**
- `policy: upsert-only` → kann NIE löschen, nur anlegen/aktualisieren
- `registry: txt` + `txtOwnerId: talos-homelab` + `txtPrefix: _extdns-.` → markiert eigene Records, keine verwaisten TXT (der Bug von damals)
- `domainFilters: timourhomelab.org`, source `gateway-httproute`

**Erwartetes Verhalten nach Merge:** external-dns legt explizite A-Records für die internen Apps an (argo/grafana/… → 192.168.0.152, identisch zum Wildcard = kein Verhaltenswechsel) + TXT-Ownership. Public CNAMEs (drova/n8n, tofu) werden harmlos übersprungen (upsert-only löscht nicht). **Kein Cutover** — läuft neben dem Bestehenden.

Validierung nach Merge: A-Records + TXT da? Keine Errors? Dann Phase 2 (Annotation public→Tunnel) + Phase 3 (Cutover, tofu per-App-Records raus, policy→sync).