### PR TITLE
n8n extdns annotation

### DIFF
--- a/kubernetes/apps/n8n/environments/production/httproute.yaml
+++ b/kubernetes/apps/n8n/environments/production/httproute.yaml
@@ -3,6 +3,9 @@ kind: HTTPRoute
 metadata:
   name: n8n-prod
   namespace: n8n-prod
+  annotations:
+    external-dns.alpha.kubernetes.io/target: b5f4258e-8cd9-4454-b46e-6f4f34219bb4.cfargotunnel.com
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
 spec:
   parentRefs:
     - name: envoy-gateway


### PR DESCRIPTION
Phase 2 Cutover (n8n): HTTPRoute-Annotation external-dns.alpha.kubernetes.io/target=Tunnel + cloudflare-proxied=true. external-dns übernimmt n8n als CNAME→Tunnel (identisch zur tofu-Variante). Ändert noch nichts am DNS (external-dns überspringt solange tofu-CNAME existiert) — der eigentliche Cutover (tofu-CNAME löschen) folgt separat.