### PR TITLE
revert n8n annotation

### DIFF
--- a/kubernetes/apps/n8n/environments/production/httproute.yaml
+++ b/kubernetes/apps/n8n/environments/production/httproute.yaml
@@ -3,9 +3,6 @@ kind: HTTPRoute
 metadata:
   name: n8n-prod
   namespace: n8n-prod
-  annotations:
-    external-dns.alpha.kubernetes.io/target: b5f4258e-8cd9-4454-b46e-6f4f34219bb4.cfargotunnel.com
-    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
 spec:
   parentRefs:
     - name: envoy-gateway


### PR DESCRIPTION
Revert der external-dns target-Annotation auf der n8n-HTTPRoute (#261). Grund: external-dns mit gateway-httproute-Source honoriert die target-Annotation NICHT — es nimmt die Gateway-LB-IP (192.168.0.152) als A-Record + proxied → Cloudflare lehnt proxied auf private IP ab (9003) → external-dns crasht fatal. Public-Cutover via external-dns funktioniert so nicht; drova/n8n bleiben tofu-managed CNAMEs (= valide explizite Public-Allowlist). Live-Route + TXT bereits bereinigt, n8n public wiederhergestellt.