### PR TITLE
renovate skip tofu providers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -138,6 +138,11 @@
       "matchDepNames": ["kubernetes_version", "talos_machine_config_version"],
       "enabled": false
     },
+    {
+      "description": "BLOCK: Tofu-Provider-Updates (Lock-Files committed → manuell via tofu providers lock, kein PR-Lärm)",
+      "matchDatasources": ["terraform-provider"],
+      "enabled": false
+    },
 
     {
       "description": "Registry override: Grafana Helm Charts (Loki/Tempo/Mimir/etc)",


### PR DESCRIPTION
Stoppt die tofu-Provider-PR-Flut (#256/257/258 etc.), die nach dem Lock-File-Commit (#253) entstand. matchDatasources terraform-provider → enabled:false. Lock-Files bleiben committed (reproduzierbar), Provider-Updates jetzt manuell via 'tofu providers lock' (passt zur tofu-Vorsicht). Module + tftpl-Images bleiben Renovate-managed.