### PR TITLE
chore(deps): update cloudflare to v5.19 - abandoned

### DIFF
--- a/tofu/cloudflare/.terraform.lock.hcl
+++ b/tofu/cloudflare/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.opentofu.org/cloudflare/cloudflare" {
   version     = "5.19.1"
-  constraints = "~> 5.0"
+  constraints = ">= 5.19.1"
   hashes = [
     "h1:HkKPMZ/n+QiExkRUSLjGMTGnuIaph+k932LiTp7CKZM=",
     "h1:LicdZu3hugYpWuCAprg2EslbVP0zANnV9n9/2KiOnYc=",

--- a/tofu/cloudflare/providers.tofu
+++ b/tofu/cloudflare/providers.tofu
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 5"
+      version = ">= 5.19.1"
     }
   }
 }


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/cloudflare-5.19.x`
Filter passed: <24h old, <5 commits ahead.