### PR TITLE
chore(deps): update kubernetes to v2.38 - abandoned

### DIFF
--- a/tofu/.terraform.lock.hcl
+++ b/tofu/.terraform.lock.hcl
@@ -76,7 +76,7 @@ provider "registry.opentofu.org/hashicorp/http" {
 
 provider "registry.opentofu.org/hashicorp/kubernetes" {
   version     = "2.38.0"
-  constraints = ">= 2.31.0, >= 2.32.0, 2.38.0"
+  constraints = ">= 2.31.0, >= 2.38.0, 2.38.0"
   hashes = [
     "h1:3VVgWmwdwXFT54fjrplnq+N4+4LZ3ZeLHAlr/0jhPiA=",
     "h1:9LfHMXiMOboc6PhcEEelKjA3VL94l3MCj7RlbKO1PQM=",

--- a/tofu/bootstrap/proxmox-csi-plugin/.terraform.lock.hcl
+++ b/tofu/bootstrap/proxmox-csi-plugin/.terraform.lock.hcl
@@ -26,9 +26,17 @@ provider "registry.opentofu.org/bpg/proxmox" {
 
 provider "registry.opentofu.org/hashicorp/kubernetes" {
   version     = "2.38.0"
-  constraints = ">= 2.31.0"
+  constraints = ">= 2.38.0"
   hashes = [
+    "h1:3VVgWmwdwXFT54fjrplnq+N4+4LZ3ZeLHAlr/0jhPiA=",
+    "h1:9LfHMXiMOboc6PhcEEelKjA3VL94l3MCj7RlbKO1PQM=",
+    "h1:AkW6iAcMGHS+P2BIc2nvQe3PZCHtDL4m6+80tEDLge0=",
+    "h1:HGkB9bCmUqMRcR5/bAUOSqPBsx6DAIEnbT1fZ8vzI78=",
+    "h1:eCV78xGlh9eay+62U4gAgCEMohuiBJXN9XTIZNn+rX4=",
     "h1:ems+O2dA7atxMWpbtqIrsH7Oa+u+ERWSfpMaFnZPbh0=",
+    "h1:iEDf790HE0h3kz58zfj5IhTVODCDqWF1hISPHz210Uw=",
+    "h1:nY7J9jFXcsRINog0KYagiWZw1GVYF9D2JmtIB7Wnrao=",
+    "h1:yw6JHRONXmiTumaQfJBxl1ierFnNNT/Qio8+ttfMcG4=",
     "zh:1096b41c4e5b2ee6c1980916fb9a8579bc1892071396f7a9432be058aabf3cbc",
     "zh:2959fde9ae3d1deb5e317df0d7b02ea4977951ee6b9c4beb083c148ca8f3681c",
     "zh:5082f98fcb3389c73339365f7df39fc6912bf2bd1a46d5f97778f441a67fd337",

--- a/tofu/bootstrap/proxmox-csi-plugin/providers.tofu
+++ b/tofu/bootstrap/proxmox-csi-plugin/providers.tofu
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">=2.31.0"
+      version = ">= 2.38.0"
     }
     proxmox = {
       source  = "bpg/proxmox"

--- a/tofu/bootstrap/volumes/persistent-volume/providers.tofu
+++ b/tofu/bootstrap/volumes/persistent-volume/providers.tofu
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.31.0"
+      version = ">= 2.38.0"
     }
   }
 }

--- a/tofu/bootstrap/volumes/providers.tofu
+++ b/tofu/bootstrap/volumes/providers.tofu
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.32.0"
+      version = ">= 2.38.0"
     }
     restapi = {
       source  = "Mastercard/restapi"


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/kubernetes-2.38.x`
Filter passed: <24h old, <5 commits ahead.