### PR TITLE
netpol uptime-kuma lock

### DIFF
--- a/kubernetes/security/foundation/network-policies/kustomization.yaml
+++ b/kubernetes/security/foundation/network-policies/kustomization.yaml
@@ -14,6 +14,7 @@ kind: Kustomization
 resources:
   # Cluster-wide network policies
   - envoy-gateway.yaml          # Envoy ingress lock — public-only
+  - uptime-kuma.yaml            # gateway-only ingress lock (standalone app, verifiziert)
   # Tenant-specific (grouped per tenant for discoverability — DAX pattern)
   - tenants/drova
 

--- a/kubernetes/security/foundation/network-policies/uptime-kuma.yaml
+++ b/kubernetes/security/foundation/network-policies/uptime-kuma.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: uptime-kuma-ingress-lock
+  namespace: uptime-kuma
+spec:
+  endpointSelector:
+    matchLabels:
+      app: uptime-kuma
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: gateway
+      toPorts:
+        - ports:
+            - { port: "3001", protocol: TCP }
+    - fromEntities: [host]
+      toPorts:
+        - ports:
+            - { port: "3001", protocol: TCP }


### PR DESCRIPTION
Gateway-only Ingress-Lock (CNP) für uptime-kuma — Pilot für #3 (no-bypass). Erlaubt Ingress nur von Envoy-Gateway + host (Probes), Egress offen. Verifiziert live: erreichbar (HTTP 302), Pod 0 Restarts, keine Cilium-Drops. uptime-kuma ist standalone (nicht gescraped, keine Intra-App-Deps) → sicher. Breiterer Rollout NICHT enthalten: Apps mit Deps (keycloak↔lldap-Federation, argocd-Intra, gescrapte Apps) brauchen per-App-Analyse — diese Policies wurden 2026-05-06 schon mal disabled weil sie Federation/Login brachen (siehe kustomization-Kommentar).