### PR TITLE
dashboard uids + alert links

### DIFF
--- a/kubernetes/infrastructure/network/cilium/base/dashboards/cilium-operator.yaml
+++ b/kubernetes/infrastructure/network/cilium/base/dashboards/cilium-operator.yaml
@@ -4,6 +4,7 @@ metadata:
   name: cilium-operator
   namespace: grafana
 spec:
+  uid: cilium-operator
   allowCrossNamespaceImport: true
   folder: Cilium
   resyncPeriod: 10m

--- a/kubernetes/infrastructure/network/cilium/base/dashboards/cilium.yaml
+++ b/kubernetes/infrastructure/network/cilium/base/dashboards/cilium.yaml
@@ -4,6 +4,7 @@ metadata:
   name: cilium
   namespace: grafana
 spec:
+  uid: cilium
   allowCrossNamespaceImport: true
   folder: Cilium
   resyncPeriod: 10m

--- a/kubernetes/infrastructure/observability/dashboards/configs/base/cert-manager-dashboard.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/configs/base/cert-manager-dashboard.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/part-of: monitoring-stack
     team: platform
 spec:
+  uid: cert-manager-working
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/configs/base/keycloak-full.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/configs/base/keycloak-full.yaml
@@ -4,6 +4,7 @@ metadata:
   name: keycloak-full
   namespace: grafana
 spec:
+  uid: keycloak-full
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/configs/base/keycloak-health.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/configs/base/keycloak-health.yaml
@@ -4,6 +4,7 @@ metadata:
   name: keycloak-health
   namespace: grafana
 spec:
+  uid: keycloak-health
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/configs/base/n8n-health.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/configs/base/n8n-health.yaml
@@ -4,6 +4,7 @@ metadata:
   name: n8n-health
   namespace: grafana
 spec:
+  uid: n8n-health
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/configs/base/velero-backup-status.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/configs/base/velero-backup-status.yaml
@@ -4,6 +4,7 @@ metadata:
   name: velero-backup-status
   namespace: grafana
 spec:
+  uid: velero-backup-status
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/configs/drova/drova-business.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/configs/drova/drova-business.yaml
@@ -4,6 +4,7 @@ metadata:
   name: drova-business
   namespace: grafana
 spec:
+  uid: drova-business
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/configs/drova/drova-dependencies.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/configs/drova/drova-dependencies.yaml
@@ -4,6 +4,7 @@ metadata:
   name: drova-dependencies
   namespace: grafana
 spec:
+  uid: drova-dependencies
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/configs/drova/drova-overview.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/configs/drova/drova-overview.yaml
@@ -4,6 +4,7 @@ metadata:
   name: drova-overview
   namespace: grafana
 spec:
+  uid: drova-overview
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/configs/drova/drova-service-detail.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/configs/drova/drova-service-detail.yaml
@@ -4,6 +4,7 @@ metadata:
   name: drova-service-detail
   namespace: grafana
 spec:
+  uid: drova-service-detail
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/configs/drova/drova-slo-burnrate.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/configs/drova/drova-slo-burnrate.yaml
@@ -4,6 +4,7 @@ metadata:
   name: drova-slo-burnrate
   namespace: grafana
 spec:
+  uid: drova-slo-burnrate
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/configs/drova/drova-slo.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/configs/drova/drova-slo.yaml
@@ -4,6 +4,7 @@ metadata:
   name: drova-slo
   namespace: grafana
 spec:
+  uid: drova-slo
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/configs/infrastructure/proxmox.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/configs/infrastructure/proxmox.yaml
@@ -4,6 +4,7 @@ metadata:
   name: proxmox-cluster
   namespace: grafana
 spec:
+  uid: proxmox-cluster
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/configs/infrastructure/talos-os.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/configs/infrastructure/talos-os.yaml
@@ -4,6 +4,7 @@ metadata:
   name: talos-os
   namespace: grafana
 spec:
+  uid: talos-os
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/configs/observability/alertmanager-state.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/configs/observability/alertmanager-state.yaml
@@ -4,6 +4,7 @@ metadata:
   name: alertmanager-state
   namespace: grafana
 spec:
+  uid: alertmanager-state
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/configs/observability/jaeger-internals.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/configs/observability/jaeger-internals.yaml
@@ -4,6 +4,7 @@ metadata:
   name: jaeger-internals
   namespace: grafana
 spec:
+  uid: jaeger-internals
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/configs/observability/tempo-service-graph.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/configs/observability/tempo-service-graph.yaml
@@ -4,6 +4,7 @@ metadata:
   name: tempo-service-graph
   namespace: grafana
 spec:
+  uid: tempo-service-graph
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/configs/observability/vector-throughput.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/configs/observability/vector-throughput.yaml
@@ -4,6 +4,7 @@ metadata:
   name: vector-throughput
   namespace: grafana
 spec:
+  uid: vector-throughput
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/data/cnpg-postgres.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/data/cnpg-postgres.yaml
@@ -4,6 +4,7 @@ metadata:
   name: cnpg-postgres
   namespace: grafana
 spec:
+  uid: cnpg-postgres
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/data/elasticsearch.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/data/elasticsearch.yaml
@@ -4,6 +4,7 @@ metadata:
   name: elasticsearch
   namespace: grafana
 spec:
+  uid: elasticsearch
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/data/kafka-exporter.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/data/kafka-exporter.yaml
@@ -4,6 +4,7 @@ metadata:
   name: kafka-exporter
   namespace: grafana
 spec:
+  uid: kafka-exporter
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/data/redis-operator.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/data/redis-operator.yaml
@@ -4,6 +4,7 @@ metadata:
   name: redis-operator
   namespace: grafana
 spec:
+  uid: redis-operator
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/data/strimzi-kafka.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/data/strimzi-kafka.yaml
@@ -4,6 +4,7 @@ metadata:
   name: strimzi-kafka
   namespace: grafana
 spec:
+  uid: strimzi-kafka
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/gitops/argocd-overview.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/gitops/argocd-overview.yaml
@@ -4,6 +4,7 @@ metadata:
   name: argocd-overview
   namespace: grafana
 spec:
+  uid: argocd-overview
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/hardware/smartctl.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/hardware/smartctl.yaml
@@ -4,6 +4,7 @@ metadata:
   name: smartctl-exporter
   namespace: grafana
 spec:
+  uid: smartctl-exporter
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/kubernetes/k8s-apiserver.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/kubernetes/k8s-apiserver.yaml
@@ -4,6 +4,7 @@ metadata:
   name: k8s-apiserver
   namespace: grafana
 spec:
+  uid: k8s-apiserver
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/kubernetes/k8s-cluster-overview.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/kubernetes/k8s-cluster-overview.yaml
@@ -4,6 +4,7 @@ metadata:
   name: k8s-cluster-overview
   namespace: grafana
 spec:
+  uid: k8s-cluster-overview
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/kubernetes/k8s-coredns.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/kubernetes/k8s-coredns.yaml
@@ -4,6 +4,7 @@ metadata:
   name: k8s-coredns
   namespace: grafana
 spec:
+  uid: k8s-coredns
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/kubernetes/k8s-kubelet.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/kubernetes/k8s-kubelet.yaml
@@ -4,6 +4,7 @@ metadata:
   name: k8s-kubelet
   namespace: grafana
 spec:
+  uid: k8s-kubelet
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/kubernetes/k8s-node-overview.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/kubernetes/k8s-node-overview.yaml
@@ -4,6 +4,7 @@ metadata:
   name: k8s-node-overview
   namespace: grafana
 spec:
+  uid: k8s-node-overview
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/kubernetes/k8s-pod-overview.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/kubernetes/k8s-pod-overview.yaml
@@ -4,6 +4,7 @@ metadata:
   name: k8s-pod-overview
   namespace: grafana
 spec:
+  uid: k8s-pod-overview
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/network/cilium-agent.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/network/cilium-agent.yaml
@@ -4,6 +4,7 @@ metadata:
   name: cilium-agent
   namespace: grafana
 spec:
+  uid: cilium-agent
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/network/cilium-operator.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/network/cilium-operator.yaml
@@ -4,6 +4,7 @@ metadata:
   name: cilium-operator
   namespace: grafana
 spec:
+  uid: cilium-operator
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/network/envoy-global.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/network/envoy-global.yaml
@@ -4,6 +4,7 @@ metadata:
   name: envoy-global
   namespace: grafana
 spec:
+  uid: envoy-global
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/network/hubble.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/network/hubble.yaml
@@ -4,6 +4,7 @@ metadata:
   name: hubble
   namespace: grafana
 spec:
+  uid: hubble
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/observability/loki-stack.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/observability/loki-stack.yaml
@@ -4,6 +4,7 @@ metadata:
   name: loki-stack
   namespace: grafana
 spec:
+  uid: loki-stack
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/observability/otel-collector.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/observability/otel-collector.yaml
@@ -4,6 +4,7 @@ metadata:
   name: otel-collector
   namespace: grafana
 spec:
+  uid: otel-collector
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/observability/prometheus.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/observability/prometheus.yaml
@@ -4,6 +4,7 @@ metadata:
   name: prometheus-stats
   namespace: grafana
 spec:
+  uid: prometheus-stats
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/security/cert-manager.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/security/cert-manager.yaml
@@ -4,6 +4,7 @@ metadata:
   name: cert-manager
   namespace: grafana
 spec:
+  uid: cert-manager
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/security/kyverno.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/security/kyverno.yaml
@@ -4,6 +4,7 @@ metadata:
   name: kyverno
   namespace: grafana
 spec:
+  uid: kyverno
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/storage/ceph-cluster.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/storage/ceph-cluster.yaml
@@ -4,6 +4,7 @@ metadata:
   name: ceph-cluster
   namespace: grafana
 spec:
+  uid: ceph-cluster
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/storage/ceph-osd.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/storage/ceph-osd.yaml
@@ -4,6 +4,7 @@ metadata:
   name: ceph-osd
   namespace: grafana
 spec:
+  uid: ceph-osd
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/storage/ceph-pools.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/storage/ceph-pools.yaml
@@ -4,6 +4,7 @@ metadata:
   name: ceph-pools
   namespace: grafana
 spec:
+  uid: ceph-pools
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/storage/velero.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/storage/velero.yaml
@@ -4,6 +4,7 @@ metadata:
   name: velero-overview
   namespace: grafana
 spec:
+  uid: velero-overview
   instanceSelector:
     matchLabels:
       app: grafana

--- a/kubernetes/infrastructure/observability/dashboards/hubble/base/dashboards/hubble-dns-namespace.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/hubble/base/dashboards/hubble-dns-namespace.yaml
@@ -4,6 +4,7 @@ metadata:
   name: hubble-dns-namespace
   namespace: grafana
 spec:
+  uid: hubble-dns-namespace
   allowCrossNamespaceImport: true
   folder: Hubble
   resyncPeriod: 10m

--- a/kubernetes/infrastructure/observability/dashboards/hubble/base/dashboards/hubble-l7-http-metrics.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/hubble/base/dashboards/hubble-l7-http-metrics.yaml
@@ -4,6 +4,7 @@ metadata:
   name: hubble-l7-http-metrics
   namespace: grafana
 spec:
+  uid: hubble-l7-http-metrics
   allowCrossNamespaceImport: true
   folder: Hubble
   resyncPeriod: 10m

--- a/kubernetes/infrastructure/observability/dashboards/hubble/base/dashboards/hubble-network-overview.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/hubble/base/dashboards/hubble-network-overview.yaml
@@ -4,6 +4,7 @@ metadata:
   name: hubble-network-overview
   namespace: grafana
 spec:
+  uid: hubble-network-overview
   allowCrossNamespaceImport: true
   folder: Hubble
   resyncPeriod: 10m

--- a/kubernetes/infrastructure/observability/dashboards/hubble/base/dashboards/hubble.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/hubble/base/dashboards/hubble.yaml
@@ -4,6 +4,7 @@ metadata:
   name: hubble
   namespace: grafana
 spec:
+  uid: hubble
   allowCrossNamespaceImport: true
   folder: Hubble
   resyncPeriod: 10m

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/apps/keycloak.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/apps/keycloak.yaml
@@ -25,6 +25,7 @@ spec:
             severity: critical
             component: apps
           annotations:
+            dashboard_url: "/d/keycloak-health"
             summary: "Keycloak down — auth provider unavailable"
             description: "All Keycloak replicas not ready — OIDC login broken cluster-wide (ArgoCD, Grafana, n8n, etc.)."
 
@@ -40,5 +41,6 @@ spec:
             component: keycloak
             priority: P2
           annotations:
+            dashboard_url: "/d/keycloak-health"
             summary: "Keycloak realm {{ $labels.realm }} elevated failed-login rate"
             description: "{{ $value }} failed logins/sec — possible credential-stuffing or brute-force."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/apps/n8n.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/apps/n8n.yaml
@@ -19,6 +19,7 @@ spec:
             component: apps
             priority: P2
           annotations:
+            dashboard_url: "/d/n8n-health"
             summary: "n8n main pod down"
             description: "n8n-main 0 ready replicas >2min — workflow execution halted."
 
@@ -30,5 +31,6 @@ spec:
             component: apps
             priority: P2
           annotations:
+            dashboard_url: "/d/n8n-health"
             summary: "n8n worker down"
             description: "n8n worker pool empty — async workflows queue up (Redis-backed)."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/compliance/kyverno.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/compliance/kyverno.yaml
@@ -23,6 +23,7 @@ spec:
             priority: P2
             component: kyverno
           annotations:
+            dashboard_url: "/d/kyverno"
             summary: "Kyverno policy {{ $labels.policy_name }} failing in {{ $labels.resource_namespace }}"
             description: "Resource {{ $labels.resource_kind }} in ns {{ $labels.resource_namespace }} fails policy {{ $labels.policy_name }}. Check `kubectl get policyreport -n {{ $labels.resource_namespace }}`."
             action: "kubectl get policyreport -n {{ $labels.resource_namespace }} -o yaml | grep -B2 'result: fail'"
@@ -42,6 +43,7 @@ spec:
             priority: P2
             component: kyverno
           annotations:
+            dashboard_url: "/d/kyverno"
             summary: "Kyverno actively denied admission of {{ $labels.resource_kind }} in {{ $labels.resource_namespace }}"
             description: "Enforce-mode policy blocked a {{ $labels.resource_kind }} create/update. Workload is degraded."
 
@@ -54,5 +56,6 @@ spec:
             priority: P2
             component: kyverno
           annotations:
+            dashboard_url: "/d/kyverno"
             summary: "Kyverno controller {{ $labels.deployment }} down"
             description: "Policy enforcement disabled — security risk."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/compliance/trivy.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/compliance/trivy.yaml
@@ -21,6 +21,7 @@ spec:
             priority: P2
             component: trivy
           annotations:
+            dashboard_url: "/d/kyverno"
             summary: "Critical CVE in {{ $labels.namespace }} ({{ $value }} findings)"
             description: "Critical-severity vulnerability detected — patch image or accept exception."
             action: "kubectl get vulnerabilityreports -n {{ $labels.namespace }} -o wide"

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/compliance/waf.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/compliance/waf.yaml
@@ -17,6 +17,7 @@ spec:
             component: security
             priority: P2
           annotations:
+            dashboard_url: "/d/envoy-global"
             summary: "Coraza WAF detection spike ({{ $value | humanize }} in 10m)"
             description: "CRS rule-matches above baseline — new false-positive source or a real probe. Triage in Kibana (KQL `message:\"Coraza\"`), then add an exclusion or treat as attack."
         - alert: CorazaWAFBlockingSpike
@@ -27,5 +28,6 @@ spec:
             component: security
             priority: P2
           annotations:
+            dashboard_url: "/d/envoy-global"
             summary: "Coraza WAF blocking spike ({{ $value | humanize }} 403s in 10m)"
             description: "Sustained 403s above baseline — an attack wave, or a false-positive hitting real users. Triage in Kibana (KQL `message:\"Coraza\"`): if legit traffic is blocked, add an exclusion or revert to DetectionOnly. Routine bot-scans below 50/10m stay silent."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/data/elasticsearch.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/data/elasticsearch.yaml
@@ -20,6 +20,7 @@ spec:
             component: data
             priority: P2
           annotations:
+            dashboard_url: "/d/elasticsearch"
             summary: "Elasticsearch cluster RED"
             description: "Primary shards unassigned — log/SIEM data unavailable. Check disk + node health."
 
@@ -33,6 +34,7 @@ spec:
             component: data
             priority: P2
           annotations:
+            dashboard_url: "/d/elasticsearch"
             summary: "Elasticsearch disk >85% on {{ $labels.instance }}"
             description: "{{ $value | humanizePercentage }} used. ES blocks writes at 95% (flood watermark)."
 
@@ -45,5 +47,6 @@ spec:
             component: data
             priority: P2
           annotations:
+            dashboard_url: "/d/elasticsearch"
             summary: "Elasticsearch last successful snapshot >48h old"
             description: "SLM policy not running — check repository + cluster health."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/data/kafka.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/data/kafka.yaml
@@ -22,6 +22,7 @@ spec:
             component: data
             priority: P2
           annotations:
+            dashboard_url: "/d/kafka-exporter"
             summary: "Kafka KRaft quorum has NO active controller in {{ $labels.namespace }}"
             description: "KRaft cannot elect a leader — all metadata ops blocked, producers/consumers cannot connect."
 
@@ -33,6 +34,7 @@ spec:
             component: data
             priority: P2
           annotations:
+            dashboard_url: "/d/kafka-exporter"
             summary: "Kafka {{ $value }} partitions under min-ISR in {{ $labels.namespace }}"
             description: "Producers with acks=all FAIL (NotEnoughReplicasException). Restart unhealthy brokers; check disk."
 
@@ -44,5 +46,6 @@ spec:
             component: data
             priority: P2
           annotations:
+            dashboard_url: "/d/kafka-exporter"
             summary: "Kafka consumer lag >50k: {{ $labels.consumergroup }}"
             description: "Consumer group {{ $labels.consumergroup }} lagging {{ $value }} events — stuck or under-provisioned."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/data/postgres.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/data/postgres.yaml
@@ -20,6 +20,7 @@ spec:
             severity: critical
             component: data
           annotations:
+            dashboard_url: "/d/cnpg-postgres"
             summary: "CNPG primary down: {{ $labels.namespace }}/{{ $labels.cluster }}"
             description: "PostgreSQL primary not serving traffic for >2min."
 
@@ -31,6 +32,7 @@ spec:
             severity: critical
             component: cnpg
           annotations:
+            dashboard_url: "/d/cnpg-postgres"
             summary: "CNPG {{ $labels.namespace }}/{{ $labels.cluster }} no successful backup in 24h"
             description: "Last backup older than 24h — RPO exceeded, data-loss risk on failure."
             action: "kubectl get backup -n <ns> | grep <cluster> ; check ScheduledBackup + barman plugin pod"
@@ -47,6 +49,7 @@ spec:
             component: data
             priority: P2
           annotations:
+            dashboard_url: "/d/cnpg-postgres"
             summary: "CNPG replication lag >30s: {{ $labels.namespace }}/{{ $labels.cluster }}"
             description: "Replica lagging primary by {{ $value }}s — failover would lose recent writes."
 
@@ -58,6 +61,7 @@ spec:
             component: data
             priority: P2
           annotations:
+            dashboard_url: "/d/cnpg-postgres"
             summary: "PostgreSQL PVC >85% full: {{ $labels.persistentvolumeclaim }}"
             description: "Storage at {{ $value | humanizePercentage }} — disk full = DB crash. Expand PVC."
 
@@ -71,5 +75,6 @@ spec:
             component: cnpg
             priority: P2
           annotations:
+            dashboard_url: "/d/cnpg-postgres"
             summary: "CNPG backup-timestamp metric absent — backups likely not running"
             description: "No backup metric for 7d while CNPG clusters exist — verify ScheduledBackup + object-store creds."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/data/redis.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/data/redis.yaml
@@ -20,6 +20,7 @@ spec:
             component: data
             priority: P2
           annotations:
+            dashboard_url: "/d/redis-operator"
             summary: "Redis down: {{ $labels.namespace }}/{{ $labels.pod }}"
             description: "Redis unreachable >5min — n8n queue / cache unavailable."
 
@@ -34,5 +35,6 @@ spec:
             component: data
             priority: P2
           annotations:
+            dashboard_url: "/d/redis-operator"
             summary: "Redis OOM imminent: {{ $labels.namespace }}/{{ $labels.pod }}"
             description: "Memory at {{ $value | humanizePercentage }} of maxmemory — eviction storm likely."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/disk-io.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/disk-io.yaml
@@ -22,6 +22,7 @@ spec:
             severity: critical
             component: hardware
           annotations:
+            dashboard_url: "/d/k8s-node-overview"
             summary: "{{ $labels.instance }} root filesystem critically full ({{ $value | humanizePercentage }})"
             description: "Node out of disk space imminent — write failures, stuck services."
 
@@ -39,5 +40,6 @@ spec:
             component: hardware
             priority: P2
           annotations:
+            dashboard_url: "/d/k8s-node-overview"
             summary: "{{ $labels.instance }} root filesystem {{ $value | humanizePercentage }} free"
             description: "Node root nearly full — clean up or expand before it hits critical."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/host-network.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/host-network.yaml
@@ -19,6 +19,7 @@ spec:
             severity: critical
             component: hardware
           annotations:
+            dashboard_url: "/d/k8s-node-overview"
             summary: "{{ $labels.instance }} bridge {{ $labels.device }} is DOWN"
             description: "Proxmox bridge down — all VM/host traffic on this bridge is cut (Ceph/cluster link affected)."
 
@@ -37,6 +38,7 @@ spec:
             component: hardware
             priority: P2
           annotations:
+            dashboard_url: "/d/k8s-node-overview"
             summary: "{{ $labels.instance }} NIC {{ $labels.device }} reporting errors"
             description: "Hardware/link errors on physical NIC — check cable, port, driver. Ceph replication runs over this link."
 
@@ -50,5 +52,6 @@ spec:
             component: hardware
             priority: P2
           annotations:
+            dashboard_url: "/d/k8s-node-overview"
             summary: "{{ $labels.instance }} NIC {{ $labels.device }} lost link (was active)"
             description: "A physical NIC that carried traffic in the last hour is now down."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/host-sensors.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/host-sensors.yaml
@@ -20,6 +20,7 @@ spec:
             component: hardware
             priority: P2
           annotations:
+            dashboard_url: "/d/k8s-node-overview"
             summary: "CPU/sensor {{ $labels.chip }} on {{ $labels.instance }} at {{ $value }}°C"
             description: "Thermal shutdown imminent — host may power off. Check airflow / dust / fan."
 
@@ -31,6 +32,7 @@ spec:
             component: hardware
             priority: P2
           annotations:
+            dashboard_url: "/d/k8s-node-overview"
             summary: "{{ $labels.instance }} critically low RAM ({{ $value | humanizePercentage }})"
             description: "OOM-killer likely active — VMs at risk of being killed (nipogi runs 84G allocated / 77G physical)."
 
@@ -48,5 +50,6 @@ spec:
             component: hardware
             priority: P2
           annotations:
+            dashboard_url: "/d/k8s-node-overview"
             summary: "{{ $labels.instance }} thrashing: swap >80% + RAM frei <15%"
             description: "Host unter echtem Speicher-Druck (Swap voll UND wenig RAM frei) → Performance-Einbruch für VMs/Ceph. Right-sizing/Workload reduzieren."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/ssd-health.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/ssd-health.yaml
@@ -20,6 +20,7 @@ spec:
             severity: critical
             component: storage
           annotations:
+            dashboard_url: "/d/smartctl-exporter"
             summary: "SSD {{ $labels.device }} CRITICAL WARNING flag set (value {{ $value }})"
             description: "NVMe critical-warning bitfield non-zero (spare/temp/reliability/read-only). Replace soon."
             action: "nvme smart-log /dev/{{ $labels.device }} on the host to decode the warning bits."
@@ -31,6 +32,7 @@ spec:
             severity: critical
             component: storage
           annotations:
+            dashboard_url: "/d/smartctl-exporter"
             summary: "SSD {{ $labels.device }} media errors ({{ $value }} new in 1h)"
             description: "Uncorrectable NAND errors — the drive is failing. Back up + replace (Ceph replicas on the other node protect cluster data)."
 
@@ -46,6 +48,7 @@ spec:
             component: storage
             priority: P2
           annotations:
+            dashboard_url: "/d/smartctl-exporter"
             summary: "SSD {{ $labels.device }} spare blocks low ({{ $value }}%)"
             description: "NVMe available-spare <10% — controller will soon enter read-only mode. Migrate Ceph OSD off (ceph osd out) + replace."
 
@@ -57,6 +60,7 @@ spec:
             component: storage
             priority: P2
           annotations:
+            dashboard_url: "/d/smartctl-exporter"
             summary: "SSD {{ $labels.device }} at {{ $value }}% wear — near end-of-life"
             description: "Past 95% of rated TBW. Order replacement; failure risk rising."
 
@@ -68,6 +72,7 @@ spec:
             component: storage
             priority: P2
           annotations:
+            dashboard_url: "/d/smartctl-exporter"
             summary: "smartctl_exporter on {{ $labels.instance }} is down"
             description: "No SMART data from this Proxmox host — SSD health is unmonitored (blind spot)."
             action: "systemctl status smartctl_exporter on the host. Restart if needed."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/infrastructure/external.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/infrastructure/external.yaml
@@ -16,6 +16,7 @@ spec:
             severity: critical
             component: hypervisor
           annotations:
+            dashboard_url: "/d/proxmox-cluster"
             summary: "External connectivity lost: {{ $labels.target }}"
             description: "Blackbox probe to {{ $labels.target }} failing >5min. ISP/router/firewall issue."
 
@@ -26,6 +27,7 @@ spec:
             severity: warning
             component: hypervisor
           annotations:
+            dashboard_url: "/d/proxmox-cluster"
             summary: "External DNS slow/failing: {{ $labels.target }}"
 
         - alert: TLSCertificateExpiringSoonExternal
@@ -35,4 +37,5 @@ spec:
             severity: warning
             component: hypervisor
           annotations:
+            dashboard_url: "/d/proxmox-cluster"
             summary: "External TLS cert expires <14d: {{ $labels.target }}"

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/infrastructure/proxmox.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/infrastructure/proxmox.yaml
@@ -20,6 +20,7 @@ spec:
             severity: critical
             component: hypervisor
           annotations:
+            dashboard_url: "/d/proxmox-cluster"
             summary: "Proxmox host {{ $labels.instance }} unreachable"
             description: "node-exporter on Proxmox host down >5min — host (and its VMs) likely offline."
 
@@ -30,6 +31,7 @@ spec:
             severity: critical
             component: hypervisor
           annotations:
+            dashboard_url: "/d/proxmox-cluster"
             summary: "ZFS pool {{ $labels.zpool }} >95% full on {{ $labels.instance }}"
             description: "Pool nearly full — VM-disks will fail writes. Free space or expand immediately."
 
@@ -40,6 +42,7 @@ spec:
             severity: critical
             component: hypervisor
           annotations:
+            dashboard_url: "/d/proxmox-cluster"
             summary: "SMART health failure: {{ $labels.disk }} on {{ $labels.instance }}"
             description: "Disk reporting SMART failure — replace soon (data-loss risk)."
 
@@ -55,6 +58,7 @@ spec:
             component: hypervisor
             priority: P2
           annotations:
+            dashboard_url: "/d/proxmox-cluster"
             summary: "Proxmox host {{ $labels.instance }} root disk >85% full"
             description: "Root at {{ $value | humanizePercentage }} — PVE config write failures loom."
 
@@ -66,6 +70,7 @@ spec:
             component: hypervisor
             priority: P2
           annotations:
+            dashboard_url: "/d/proxmox-cluster"
             summary: "Proxmox host {{ $labels.instance }} memory <10% available"
             description: "VM scheduling/migration may fail (nipogi RAM is tight). Available {{ $value | humanizePercentage }}."
 
@@ -77,6 +82,7 @@ spec:
             component: hypervisor
             priority: P2
           annotations:
+            dashboard_url: "/d/proxmox-cluster"
             summary: "ZFS pool {{ $labels.zpool }} degraded on {{ $labels.instance }}"
             description: "Pool state {{ $labels.state }} — single-disk pools have no redundancy, check the disk."
 
@@ -88,6 +94,7 @@ spec:
             component: hypervisor
             priority: P2
           annotations:
+            dashboard_url: "/d/proxmox-cluster"
             summary: "Proxmox PVE exporter down"
             description: "Cannot scrape Proxmox API — VM/cluster state not visible in Grafana."
 
@@ -99,5 +106,6 @@ spec:
             component: hypervisor
             priority: P2
           annotations:
+            dashboard_url: "/d/proxmox-cluster"
             summary: "Proxmox VM-backup on {{ $labels.host }} is stale"
             description: "Newest vzdump archive on {{ $labels.host }} older than 26h — nightly job (02:00) missed or failed."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/infrastructure/talos.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/infrastructure/talos.yaml
@@ -24,6 +24,7 @@ spec:
             component: hypervisor
             priority: P2
           annotations:
+            dashboard_url: "/d/talos-os"
             summary: "Talos filesystem read-only on {{ $labels.instance }}:{{ $labels.mountpoint }}"
             description: "Real data-disk went read-only — likely disk failure or corruption."
 
@@ -35,6 +36,7 @@ spec:
             component: hypervisor
             priority: P2
           annotations:
+            dashboard_url: "/d/talos-os"
             summary: "Talos node {{ $labels.instance }} clock skew {{ $value }}s"
             description: "NTP sync issue — service-account / SVID tokens may fail (breaks SPIRE mTLS, webhook auth)."
 
@@ -46,5 +48,6 @@ spec:
             component: hypervisor
             priority: P2
           annotations:
+            dashboard_url: "/d/talos-os"
             summary: "Talos node {{ $labels.instance }} rebooted recently"
             description: "Node uptime <10min — investigate if unplanned."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/kubernetes/cluster.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/kubernetes/cluster.yaml
@@ -21,6 +21,7 @@ spec:
             severity: critical
             component: kubernetes
           annotations:
+            dashboard_url: "/d/k8s-cluster-overview"
             summary: "Kubernetes API server is down"
             description: "API server unreachable for >2 minutes. All cluster operations halted."
 
@@ -31,6 +32,7 @@ spec:
             severity: critical
             component: kubernetes
           annotations:
+            dashboard_url: "/d/k8s-cluster-overview"
             summary: "etcd quorum lost"
             description: "etcd has lost quorum — cluster state at risk of corruption."
 
@@ -41,6 +43,7 @@ spec:
             severity: critical
             component: control-plane
           annotations:
+            dashboard_url: "/d/k8s-cluster-overview"
             summary: "Control plane node {{ $labels.node }} is down"
             description: "Single control-plane node (ctrl-0 = SPOF) offline — complete cluster outage."
 
@@ -53,6 +56,7 @@ spec:
             severity: critical
             component: dns
           annotations:
+            dashboard_url: "/d/k8s-cluster-overview"
             summary: "CoreDNS has no healthy replicas"
             description: "CoreDNS down >2min — cluster DNS resolution broken, expect cascade failures."
             action: "kubectl get pods -n kube-system -l k8s-app=kube-dns + restart"
@@ -69,6 +73,7 @@ spec:
             component: dns
             priority: P2
           annotations:
+            dashboard_url: "/d/k8s-cluster-overview"
             summary: "CoreDNS upstream-forward unhealthy"
             description: "CoreDNS erreicht seine Upstream-DNS (forward zum Gateway) nicht → EXTERNE Auflösung bricht (interne svc-DNS evtl. noch ok). Das SERVFAIL-extern-Szenario nach Netz/upgrade-k8s-Changes."
             action: "kubectl logs -n kube-system -l k8s-app=kube-dns ; Node resolv.conf/Gateway prüfen"
@@ -83,6 +88,7 @@ spec:
             component: dns
             priority: P2
           annotations:
+            dashboard_url: "/d/k8s-cluster-overview"
             summary: "CoreDNS SERVFAIL-Rate hoch ({{ $value | humanizePercentage }})"
             description: ">5% der DNS-Antworten sind SERVFAIL — Auflösung schlägt fehl (Upstream tot, Policy-Drop Pod→CoreDNS, oder Misconfig)."
 
@@ -93,6 +99,7 @@ spec:
             component: dns
             priority: P2
           annotations:
+            dashboard_url: "/d/k8s-cluster-overview"
             summary: "CoreDNS plugin panic ({{ $value }})"
             description: "CoreDNS-Plugin gepanict — DNS instabil. kubectl logs -n kube-system -l k8s-app=kube-dns"
 
@@ -104,6 +111,7 @@ spec:
             component: observability
             priority: P2
           annotations:
+            dashboard_url: "/d/k8s-cluster-overview"
             summary: "kube-state-metrics liefert keine Metriken — kube_*-Alerts blind"
             description: "KSM down → ~die Hälfte der Alerts (Pods/Nodes/Deployments/Jobs/PVCs auf kube_*-Basis) feuern STILL nicht mehr = Meta-Blindheit. Check: kubectl get pods -n monitoring -l app.kubernetes.io/name=kube-state-metrics"
 
@@ -115,6 +123,7 @@ spec:
             component: kubernetes
             priority: P2
           annotations:
+            dashboard_url: "/d/k8s-cluster-overview"
             summary: "Node {{ $labels.node }} NotReady (>5m)"
             description: "Kubelet meldet Node nicht Ready — Pods werden evicted/rescheduled, Kapazität weg. (ControlPlaneNodeDown deckt nur ctrl-0.) Check: kubectl describe node {{ $labels.node }}"
 
@@ -126,6 +135,7 @@ spec:
             component: kubernetes
             priority: P2
           annotations:
+            dashboard_url: "/d/k8s-cluster-overview"
             summary: "Pod {{ $labels.namespace }}/{{ $labels.pod }} cannot pull image"
             description: "Container {{ $labels.container }} in {{ $labels.reason }} state for >5 minutes."
 
@@ -137,6 +147,7 @@ spec:
             component: kubernetes
             priority: P2
           annotations:
+            dashboard_url: "/d/k8s-cluster-overview"
             summary: "Node {{ $labels.node }} has memory pressure"
             description: "Node {{ $labels.node }} under memory pressure — pods may be evicted."
 
@@ -148,6 +159,7 @@ spec:
             component: kubernetes
             priority: P2
           annotations:
+            dashboard_url: "/d/k8s-cluster-overview"
             summary: "Node {{ $labels.node }} has disk pressure"
             description: "Node {{ $labels.node }} under disk pressure — pods may be evicted."
 
@@ -161,6 +173,7 @@ spec:
             component: control-plane
             priority: P2
           annotations:
+            dashboard_url: "/d/k8s-cluster-overview"
             summary: "kube-apiserver 5xx-rate >5%"
             description: "Many requests returning 5xx — check etcd, controller-manager, webhook-availability."
 
@@ -175,6 +188,7 @@ spec:
             component: webhooks
             priority: P2
           annotations:
+            dashboard_url: "/d/k8s-cluster-overview"
             summary: "Admission webhook {{ $labels.name }} failing"
             description: "Webhook rejecting requests AND not responding — investigate cert-manager-webhook, cnpg-webhook, kyverno."
             action: "kubectl delete secret <webhook-cert> -n <ns>; kubectl rollout restart deploy/<webhook>"
@@ -190,5 +204,6 @@ spec:
             component: jobs
             priority: P2
           annotations:
+            dashboard_url: "/d/k8s-cluster-overview"
             summary: "CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} failure-rate high"
             description: ">50% of last-hour jobs failed for >2h — check job logs."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/kubernetes/workloads.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/kubernetes/workloads.yaml
@@ -21,6 +21,7 @@ spec:
             component: application
             priority: P2
           annotations:
+            dashboard_url: "/d/k8s-pod-overview"
             summary: "Pod {{ $labels.namespace }}/{{ $labels.pod }} is crash looping"
             description: "Container {{ $labels.container }} in CrashLoopBackOff >5min."
 
@@ -31,6 +32,7 @@ spec:
             component: application
             priority: P2
           annotations:
+            dashboard_url: "/d/k8s-pod-overview"
             summary: "OOM kill: {{ $labels.namespace }}/{{ $labels.pod }}/{{ $labels.container }}"
             description: "Container OOM-killed in last 15min — raise memory limit or fix a leak."
 
@@ -42,5 +44,6 @@ spec:
             component: application
             priority: P2
           annotations:
+            dashboard_url: "/d/k8s-pod-overview"
             summary: "Pod {{ $labels.namespace }}/{{ $labels.pod }} not ready"
             description: "Pod stuck in {{ $labels.phase }} for 15+ min — scheduling failure or PVC unbound."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/cilium.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/cilium.yaml
@@ -20,6 +20,7 @@ spec:
             severity: critical
             component: network
           annotations:
+            dashboard_url: "/d/cilium-agent"
             summary: "Multiple Cilium agents down ({{ $value }})"
             description: "More than 1 Cilium agent unreachable — pod-to-pod networking degraded cluster-wide."
 
@@ -36,6 +37,7 @@ spec:
             component: network
             priority: P2
           annotations:
+            dashboard_url: "/d/cilium-agent"
             summary: "Cilium operator down (all replicas)"
             description: "New IPs/policies cannot be programmed. (Dampened — single-master restart-storms are benign.)"
 
@@ -50,6 +52,7 @@ spec:
             component: security
             priority: P2
           annotations:
+            dashboard_url: "/d/cilium-agent"
             summary: "SPIRE-Agents down — Cilium mTLS not enforced"
             description: "Without SPIRE, mTLS-required NetworkPolicies silently stop enforcing (4-day breakage on 2026-05-13)."
             action: "kubectl rollout restart -n cilium-spire daemonset/spire-agent"
@@ -62,6 +65,7 @@ spec:
             component: network
             priority: P2
           annotations:
+            dashboard_url: "/d/cilium-agent"
             summary: "Cilium WireGuard encryption disabled on {{ $value }} agents"
             description: "Pod traffic not encrypted — investigate WireGuard transparent encryption."
 
@@ -73,6 +77,7 @@ spec:
             component: network
             priority: P2
           annotations:
+            dashboard_url: "/d/cilium-agent"
             summary: "High NetworkPolicy denial rate ({{ $value | humanize }}/s)"
             description: "Many flows dropped by NetworkPolicies — misconfigured policy or attempted lateral movement."
 
@@ -85,6 +90,7 @@ spec:
             component: network
             priority: P2
           annotations:
+            dashboard_url: "/d/cilium-agent"
             summary: "Cilium: {{ $value }} node(s) unreachable in datapath (>15m)"
             description: "Node-to-node Cilium health-probe failing though agents are UP — datapath/WireGuard/identity broken (not a process crash). This is the gap that hid the 2026-05-24/25 cross-host outages behind PrometheusTargetDown-noise."
             action: "kubectl exec -n kube-system ds/cilium -c cilium-agent -- cilium-health status → finde 0/1-Node → cilium-agent dort neustarten (Identity-Resync). Cross-host? pve-firewall auf Proxmox-Hosts prüfen."
@@ -97,5 +103,6 @@ spec:
             component: network
             priority: P2
           annotations:
+            dashboard_url: "/d/cilium-agent"
             summary: "Cilium eBPF map >80% full ({{ $value | humanizePercentage }})"
             description: "Eine eBPF-Map nähert sich der Kapazität. Bei 100% scheitern neue Pods/Connections/Policies/Services LAUTLOS zu programmieren. Welche Map: cilium_bpf_map_pressure by (map_name) im Grafana."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/ingress.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/ingress.yaml
@@ -19,6 +19,7 @@ spec:
             severity: critical
             component: network
           annotations:
+            dashboard_url: "/d/envoy-global"
             summary: "All Cloudflared tunnels down"
             description: "External access via Cloudflare Tunnel completely down — all public services unreachable."
 
@@ -34,6 +35,7 @@ spec:
             component: network
             priority: P2
           annotations:
+            dashboard_url: "/d/envoy-global"
             summary: "Envoy Gateway controller down"
             description: "Gateway config updates blocked >3min (existing routes keep serving)."
 
@@ -49,6 +51,7 @@ spec:
             component: network
             priority: P2
           annotations:
+            dashboard_url: "/d/envoy-global"
             summary: "Envoy Gateway 5xx rate >5% ({{ $value | humanize }}%)"
             description: "Edge proxy seeing high upstream errors — backend services degraded, users see failures."
 
@@ -68,5 +71,6 @@ spec:
             component: network
             priority: P2
           annotations:
+            dashboard_url: "/d/envoy-global"
             summary: "Envoy Gateway: no healthy endpoints for {{ $labels.envoy_cluster_name }}"
             description: "User-facing upstream has 0 healthy endpoints >10min — traffic dropped."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/vpn.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/vpn.yaml
@@ -22,6 +22,7 @@ spec:
             component: vpn
             priority: P2
           annotations:
+            dashboard_url: "/d/hubble"
             summary: "Tailscale subnet-router down"
             description: "No healthy ts-*-connector pod — remote kubectl / Pod-CIDR access via Tailnet broken."
             action: "kubectl get pods -n tailscale ; check OAuth credentials"

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/observability/alertmanager-fixed.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/observability/alertmanager-fixed.yaml
@@ -31,6 +31,7 @@ spec:
             severity: warning
             component: monitoring
           annotations:
+            dashboard_url: "/d/alertmanager-state"
             summary: "Alertmanager {{ $labels.pod }} failed to send notifications via {{ $labels.integration }}"
             description: "Alertmanager {{ $labels.namespace }}/{{ $labels.pod }} failed to send {{ $value | humanizePercentage }} of notifications to {{ $labels.integration }}."
 
@@ -52,5 +53,6 @@ spec:
             severity: critical
             component: monitoring
           annotations:
+            dashboard_url: "/d/alertmanager-state"
             summary: "All Alertmanager instances failed to send {{ $labels.integration }} notifications"
             description: "ALL Alertmanager instances failed to send {{ $value | humanizePercentage }} of {{ $labels.integration }} notifications. Notification pipeline broken."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/observability/health.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/observability/health.yaml
@@ -24,6 +24,7 @@ spec:
             severity: critical
             component: monitoring
           annotations:
+            dashboard_url: "/d/prometheus-stats"
             summary: "Prometheus replica missing — metrics stopped"
             description: "Fewer ready Prometheus pods than desired >5min (often Phase=Succeeded after upgrade-eviction). All SLO/Rollout alerts blind until restarted."
 
@@ -36,6 +37,7 @@ spec:
             severity: critical
             component: monitoring
           annotations:
+            dashboard_url: "/d/prometheus-stats"
             summary: "Alertmanager replica missing — gossip mesh degraded"
             description: "Fewer ready AM pods than desired >10min. A single dead AM can stay invisible (HA majority). Fix: kubectl delete pod -n monitoring <name> --force."
 
@@ -51,6 +53,7 @@ spec:
             component: observability
             priority: P2
           annotations:
+            dashboard_url: "/d/prometheus-stats"
             summary: "Scrape target down: {{ $labels.job }}/{{ $labels.instance }}"
             description: "Prometheus cannot scrape {{ $labels.instance }} for >15min."
 
@@ -62,6 +65,7 @@ spec:
             component: observability
             priority: P2
           annotations:
+            dashboard_url: "/d/prometheus-stats"
             summary: "Grafana is down"
             description: "Grafana unreachable >5min — dashboards unavailable (alerting unaffected)."
 
@@ -73,6 +77,7 @@ spec:
             component: deployment
             priority: P2
           annotations:
+            dashboard_url: "/d/prometheus-stats"
             summary: "Argo Rollout aborted — {{ $labels.namespace }}/{{ $labels.name }}"
             description: "Rollout Degraded >5min (AnalysisTemplate fail, canary health-check, image-pull). New release stuck; users on old version."
 
@@ -85,6 +90,7 @@ spec:
             component: ingress
             priority: P2
           annotations:
+            dashboard_url: "/d/prometheus-stats"
             summary: "Envoy-gateway pod restart-loop (>10 in 1h)"
             description: "Repeated cold-starts hurt user-facing latency. If Reason=Completed: likely Talos-eviction race."
 
@@ -96,6 +102,7 @@ spec:
             component: observability
             priority: P2
           annotations:
+            dashboard_url: "/d/prometheus-stats"
             summary: "Loki {{ $labels.job }} down"
             description: "Log store unreachable >10min — log ingestion/query unavailable (metrics-alerting unaffected)."
 
@@ -107,6 +114,7 @@ spec:
             component: observability
             priority: P2
           annotations:
+            dashboard_url: "/d/prometheus-stats"
             summary: "Vector log-shipper {{ $labels.instance }} down"
             description: "Vector agent/aggregator down >10min — pod logs not shipped to Loki/Elasticsearch."
 
@@ -119,5 +127,6 @@ spec:
             component: observability
             priority: P2
           annotations:
+            dashboard_url: "/d/prometheus-stats"
             summary: "Vector sink {{ $labels.component_id }} dropping events"
             description: "Vector is discarding events at the {{ $labels.component_id }} sink for >15min — poison docs (ES mapping conflict), template-render failures or batch rejects. Logs silently lost. Check: kubectl logs -n elastic-system deploy/vector-aggregator | grep -v '^{' | grep ERROR"

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/observability/tempo.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/observability/tempo.yaml
@@ -19,5 +19,6 @@ spec:
             component: tempo
             priority: P2
           annotations:
+            dashboard_url: "/d/tempo-service-graph"
             summary: "Tempo distributor down — traces being dropped"
             description: "Apps cannot push traces; OTel-Collector queue grows. (Tracing only — no user impact.)"

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/observability/tracing.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/observability/tracing.yaml
@@ -19,5 +19,6 @@ spec:
             component: tracing
             priority: P2
           annotations:
+            dashboard_url: "/d/jaeger-internals"
             summary: "OTel-Collector failing to export spans"
             description: "Spans dropped — backend (Jaeger/Tempo) unreachable or rate-limited. All tracing affected."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/argocd.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/argocd.yaml
@@ -21,6 +21,7 @@ spec:
             component: platform
             priority: P2
           annotations:
+            dashboard_url: "/d/argocd-overview"
             summary: "ArgoCD application-controller down"
             description: "GitOps reconciliation halted >5min — no auto-deploy/self-heal until restored."
 
@@ -32,6 +33,7 @@ spec:
             component: platform
             priority: P2
           annotations:
+            dashboard_url: "/d/argocd-overview"
             summary: "ArgoCD app unhealthy: {{ $labels.name }} ({{ $labels.health_status }})"
             description: "App resources Degraded/Missing >30min — distinct from expected manual-sync drift. Check the app."
 
@@ -45,6 +47,7 @@ spec:
             component: identity
             priority: P2
           annotations:
+            dashboard_url: "/d/argocd-overview"
             summary: "LLDAP bootstrap CronJob hasn't succeeded in 3h"
             description: "User reconciliation broken — Keycloak login may fail."
             action: "kubectl get cronjob -n lldap; kubectl logs -n lldap -l cronjob=lldap-bootstrap"

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/cert-manager.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/cert-manager.yaml
@@ -20,6 +20,7 @@ spec:
             severity: critical
             component: platform
           annotations:
+            dashboard_url: "/d/cert-manager"
             summary: "TLS cert expires in <7d: {{ $labels.name }}"
             description: "Certificate {{ $labels.name }} in {{ $labels.namespace }} expires in {{ $value | humanizeDuration }} — service will break."
 
@@ -35,6 +36,7 @@ spec:
             component: platform
             priority: P2
           annotations:
+            dashboard_url: "/d/cert-manager"
             summary: "TLS cert expires in <30d: {{ $labels.name }}"
             description: "Renewal should happen automatically — verify cert-manager is healthy."
 
@@ -46,5 +48,6 @@ spec:
             component: platform
             priority: P2
           annotations:
+            dashboard_url: "/d/cert-manager"
             summary: "cert-manager controller down"
             description: "Unreachable >5min — certificate renewals + new issuance blocked."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/operators.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/operators.yaml
@@ -19,6 +19,7 @@ spec:
             component: platform
             priority: P2
           annotations:
+            dashboard_url: "/d/argocd-overview"
             summary: "Sealed-Secrets controller down"
             description: "New SealedSecrets cannot be decrypted while the controller is down — deployments referencing fresh secrets will stall."
 
@@ -30,5 +31,6 @@ spec:
             component: platform
             priority: P2
           annotations:
+            dashboard_url: "/d/argocd-overview"
             summary: "CloudNativePG operator down"
             description: "PostgreSQL cluster management blocked (failover/scaling/backup orchestration) — running DBs keep serving."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/csi.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/csi.yaml
@@ -21,6 +21,7 @@ spec:
             severity: critical
             component: storage
           annotations:
+            dashboard_url: "/d/ceph-cluster"
             summary: "PVC {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} <10% free ({{ $value | humanizePercentage }})"
             description: "Disk nearly full — app may fail / data loss. Expand the PVC now."
 
@@ -39,6 +40,7 @@ spec:
             component: storage
             priority: P2
           annotations:
+            dashboard_url: "/d/ceph-cluster"
             summary: "PVC {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} pending >30min"
             description: "Workload blocked. Likely stuck CSI omap-lock — see PVC-recovery runbook."
             action: "kubectl exec -n rook-ceph deploy/rook-ceph-tools -- rados -p replicapool-enterprise rmomapkey csi.volumes.default csi.volume.<PVC-UID>"
@@ -51,6 +53,7 @@ spec:
             component: storage
             priority: P2
           annotations:
+            dashboard_url: "/d/ceph-cluster"
             summary: "Ceph CSI provisioner {{ $labels.deployment }} has 0 replicas"
             description: "PVC creation/deletion blocked cluster-wide while provisioner is down."
 
@@ -62,6 +65,7 @@ spec:
             component: storage
             priority: P2
           annotations:
+            dashboard_url: "/d/ceph-cluster"
             summary: "{{ $value }} Released PVs — CSI cleanup not keeping up"
             description: "Released PVs accumulate when CSI deletion sticks on omap-locks. Hourly cleanup CronJob should handle it."
 
@@ -73,5 +77,6 @@ spec:
             component: storage
             priority: P2
           annotations:
+            dashboard_url: "/d/ceph-cluster"
             summary: "Ceph OSD {{ $labels.ceph_daemon }} flapping (>2 state changes in 10min)"
             description: "OSD bouncing up/down — investigate disk health, network, or memory pressure."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/rook-ceph.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/rook-ceph.yaml
@@ -21,6 +21,7 @@ spec:
             severity: critical
             component: storage
           annotations:
+            dashboard_url: "/d/ceph-cluster"
             summary: "Ceph cluster HEALTH_ERR"
             description: "Rook-Ceph reports HEALTH_ERR — data integrity at risk."
 
@@ -31,6 +32,7 @@ spec:
             severity: critical
             component: storage
           annotations:
+            dashboard_url: "/d/ceph-cluster"
             summary: "Ceph lost quorum — majority of OSDs down"
             description: "More than 50% of OSDs down — DATA LOSS RISK, storage unavailable."
 
@@ -46,6 +48,7 @@ spec:
             component: storage
             priority: P2
           annotations:
+            dashboard_url: "/d/ceph-cluster"
             summary: "Ceph OSD {{ $labels.ceph_daemon }} down"
             description: "OSD down >10min — replication degraded (replica=2, msa2 still holds copies)."
 
@@ -61,6 +64,7 @@ spec:
             component: storage
             priority: P2
           annotations:
+            dashboard_url: "/d/ceph-cluster"
             summary: "Ceph {{ $value }} PGs not active for 15m — data availability degraded"
             description: "PGs stuck inactive/peering — clients on them block (slow-ops cascade → RGW/CNPG timeouts). Check 'ceph pg dump_stuck inactive' + cross-node OSD heartbeats / Cilium NodeEncryption."
 
@@ -72,6 +76,7 @@ spec:
             component: storage
             priority: P2
           annotations:
+            dashboard_url: "/d/ceph-cluster"
             summary: "Ceph OSD {{ $labels.ceph_daemon }} >75% full"
             description: "OSD at {{ $value | humanizePercentage }} — add capacity before it blocks writes."
 
@@ -83,6 +88,7 @@ spec:
             component: storage
             priority: P2
           annotations:
+            dashboard_url: "/d/ceph-cluster"
             summary: "Rook-Ceph operator down"
             description: "Operator unreachable >5min — Ceph reconcile/management operations blocked."
 
@@ -96,5 +102,6 @@ spec:
             component: storage
             priority: P2
           annotations:
+            dashboard_url: "/d/ceph-cluster"
             summary: "RGW bucket {{ $labels.bucket }} >85% of quota"
             description: "Bucket fills soon — Velero/CNPG/Loki/Tempo writes will fail at 100%."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/velero.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/velero.yaml
@@ -20,6 +20,7 @@ spec:
             severity: critical
             component: backup
           annotations:
+            dashboard_url: "/d/velero-overview"
             summary: "No successful Velero backup in 24h for {{ $labels.schedule }}"
             description: "RPO exceeded — covers failed/partial/not-running causes. DR-readiness compromised."
             action: "velero backup get ; velero backup logs <name> ; check RGW bucket quota + creds"
@@ -36,6 +37,7 @@ spec:
             component: backup
             priority: P2
           annotations:
+            dashboard_url: "/d/velero-overview"
             summary: "Velero controller down"
             description: "Velero unreachable >5min — no backups will run until restored."
 
@@ -47,5 +49,6 @@ spec:
             component: backup
             priority: P2
           annotations:
+            dashboard_url: "/d/velero-overview"
             summary: "Velero partial-failure backup ({{ $value }})"
             description: "Backup completed with errors — some volumes may be missing from the restore point."


### PR DESCRIPTION
A der Observability-Overhaul: (1) stabile UIDs (spec.uid=name) auf 49 GrafanaDashboards. (2) dashboard_url-Annotation auf ALLE 116 Alerts → ihr Dashboard. Telegram-Template (values-prod.yaml:529) nutzt dashboard_url + prefixt grafana_url → jeder Alert-Button geht jetzt aufs spezifische Dashboard statt generisch. Enterprise 'Alert→Drilldown'-Kette komplett.