### PR TITLE
cloudflared scrape + dashboard

### DIFF
--- a/kubernetes/infrastructure/ingress/cloudflared/base/daemon-set.yaml
+++ b/kubernetes/infrastructure/ingress/cloudflared/base/daemon-set.yaml
@@ -35,6 +35,10 @@ spec:
             - --config
             - /etc/cloudflared/config/config.yaml
             - run
+          ports:
+            - name: metrics
+              containerPort: 2000
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /ready

--- a/kubernetes/infrastructure/ingress/cloudflared/base/kustomization.yaml
+++ b/kubernetes/infrastructure/ingress/cloudflared/base/kustomization.yaml
@@ -13,3 +13,4 @@ configMapGenerator:
 resources:
   - sealed-credentials.yaml
   - daemon-set.yaml
+  - podmonitor.yaml

--- a/kubernetes/infrastructure/ingress/cloudflared/base/podmonitor.yaml
+++ b/kubernetes/infrastructure/ingress/cloudflared/base/podmonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: cloudflared
+  namespace: cloudflared
+  labels:
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app: cloudflared
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s

--- a/kubernetes/infrastructure/observability/dashboards/configs/base/cloudflared.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/configs/base/cloudflared.yaml
@@ -1,0 +1,45 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: cloudflared
+  namespace: grafana
+spec:
+  uid: cloudflared
+  instanceSelector:
+    matchLabels:
+      app: grafana
+  allowCrossNamespaceImport: true
+  folder: Network
+  resyncPeriod: 5m
+  json: |
+    {
+      "title": "Cloudflared — Tunnel",
+      "uid": "cloudflared",
+      "tags": ["cloudflared", "tunnel", "network"],
+      "timezone": "browser",
+      "schemaVersion": 39,
+      "refresh": "30s",
+      "time": {"from": "now-6h", "to": "now"},
+      "templating": {"list": []},
+      "panels": [
+        {"id": 900, "type": "row", "title": "Cloudflared Tunnel", "gridPos": {"x": 0, "y": 0, "w": 24, "h": 1}},
+        {"id": 1, "type": "stat", "title": "HA Connections (aktiv)", "gridPos": {"x": 0, "y": 1, "w": 6, "h": 5},
+         "datasource": {"type": "prometheus", "uid": "prometheus"},
+         "targets": [{"expr": "sum(cloudflared_tunnel_ha_connections)"}],
+         "fieldConfig": {"defaults": {"unit": "short", "decimals": 0, "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "yellow", "value": 1}, {"color": "green", "value": 2}]}}},
+         "options": {"colorMode": "background", "graphMode": "none"}},
+        {"id": 2, "type": "stat", "title": "Concurrent Requests", "gridPos": {"x": 6, "y": 1, "w": 6, "h": 5},
+         "datasource": {"type": "prometheus", "uid": "prometheus"},
+         "targets": [{"expr": "sum(cloudflared_tunnel_concurrent_requests_per_tunnel)"}],
+         "fieldConfig": {"defaults": {"unit": "short", "decimals": 0}},
+         "options": {"colorMode": "value", "graphMode": "area"}},
+        {"id": 3, "type": "timeseries", "title": "Request-Rate (req/s)", "gridPos": {"x": 12, "y": 1, "w": 12, "h": 9},
+         "datasource": {"type": "prometheus", "uid": "prometheus"},
+         "targets": [{"expr": "sum(rate(cloudflared_tunnel_total_requests[5m]))", "legendFormat": "requests/s"}],
+         "fieldConfig": {"defaults": {"unit": "reqps", "custom": {"fillOpacity": 10}}}},
+        {"id": 4, "type": "timeseries", "title": "Request-Errors (err/s)", "gridPos": {"x": 0, "y": 6, "w": 12, "h": 9},
+         "datasource": {"type": "prometheus", "uid": "prometheus"},
+         "targets": [{"expr": "sum(rate(cloudflared_tunnel_request_errors[5m]))", "legendFormat": "errors/s"}],
+         "fieldConfig": {"defaults": {"unit": "short", "color": {"mode": "fixed", "fixedColor": "red"}, "custom": {"fillOpacity": 10}}}}
+      ]
+    }

--- a/kubernetes/infrastructure/observability/dashboards/configs/base/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/configs/base/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - n8n-health.yaml
   - keycloak-health.yaml
   - keycloak-full.yaml
+  - cloudflared.yaml
 
 labels:
   - pairs:


### PR DESCRIPTION
B des Observability-Overhauls: cloudflared metrics-Port (:2000 named) am DaemonSet + PodMonitor (release-Label) → Prometheus scrapt cloudflared. Custom Dashboard (uid cloudflared, Network-Folder) mit NUR verifizierten Metriken (ha_connections, total_requests, request_errors, concurrent) → keine leeren Panels. influxdb übersprungen (nicht deployed). lldap/renovate/netbird/authelia exportieren keine Metriken → kein Dashboard möglich.