### PR TITLE
drova: kafka processing-errors alert

### DIFF
--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/tenants/drova/kafka.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/tenants/drova/kafka.yaml
@@ -1,0 +1,30 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: kafka-drova
+  labels:
+    release: kube-prometheus-stack
+spec:
+  # App-level Kafka signal (otelgrpc/messaging instrumentation, v0.20.0+).
+  # Broker-level alerts (quorum/ISR/lag) live in ../../data/kafka.yaml — this is the
+  # complementary "a service fails to process/emit events" signal. Latency + per-topic
+  # throughput → Grafana "drova-overview" Kafka row, not alerts (lean principle).
+  groups:
+    - name: drova-kafka-processing
+      interval: 1m
+      rules:
+        - alert: DrovaKafkaProcessingErrors
+          expr: |
+            sum by (service_name) (rate(messaging_consume_messages_total{status="error"}[5m])) > 0
+            or
+            sum by (service_name) (rate(messaging_publish_messages_total{status="error"}[5m])) > 0
+          for: 10m
+          labels:
+            severity: warning
+            priority: P2
+            component: kafka
+            tenant: drova
+          annotations:
+            summary: "Drova {{ $labels.service_name }} failing Kafka event processing"
+            description: "{{ $labels.service_name }} has Kafka publish/consume errors (messaging_*{status=\"error\"}) sustained >10min — events route to drova.retry.* or are dropped. Check the consumer/producer handler."
+            dashboard_url: "https://grafana.timourhomelab.org/d/drova-overview"

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/tenants/drova/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/tenants/drova/kustomization.yaml
@@ -6,4 +6,5 @@ kind: Kustomization
 resources:
   - apps.yaml         # DrovaServiceDown, DrovaPodCrashLooping (keep — page/ticket)
   - slos.yaml         # SLO burn-rate alerts (the Google-SRE pattern — keep)
+  - kafka.yaml        # DrovaKafkaProcessingErrors (app-level messaging_* failures)
   # anomaly.yaml + latency.yaml → Dashboard (Grafana "Drova Golden Signals"/"SLO"), nicht Alert


### PR DESCRIPTION
Add DrovaKafkaProcessingErrors (warning, Slack-only) — app-level signal for messaging_*{status=error} on publish/consume, sustained >10min.

Complements the broker-level Kafka alerts (quorum/ISR/lag in data/kafka.yaml) with the missing 'a service fails to process/emit events' signal, now measurable via the v0.20.0 messaging instrumentation. Uses 'or' (not '+') so services with only consume- or only publish-errors (chat/payment) still fire. Latency/per-topic → drova-overview dashboard, not alerts.