### PR TITLE
pre-commit hooks: yamllint + tofu/tflint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,11 +146,6 @@ renovate.json
 # All terraform modules that seem unused
 tofu/modules/
 
-# Pre-commit hooks
-.pre-commit-config.yaml
-.yamllint.yaml
-.yamllint
-
 # Research Notes (private)
 NOTES.md
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+  - repo: local
+    hooks:
+      - id: yamllint
+        name: yamllint
+        entry: yamllint -c .yamllint.yaml
+        language: system
+        types: [yaml]
+
+      - id: tofu-fmt
+        name: tofu fmt
+        entry: tofu fmt -check -recursive tofu/
+        language: system
+        files: \.(tf|tofu)$
+        pass_filenames: false
+
+      - id: tflint
+        name: tflint
+        entry: bash -c 'cd tofu && tflint --recursive'
+        language: system
+        files: \.(tf|tofu)$
+        pass_filenames: false

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,32 @@
+extends: default
+
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+
+ignore: |
+  README.md
+  LICENSE
+  notes/
+  **/charts/**
+  **/templates/**
+  **/*sealed*.yaml
+  **/sealed-secret*.yaml
+  kubernetes/infrastructure/observability/dashboards/
+
+rules:
+  document-start: disable
+  line-length: disable
+  indentation: disable
+  comments-indentation: disable
+  comments: disable
+  empty-lines: disable
+  truthy: disable
+  brackets: disable
+  braces: disable
+  colons: disable
+  commas: disable
+  hyphens: disable
+  key-duplicates: enable
+  trailing-spaces: enable
+  new-line-at-end-of-file: enable

--- a/tofu/.tflint.hcl
+++ b/tofu/.tflint.hcl
@@ -1,0 +1,7 @@
+plugin "terraform" {
+  enabled = true
+}
+
+config {
+  call_module_type = "local"
+}


### PR DESCRIPTION
Root-level pre-commit linting (local, on git commit — no CI workflow).

- .pre-commit-config.yaml: yamllint + tofu fmt -check + tflint
- .yamllint.yaml: tuned (style off, bug-catchers on; ignores vendored helm charts, inline-JSON dashboards, sealed secrets)
- tofu/.tflint.hcl: terraform ruleset for .tofu files
- .gitignore: un-ignore the configs so they are tracked

Lints both YAML and OpenTofu locally. Tested: yamllint 62 findings (from 8248 pre-tune), tofu fmt clean, tflint clean.