### PR TITLE
fix: grafana dashboards 403 (WAF false-positive)

### DIFF
--- a/kubernetes/infrastructure/ingress/gateway/base/waf/coraza-waf.yaml
+++ b/kubernetes/infrastructure/ingress/gateway/base/waf/coraza-waf.yaml
@@ -34,5 +34,7 @@ spec:
             # Kibana false-positive exclusions (942220 INT_MAX in bsearch, 911100 DELETE on saved_objects)
             - 'SecRule REQUEST_URI "@beginsWith /internal/bsearch" "id:1100010,phase:1,pass,nolog,ctl:ruleRemoveById=942220"'
             - 'SecRule REQUEST_URI "@beginsWith /api/saved_objects" "id:1100011,phase:1,pass,nolog,ctl:ruleRemoveById=911100"'
+            # Grafana false-positive exclusion (PromQL in /api/ds/query trips 942xxx SQLi → 949110 block)
+            - 'SecRule REQUEST_URI "@beginsWith /api/ds/" "id:1100012,phase:1,pass,nolog,ctl:ruleEngine=Off"'
             - "Include @owasp_crs/*.conf"
         default_directives: "default"


### PR DESCRIPTION
Coraza WAF blocks Grafana /api/ds/query POSTs with 403 — PromQL bodies (=~, quotes, or/and) trip CRS 942100 (SQLi libinjection) → 949110 anomaly-score-exceeded → block. All dashboards broken.

Fix: path-scoped ctl:ruleEngine=Off for /api/ds/ (Grafana datasource proxy, authenticated + VPN-only), same pattern as the WS/gRPC bypass and Kibana exclusions.