### PR TITLE
fix: 2 broken community dashboards + kibana WAF

### DIFF
--- a/kubernetes/infrastructure/ingress/gateway/base/waf/coraza-waf.yaml
+++ b/kubernetes/infrastructure/ingress/gateway/base/waf/coraza-waf.yaml
@@ -31,9 +31,9 @@ spec:
             - "SecResponseBodyAccess Off"  # drova SPA > 512KB → empty 520; Off keeps request-side protection
             - 'SecRule REQUEST_HEADERS:Upgrade "@streq websocket" "id:1000,phase:1,pass,nolog,ctl:ruleEngine=Off"'
             - 'SecRule REQUEST_HEADERS:Content-Type "@beginsWith application/grpc" "id:1001,phase:1,pass,nolog,ctl:ruleEngine=Off"'
-            # Kibana false-positive exclusions (942220 INT_MAX in bsearch, 911100 DELETE on saved_objects)
-            - 'SecRule REQUEST_URI "@beginsWith /internal/bsearch" "id:1100010,phase:1,pass,nolog,ctl:ruleRemoveById=942220"'
-            - 'SecRule REQUEST_URI "@beginsWith /api/saved_objects" "id:1100011,phase:1,pass,nolog,ctl:ruleRemoveById=911100"'
+            # Kibana false-positive exclusions (complex KQL/bsearch trips 942xxx SQLi → 949110 block)
+            - 'SecRule REQUEST_URI "@beginsWith /internal/bsearch" "id:1100010,phase:1,pass,nolog,ctl:ruleEngine=Off"'
+            - 'SecRule REQUEST_URI "@beginsWith /api/saved_objects" "id:1100011,phase:1,pass,nolog,ctl:ruleEngine=Off"'
             # Grafana false-positive exclusion (PromQL in /api/ds/query trips 942xxx SQLi → 949110 block)
             - 'SecRule REQUEST_URI "@beginsWith /api/ds/" "id:1100012,phase:1,pass,nolog,ctl:ruleEngine=Off"'
             - "Include @owasp_crs/*.conf"

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/data/cnpg-postgres.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/data/cnpg-postgres.yaml
@@ -14,6 +14,6 @@ spec:
   datasources:
     - inputName: "DS_PROMETHEUS"
       datasourceName: "prometheus"
-    - inputName: "DS_LOKI"
-      datasourceName: "loki"
+    - inputName: "DS_EXPRESSION"
+      datasourceName: "__expr__"
   url: "https://grafana.com/api/dashboards/20417/revisions/3/download"

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/data/kafka-exporter.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/data/kafka-exporter.yaml
@@ -12,8 +12,6 @@ spec:
   folder: "Data"
   resyncPeriod: 5m
   datasources:
-    - inputName: "DS_PROMETHEUS"
+    - inputName: "DS_PROMETHEUS_WH211"
       datasourceName: "prometheus"
-    - inputName: "DS_LOKI"
-      datasourceName: "loki"
   url: "https://grafana.com/api/dashboards/7589/revisions/5/download"


### PR DESCRIPTION
Audit of all 40 live dashboards found 2 broken (datasource-not-found), rest fine:

- kafka-exporter: grafana.com 7589 uses input DS_PROMETHEUS_WH211, CR mapped DS_PROMETHEUS → mismatch. Fixed inputName + dropped extraneous DS_LOKI.
- cnpg-postgres: grafana.com 20417 uses DS_EXPRESSION (__expr__ engine), unmapped → added mapping.

Plus kibana WAF: /internal/bsearch + /api/saved_objects now ruleEngine=Off (complex KQL tripped 942xxx SQLi → 403, same FP as grafana).