### PR TITLE
fix dns probe false-positive

### DIFF
--- a/kubernetes/infrastructure/observability/blackbox-exporter/base/probes.yaml
+++ b/kubernetes/infrastructure/observability/blackbox-exporter/base/probes.yaml
@@ -35,11 +35,12 @@ spec:
   targets:
     staticConfig:
       static:
-        - 1.1.1.1:53
-        - 8.8.8.8:53
-        - 192.168.0.1:53
+        # Cilium FQDN-egress blockt direktes externes :53 (Pods müssen über CoreDNS).
+        # CoreDNS einen externen Namen auflösen lassen testet den echten Resolution-Pfad;
+        # direkte external-resolver-Targets (1.1.1.1:53 etc.) wären strukturell False-Positives.
+        - kube-dns.kube-system.svc.cluster.local:53
       labels:
-        env: external
+        env: cluster-dns
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: Probe

--- a/kubernetes/infrastructure/observability/blackbox-exporter/base/values.yaml
+++ b/kubernetes/infrastructure/observability/blackbox-exporter/base/values.yaml
@@ -37,7 +37,7 @@ config:
       dns:
         query_name: "cloudflare.com"
         query_type: "A"
-        valid_rcodes: ["NOSUCHNAME","NOERROR"]
+        valid_rcodes: ["NXDOMAIN","NOERROR"]
         preferred_ip_protocol: "ip4"
     tcp_connect:
       prober: tcp


### PR DESCRIPTION
external-dns blackbox probe was firing ExternalDNSResolutionFailed — two bugs:

1. **module config**: `valid_rcodes: ["NOSUCHNAME", ...]` — NOSUCHNAME is not a valid rcode string (it's NXDOMAIN), so dns_external validation failed even when the query succeeded.
2. **targets**: probed external resolvers directly (1.1.1.1:53 etc.), which Cilium FQDN-egress blocks by design (pods resolve via CoreDNS). Repointed at CoreDNS → tests the real resolution path (CoreDNS resolving an external name).

Verified: blackbox /probe to CoreDNS returns probe_dns_query_succeeded=1 with answers; only the bad rcode string blocked probe_success.