### PR TITLE
alert action remediations

### DIFF
--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/apps/keycloak.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/apps/keycloak.yaml
@@ -28,6 +28,7 @@ spec:
             dashboard_url: "/d/keycloak-health"
             summary: "Keycloak down — auth provider unavailable"
             description: "All Keycloak replicas not ready — OIDC login broken cluster-wide (ArgoCD, Grafana, n8n, etc.)."
+            action: "kubectl -n keycloak get pod -l app=keycloak + logs (watch OOMKill — 23x crashloop 2026-05-24); check the CNPG keycloak-db."
 
     # ── TICKET ──
     - name: keycloak-ticket
@@ -44,3 +45,4 @@ spec:
             dashboard_url: "/d/keycloak-health"
             summary: "Keycloak realm {{ $labels.realm }} elevated failed-login rate"
             description: "{{ $value }} failed logins/sec — possible credential-stuffing or brute-force."
+            action: "Check keycloak logs for realm {{ $labels.realm }}; if credential-stuffing: rate-limit + block the source IPs."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/apps/n8n.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/apps/n8n.yaml
@@ -22,6 +22,7 @@ spec:
             dashboard_url: "/d/n8n-health"
             summary: "n8n main pod down"
             description: "n8n-main 0 ready replicas >2min — workflow execution halted."
+            action: "kubectl -n n8n-prod get pod -l app=n8n-main + logs; check the CNPG n8n-postgres + Redis backend."
 
         - alert: N8NWorkerDown
           expr: kube_deployment_status_replicas_available{namespace="n8n-prod",deployment="n8n-worker"} == 0
@@ -34,3 +35,4 @@ spec:
             dashboard_url: "/d/n8n-health"
             summary: "n8n worker down"
             description: "n8n worker pool empty — async workflows queue up (Redis-backed)."
+            action: "kubectl -n n8n-prod get pod -l app=n8n-worker + logs; async workflows queue in Redis until restored."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/compliance/kyverno.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/compliance/kyverno.yaml
@@ -46,6 +46,7 @@ spec:
             dashboard_url: "/d/kyverno"
             summary: "Kyverno actively denied admission of {{ $labels.resource_kind }} in {{ $labels.resource_namespace }}"
             description: "Enforce-mode policy blocked a {{ $labels.resource_kind }} create/update. Workload is degraded."
+            action: "kubectl get events -n {{ $labels.resource_namespace }} | grep -i denied; find the enforce-policy blocking the {{ $labels.resource_kind }}; fix the resource or the policy."
 
         - alert: KyvernoControllerDown
           expr: |
@@ -59,3 +60,4 @@ spec:
             dashboard_url: "/d/kyverno"
             summary: "Kyverno controller {{ $labels.deployment }} down"
             description: "Policy enforcement disabled — security risk."
+            action: "kubectl get pod -A -l app.kubernetes.io/name=kyverno + logs; policy enforcement is OFF until restored (security risk)."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/compliance/waf.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/compliance/waf.yaml
@@ -20,6 +20,7 @@ spec:
             dashboard_url: "/d/envoy-global"
             summary: "Coraza WAF detection spike ({{ $value | humanize }} in 10m)"
             description: "CRS rule-matches above baseline — new false-positive source or a real probe. Triage in Kibana (KQL `message:\"Coraza\"`), then add an exclusion or treat as attack."
+            action: "Kibana KQL message:Coraza → FP source or probe? Add a path-scoped exclusion (coraza-waf.yaml directives_map) or treat as attack."
         - alert: CorazaWAFBlockingSpike
           expr: sum(increase(waf_coraza_detections_total{action="denied"}[10m])) > 50
           for: 10m
@@ -31,3 +32,4 @@ spec:
             dashboard_url: "/d/envoy-global"
             summary: "Coraza WAF blocking spike ({{ $value | humanize }} 403s in 10m)"
             description: "Sustained 403s above baseline — an attack wave, or a false-positive hitting real users. Triage in Kibana (KQL `message:\"Coraza\"`): if legit traffic is blocked, add an exclusion or revert to DetectionOnly. Routine bot-scans below 50/10m stay silent."
+            action: "Kibana KQL message:Coraza → if legit traffic blocked, add an exclusion or revert SecRuleEngine to DetectionOnly; else attack wave."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/data/elasticsearch.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/data/elasticsearch.yaml
@@ -23,6 +23,7 @@ spec:
             dashboard_url: "/d/elasticsearch"
             summary: "Elasticsearch cluster RED"
             description: "Primary shards unassigned — log/SIEM data unavailable. Check disk + node health."
+            action: "'GET _cluster/allocation/explain' for unassigned primaries; free disk if a watermark is hit; check node health."
 
         - alert: ElasticsearchDiskFillingUp
           expr: |
@@ -37,6 +38,7 @@ spec:
             dashboard_url: "/d/elasticsearch"
             summary: "Elasticsearch disk >85% on {{ $labels.instance }}"
             description: "{{ $value | humanizePercentage }} used. ES blocks writes at 95% (flood watermark)."
+            action: "Free ES disk: delete old indices or lower ILM retention before the 95% flood watermark blocks writes."
 
         - alert: ElasticsearchSnapshotStale
           expr: |
@@ -50,3 +52,4 @@ spec:
             dashboard_url: "/d/elasticsearch"
             summary: "Elasticsearch last successful snapshot >48h old"
             description: "SLM policy not running — check repository + cluster health."
+            action: "'GET _slm/policy'; check the snapshot repo (Ceph-RGW); 'POST _slm/policy/<id>/_execute' to retry."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/data/kafka.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/data/kafka.yaml
@@ -25,6 +25,7 @@ spec:
             dashboard_url: "/d/kafka-exporter"
             summary: "Kafka KRaft quorum has NO active controller in {{ $labels.namespace }}"
             description: "KRaft cannot elect a leader — all metadata ops blocked, producers/consumers cannot connect."
+            action: "kubectl -n {{ $labels.namespace }} get pod -l strimzi.io/controller-role=true + logs; do NOT delete all controllers (KRaft quorum)."
 
         - alert: KafkaUnderMinISR
           expr: kafka_cluster_partition_under_min_isr{pod=~".*kafka.*"} > 0
@@ -37,6 +38,7 @@ spec:
             dashboard_url: "/d/kafka-exporter"
             summary: "Kafka {{ $value }} partitions under min-ISR in {{ $labels.namespace }}"
             description: "Producers with acks=all FAIL (NotEnoughReplicasException). Restart unhealthy brokers; check disk."
+            action: "kubectl -n {{ $labels.namespace }} get pod -l strimzi.io/broker-role=true; restart unhealthy brokers one at a time; check broker disk."
 
         - alert: KafkaConsumerLagCritical
           expr: kafka_consumergroup_lag_sum > 50000
@@ -49,3 +51,4 @@ spec:
             dashboard_url: "/d/kafka-exporter"
             summary: "Kafka consumer lag >50k: {{ $labels.consumergroup }}"
             description: "Consumer group {{ $labels.consumergroup }} lagging {{ $value }} events — stuck or under-provisioned."
+            action: "Check the consumer pods (scaled/stuck?); 'kafka-consumer-groups --describe'; scale or restart the consumer."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/data/postgres.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/data/postgres.yaml
@@ -23,6 +23,7 @@ spec:
             dashboard_url: "/d/cnpg-postgres"
             summary: "CNPG primary down: {{ $labels.namespace }}/{{ $labels.cluster }}"
             description: "PostgreSQL primary not serving traffic for >2min."
+            action: "kubectl cnpg status {{ $labels.cluster }} -n {{ $labels.namespace }}; check pods; 'kubectl cnpg promote' a healthy replica if the primary is lost."
 
         - alert: CNPGBackupStale
           expr: |
@@ -35,7 +36,7 @@ spec:
             dashboard_url: "/d/cnpg-postgres"
             summary: "CNPG {{ $labels.namespace }}/{{ $labels.cluster }} no successful backup in 24h"
             description: "Last backup older than 24h — RPO exceeded, data-loss risk on failure."
-            action: "kubectl get backup -n <ns> | grep <cluster> ; check ScheduledBackup + barman plugin pod"
+            action: "kubectl get backup -n {{ $labels.namespace }} | grep {{ $labels.cluster }} ; check ScheduledBackup + barman plugin pod"
 
     # ── TICKET ──
     - name: postgres-ticket
@@ -52,6 +53,7 @@ spec:
             dashboard_url: "/d/cnpg-postgres"
             summary: "CNPG replication lag >30s: {{ $labels.namespace }}/{{ $labels.cluster }}"
             description: "Replica lagging primary by {{ $value }}s — failover would lose recent writes."
+            action: "kubectl cnpg status {{ $labels.cluster }} -n {{ $labels.namespace }}; check replica WAL apply + Ceph IO pressure on the replica's PVC."
 
         - alert: CnpgStorageNearFull
           expr: (kubelet_volume_stats_used_bytes{persistentvolumeclaim=~".*-postgres-.*|.*-cnpg-.*"} / kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~".*-postgres-.*|.*-cnpg-.*"}) > 0.85
@@ -64,6 +66,7 @@ spec:
             dashboard_url: "/d/cnpg-postgres"
             summary: "PostgreSQL PVC >85% full: {{ $labels.persistentvolumeclaim }}"
             description: "Storage at {{ $value | humanizePercentage }} — disk full = DB crash. Expand PVC."
+            action: "Expand the CNPG PVC online (raise cluster.spec.storage.size) before disk-full crashes the DB."
 
         - alert: CNPGBackupNeverRan
           expr: |
@@ -78,3 +81,4 @@ spec:
             dashboard_url: "/d/cnpg-postgres"
             summary: "CNPG backup-timestamp metric absent — backups likely not running"
             description: "No backup metric for 7d while CNPG clusters exist — verify ScheduledBackup + object-store creds."
+            action: "kubectl get scheduledbackup -A; verify the barman ObjectStore secret/creds + the backup plugin pod."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/data/redis.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/data/redis.yaml
@@ -23,6 +23,7 @@ spec:
             dashboard_url: "/d/redis-operator"
             summary: "Redis down: {{ $labels.namespace }}/{{ $labels.pod }}"
             description: "Redis unreachable >5min — n8n queue / cache unavailable."
+            action: "kubectl -n {{ $labels.namespace }} get pod -l app=redis + logs; check the redis-operator (it should recreate the pod)."
 
         - alert: RedisOutOfMemory
           expr: |
@@ -38,3 +39,4 @@ spec:
             dashboard_url: "/d/redis-operator"
             summary: "Redis OOM imminent: {{ $labels.namespace }}/{{ $labels.pod }}"
             description: "Memory at {{ $value | humanizePercentage }} of maxmemory — eviction storm likely."
+            action: "Raise maxmemory or find the key leak; n8n queue backlog fills it — check worker throughput."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/disk-io.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/disk-io.yaml
@@ -25,6 +25,7 @@ spec:
             dashboard_url: "/d/k8s-node-overview"
             summary: "{{ $labels.instance }} root filesystem critically full ({{ $value | humanizePercentage }})"
             description: "Node out of disk space imminent — write failures, stuck services."
+            action: "SSH host; 'journalctl --vacuum-size=200M'; 'du -sh /var/*' to find the offender; prune images/logs."
 
     # ── TICKET ──
     - name: disk-io-ticket
@@ -43,3 +44,4 @@ spec:
             dashboard_url: "/d/k8s-node-overview"
             summary: "{{ $labels.instance }} root filesystem {{ $value | humanizePercentage }} free"
             description: "Node root nearly full — clean up or expand before it hits critical."
+            action: "SSH host; 'journalctl --vacuum-size=200M' + prune old images/logs before it hits critical."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/host-network.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/host-network.yaml
@@ -22,6 +22,7 @@ spec:
             dashboard_url: "/d/k8s-node-overview"
             summary: "{{ $labels.instance }} bridge {{ $labels.device }} is DOWN"
             description: "Proxmox bridge down — all VM/host traffic on this bridge is cut (Ceph/cluster link affected)."
+            action: "SSH host; 'ip link show vmbr*'; 'ifreload -a' or restart networking; verify the Proxmox bridge config."
 
     # ── TICKET ──
     - name: host-network-ticket
@@ -41,6 +42,7 @@ spec:
             dashboard_url: "/d/k8s-node-overview"
             summary: "{{ $labels.instance }} NIC {{ $labels.device }} reporting errors"
             description: "Hardware/link errors on physical NIC — check cable, port, driver. Ceph replication runs over this link."
+            action: "SSH host; 'ethtool -S {{ $labels.device }}' for error counters; check cable/port/driver (this carries Ceph replication)."
 
         - alert: HostActiveLinkLost
           expr: |
@@ -55,3 +57,4 @@ spec:
             dashboard_url: "/d/k8s-node-overview"
             summary: "{{ $labels.instance }} NIC {{ $labels.device }} lost link (was active)"
             description: "A physical NIC that carried traffic in the last hour is now down."
+            action: "SSH host; 'ethtool {{ $labels.device }}' (link detected?); check cable/switch port; 'ip link set {{ $labels.device }} up'."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/host-sensors.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/host-sensors.yaml
@@ -23,6 +23,7 @@ spec:
             dashboard_url: "/d/k8s-node-overview"
             summary: "CPU/sensor {{ $labels.chip }} on {{ $labels.instance }} at {{ $value }}°C"
             description: "Thermal shutdown imminent — host may power off. Check airflow / dust / fan."
+            action: "PHYSICAL: clean dust + check fan/airflow on the host; reduce load until temp drops below throttle."
 
         - alert: HostMemoryCritical
           expr: node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes < 0.05
@@ -35,6 +36,7 @@ spec:
             dashboard_url: "/d/k8s-node-overview"
             summary: "{{ $labels.instance }} critically low RAM ({{ $value | humanizePercentage }})"
             description: "OOM-killer likely active — VMs at risk of being killed (nipogi runs 84G allocated / 77G physical)."
+            action: "kubectl top nodes; reduce/rebalance VM RAM (nipogi overcommitted 84G/77G) before the OOM-killer hits."
 
         - alert: HostSwapUsageHigh
           # Feuert nur bei ECHTEM Thrashing: Swap voll UND wenig RAM frei.
@@ -53,3 +55,4 @@ spec:
             dashboard_url: "/d/k8s-node-overview"
             summary: "{{ $labels.instance }} thrashing: swap >80% + RAM frei <15%"
             description: "Host unter echtem Speicher-Druck (Swap voll UND wenig RAM frei) → Performance-Einbruch für VMs/Ceph. Right-sizing/Workload reduzieren."
+            action: "kubectl top pods -A --sort-by=memory; right-size the memory-heavy workloads on this host."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/infrastructure/external.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/infrastructure/external.yaml
@@ -19,6 +19,7 @@ spec:
             dashboard_url: "/d/proxmox-cluster"
             summary: "External connectivity lost: {{ $labels.target }}"
             description: "Blackbox probe to {{ $labels.target }} failing >5min. ISP/router/firewall issue."
+            action: "Check ISP/router/modem; ping {{ $labels.target }} from a host; this is upstream of the cluster."
 
         - alert: ExternalDNSResolutionFailed
           expr: probe_dns_lookup_time_seconds{job="blackbox-dns"} > 5 or probe_success{job="blackbox-dns"} == 0
@@ -29,6 +30,7 @@ spec:
           annotations:
             dashboard_url: "/d/proxmox-cluster"
             summary: "External DNS slow/failing: {{ $labels.target }}"
+            action: "kubectl logs -n kube-system -l k8s-app=kube-dns; the probe tests CoreDNS resolving externally — check upstream/Gateway."
 
         - alert: TLSCertificateExpiringSoonExternal
           expr: probe_ssl_earliest_cert_expiry{job=~"blackbox-.*"} - time() < 14 * 24 * 3600
@@ -39,3 +41,4 @@ spec:
           annotations:
             dashboard_url: "/d/proxmox-cluster"
             summary: "External TLS cert expires <14d: {{ $labels.target }}"
+            action: "Check the cert for {{ $labels.target }}; cert-manager (internal) or the external CA; <14d to expiry."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/infrastructure/proxmox.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/infrastructure/proxmox.yaml
@@ -23,6 +23,7 @@ spec:
             dashboard_url: "/d/proxmox-cluster"
             summary: "Proxmox host {{ $labels.instance }} unreachable"
             description: "node-exporter on Proxmox host down >5min — host (and its VMs) likely offline."
+            action: "Check the Proxmox host ({{ $labels.instance }}) physically; SSH it; its VMs are down too — full-host outage."
 
         - alert: ProxmoxZfsPoolCritical
           expr: (node_zfs_zpool_alloc{job="proxmox-host-node"} / node_zfs_zpool_size{job="proxmox-host-node"}) > 0.95
@@ -34,6 +35,7 @@ spec:
             dashboard_url: "/d/proxmox-cluster"
             summary: "ZFS pool {{ $labels.zpool }} >95% full on {{ $labels.instance }}"
             description: "Pool nearly full — VM-disks will fail writes. Free space or expand immediately."
+            action: "SSH the host; 'zpool list {{ $labels.zpool }}'; free space (old VM disks/snapshots) or expand the pool."
 
         - alert: ProxmoxDiskSmartFailure
           expr: smartmon_device_smart_healthy{job="proxmox-host-node"} == 0
@@ -45,6 +47,7 @@ spec:
             dashboard_url: "/d/proxmox-cluster"
             summary: "SMART health failure: {{ $labels.disk }} on {{ $labels.instance }}"
             description: "Disk reporting SMART failure — replace soon (data-loss risk)."
+            action: "SSH the host; 'smartctl -a {{ $labels.disk }}'; plan a disk replacement (data-loss risk)."
 
     # ── TICKET ──
     - name: proxmox-ticket
@@ -61,6 +64,7 @@ spec:
             dashboard_url: "/d/proxmox-cluster"
             summary: "Proxmox host {{ $labels.instance }} root disk >85% full"
             description: "Root at {{ $value | humanizePercentage }} — PVE config write failures loom."
+            action: "SSH the host; clean /var/log + old ISOs/backups; PVE config writes fail when root fills."
 
         - alert: ProxmoxHostMemoryPressure
           expr: (node_memory_MemAvailable_bytes{job="proxmox-host-node"} / node_memory_MemTotal_bytes{job="proxmox-host-node"}) < 0.10
@@ -73,6 +77,7 @@ spec:
             dashboard_url: "/d/proxmox-cluster"
             summary: "Proxmox host {{ $labels.instance }} memory <10% available"
             description: "VM scheduling/migration may fail (nipogi RAM is tight). Available {{ $value | humanizePercentage }}."
+            action: "SSH the host; check VM RAM allocation (nipogi is tight); reduce/rebalance before migration fails."
 
         - alert: ProxmoxZfsPoolDegraded
           expr: node_zfs_zpool_state{job="proxmox-host-node",state!="online"} > 0
@@ -85,6 +90,7 @@ spec:
             dashboard_url: "/d/proxmox-cluster"
             summary: "ZFS pool {{ $labels.zpool }} degraded on {{ $labels.instance }}"
             description: "Pool state {{ $labels.state }} — single-disk pools have no redundancy, check the disk."
+            action: "SSH the host; 'zpool status {{ $labels.zpool }}'; single-disk pool = no redundancy, check/replace the disk."
 
         - alert: ProxmoxApiExporterDown
           expr: up{job="proxmox-pve"} == 0
@@ -97,6 +103,7 @@ spec:
             dashboard_url: "/d/proxmox-cluster"
             summary: "Proxmox PVE exporter down"
             description: "Cannot scrape Proxmox API — VM/cluster state not visible in Grafana."
+            action: "Check the pve-exporter pod + the Proxmox API token; Grafana loses VM/cluster state meanwhile."
 
         - alert: ProxmoxBackupStale
           expr: time() - max by (host) (pve_vzdump_last_backup_timestamp_seconds) > 93600
@@ -109,3 +116,4 @@ spec:
             dashboard_url: "/d/proxmox-cluster"
             summary: "Proxmox VM-backup on {{ $labels.host }} is stale"
             description: "Newest vzdump archive on {{ $labels.host }} older than 26h — nightly job (02:00) missed or failed."
+            action: "SSH {{ $labels.host }}; check the vzdump cron (02:00) + 'pvesm status'; is the backup storage reachable?"

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/infrastructure/talos.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/infrastructure/talos.yaml
@@ -27,6 +27,7 @@ spec:
             dashboard_url: "/d/talos-os"
             summary: "Talos filesystem read-only on {{ $labels.instance }}:{{ $labels.mountpoint }}"
             description: "Real data-disk went read-only — likely disk failure or corruption."
+            action: "talosctl -n <node> dmesg | grep -iE 'read-only|I/O error'; likely disk failure — check the Proxmox VM disk + Ceph."
 
         - alert: TalosNodeClockSkew
           expr: abs(node_timex_offset_seconds) > 0.5
@@ -39,6 +40,7 @@ spec:
             dashboard_url: "/d/talos-os"
             summary: "Talos node {{ $labels.instance }} clock skew {{ $value }}s"
             description: "NTP sync issue — service-account / SVID tokens may fail (breaks SPIRE mTLS, webhook auth)."
+            action: "talosctl -n <node> time; NTP broken → SPIRE/SA-tokens fail; check the host clock + NTP server."
 
         - alert: TalosNodeRebootedRecently
           expr: (time() - node_boot_time_seconds) < 600
@@ -51,3 +53,4 @@ spec:
             dashboard_url: "/d/talos-os"
             summary: "Talos node {{ $labels.instance }} rebooted recently"
             description: "Node uptime <10min — investigate if unplanned."
+            action: "talosctl -n <node> get events / dmesg; if unplanned: check the Proxmox VM + host stability."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/kubernetes/cluster.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/kubernetes/cluster.yaml
@@ -24,6 +24,7 @@ spec:
             dashboard_url: "/d/k8s-cluster-overview"
             summary: "Kubernetes API server is down"
             description: "API server unreachable for >2 minutes. All cluster operations halted."
+            action: "Check ctrl-0 (SPOF): 'talosctl health' + etcd/kubelet on the control plane; verify the Proxmox VM is up."
 
         - alert: EtcdQuorumLoss
           expr: sum(up{job=~"kube-etcd|etcd"}) < ((count(up{job=~"kube-etcd|etcd"}) / 2) + 1)
@@ -35,6 +36,7 @@ spec:
             dashboard_url: "/d/k8s-cluster-overview"
             summary: "etcd quorum lost"
             description: "etcd has lost quorum — cluster state at risk of corruption."
+            action: "talosctl etcd status; single-node etcd on ctrl-0 — restore from snapshot if corrupt ('talosctl etcd snapshot')."
 
         - alert: ControlPlaneNodeDown
           expr: kube_node_status_condition{condition="Ready",status="true",node="ctrl-0"} == 0
@@ -46,6 +48,7 @@ spec:
             dashboard_url: "/d/k8s-cluster-overview"
             summary: "Control plane node {{ $labels.node }} is down"
             description: "Single control-plane node (ctrl-0 = SPOF) offline — complete cluster outage."
+            action: "{{ $labels.node }} offline = full outage (known SPOF); check the Proxmox VM + 'talosctl health'."
 
         - alert: CoreDNSDown
           expr: |
@@ -91,6 +94,7 @@ spec:
             dashboard_url: "/d/k8s-cluster-overview"
             summary: "CoreDNS SERVFAIL-Rate hoch ({{ $value | humanizePercentage }})"
             description: ">5% der DNS-Antworten sind SERVFAIL — Auflösung schlägt fehl (Upstream tot, Policy-Drop Pod→CoreDNS, oder Misconfig)."
+            action: "kubectl logs -n kube-system -l k8s-app=kube-dns; check upstream/Gateway + Cilium policy Pod→CoreDNS."
 
         - alert: CoreDNSPanics
           expr: increase(coredns_panics_total[10m]) > 0
@@ -102,6 +106,7 @@ spec:
             dashboard_url: "/d/k8s-cluster-overview"
             summary: "CoreDNS plugin panic ({{ $value }})"
             description: "CoreDNS-Plugin gepanict — DNS instabil. kubectl logs -n kube-system -l k8s-app=kube-dns"
+            action: "kubectl logs -n kube-system -l k8s-app=kube-dns --previous; identify the panicking plugin; restart CoreDNS."
 
         - alert: KubeStateMetricsDown
           expr: absent(kube_node_status_condition{condition="Ready"})
@@ -114,6 +119,7 @@ spec:
             dashboard_url: "/d/k8s-cluster-overview"
             summary: "kube-state-metrics liefert keine Metriken — kube_*-Alerts blind"
             description: "KSM down → ~die Hälfte der Alerts (Pods/Nodes/Deployments/Jobs/PVCs auf kube_*-Basis) feuern STILL nicht mehr = Meta-Blindheit. Check: kubectl get pods -n monitoring -l app.kubernetes.io/name=kube-state-metrics"
+            action: "kubectl -n monitoring rollout restart deploy/kube-state-metrics; ~half the alerts are blind until it's back."
 
         - alert: KubeNodeNotReady
           expr: kube_node_status_condition{condition="Ready",status="true"} == 0
@@ -126,6 +132,7 @@ spec:
             dashboard_url: "/d/k8s-cluster-overview"
             summary: "Node {{ $labels.node }} NotReady (>5m)"
             description: "Kubelet meldet Node nicht Ready — Pods werden evicted/rescheduled, Kapazität weg. (ControlPlaneNodeDown deckt nur ctrl-0.) Check: kubectl describe node {{ $labels.node }}"
+            action: "kubectl describe node {{ $labels.node }}; check kubelet (talosctl logs kubelet) + the node's Proxmox VM."
 
         - alert: ImagePullBackoff
           expr: kube_pod_container_status_waiting_reason{reason=~"ImagePullBackOff|ErrImagePull"} == 1
@@ -138,6 +145,7 @@ spec:
             dashboard_url: "/d/k8s-cluster-overview"
             summary: "Pod {{ $labels.namespace }}/{{ $labels.pod }} cannot pull image"
             description: "Container {{ $labels.container }} in {{ $labels.reason }} state for >5 minutes."
+            action: "kubectl describe pod -n {{ $labels.namespace }} {{ $labels.pod }}; check image name/registry/pull-secret (quay/ghcr outages bite)."
 
         - alert: NodeMemoryPressure
           expr: kube_node_status_condition{condition="MemoryPressure",status="true"} == 1
@@ -150,6 +158,7 @@ spec:
             dashboard_url: "/d/k8s-cluster-overview"
             summary: "Node {{ $labels.node }} has memory pressure"
             description: "Node {{ $labels.node }} under memory pressure — pods may be evicted."
+            action: "kubectl describe node {{ $labels.node }}; find memory-heavy pods ('kubectl top pods -A'); evict/reschedule."
 
         - alert: NodeDiskPressure
           expr: kube_node_status_condition{condition="DiskPressure",status="true"} == 1
@@ -162,6 +171,7 @@ spec:
             dashboard_url: "/d/k8s-cluster-overview"
             summary: "Node {{ $labels.node }} has disk pressure"
             description: "Node {{ $labels.node }} under disk pressure — pods may be evicted."
+            action: "kubectl describe node {{ $labels.node }}; clean node disk (images/logs) + check ephemeral-storage hogs."
 
         - alert: APIServerErrorRateHigh
           expr: |
@@ -176,6 +186,7 @@ spec:
             dashboard_url: "/d/k8s-cluster-overview"
             summary: "kube-apiserver 5xx-rate >5%"
             description: "Many requests returning 5xx — check etcd, controller-manager, webhook-availability."
+            action: "Check etcd health + controller-manager + webhook availability (a slow/failing webhook spikes apiserver 5xx)."
 
         - alert: WebhookFailing
           expr: |
@@ -207,3 +218,4 @@ spec:
             dashboard_url: "/d/k8s-cluster-overview"
             summary: "CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} failure-rate high"
             description: ">50% of last-hour jobs failed for >2h — check job logs."
+            action: "kubectl -n {{ $labels.namespace }} get job | grep {{ $labels.cronjob }}; logs the last failed job for the root cause."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/kubernetes/workloads.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/kubernetes/workloads.yaml
@@ -24,6 +24,7 @@ spec:
             dashboard_url: "/d/k8s-pod-overview"
             summary: "Pod {{ $labels.namespace }}/{{ $labels.pod }} is crash looping"
             description: "Container {{ $labels.container }} in CrashLoopBackOff >5min."
+            action: "kubectl logs -n {{ $labels.namespace }} {{ $labels.pod }} --previous; describe for the crash reason; fix config/image/resources."
 
         - alert: ContainerOOMKilled
           expr: increase(kube_pod_container_status_terminated_reason{reason="OOMKilled"}[15m]) > 0
@@ -35,6 +36,7 @@ spec:
             dashboard_url: "/d/k8s-pod-overview"
             summary: "OOM kill: {{ $labels.namespace }}/{{ $labels.pod }}/{{ $labels.container }}"
             description: "Container OOM-killed in last 15min — raise memory limit or fix a leak."
+            action: "Raise {{ $labels.container }}'s memory limit or fix the leak; kubectl describe pod -n {{ $labels.namespace }} {{ $labels.pod }}."
 
         - alert: PodNotReady
           expr: kube_pod_status_phase{phase!~"Running|Succeeded|Failed"} == 1
@@ -47,3 +49,4 @@ spec:
             dashboard_url: "/d/k8s-pod-overview"
             summary: "Pod {{ $labels.namespace }}/{{ $labels.pod }} not ready"
             description: "Pod stuck in {{ $labels.phase }} for 15+ min — scheduling failure or PVC unbound."
+            action: "kubectl describe pod -n {{ $labels.namespace }} {{ $labels.pod }}; check events — scheduling, PVC-unbound, or failing readiness."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/cilium.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/cilium.yaml
@@ -23,6 +23,7 @@ spec:
             dashboard_url: "/d/cilium-agent"
             summary: "Multiple Cilium agents down ({{ $value }})"
             description: "More than 1 Cilium agent unreachable — pod-to-pod networking degraded cluster-wide."
+            action: "kubectl -n kube-system get pod -l k8s-app=cilium; 'kubectl logs -p' the crashing agents — usually kernel/eBPF or a bad config rollout."
 
     # ── TICKET ──
     - name: cilium-ticket
@@ -40,6 +41,7 @@ spec:
             dashboard_url: "/d/cilium-agent"
             summary: "Cilium operator down (all replicas)"
             description: "New IPs/policies cannot be programmed. (Dampened — single-master restart-storms are benign.)"
+            action: "kubectl -n kube-system rollout restart deploy/cilium-operator; check logs (single-master restart-storms are benign)."
 
         - alert: SPIREAgentDown
           expr: |
@@ -68,6 +70,7 @@ spec:
             dashboard_url: "/d/cilium-agent"
             summary: "Cilium WireGuard encryption disabled on {{ $value }} agents"
             description: "Pod traffic not encrypted — investigate WireGuard transparent encryption."
+            action: "Check cilium-config enable-wireguard + agent 'cilium status | grep Encryption'; restart affected agents (watch encrypt-node drift 2026-05-23)."
 
         - alert: HubbleHighPolicyDrops
           expr: sum(rate(hubble_drop_total{reason="POLICY_DENIED"}[5m])) > 10
@@ -80,6 +83,7 @@ spec:
             dashboard_url: "/d/cilium-agent"
             summary: "High NetworkPolicy denial rate ({{ $value | humanize }}/s)"
             description: "Many flows dropped by NetworkPolicies — misconfigured policy or attempted lateral movement."
+            action: "hubble observe --verdict DROPPED to find source/dest; fix the policy, or treat as a lateral-movement attempt."
 
         - alert: CiliumNodeUnreachable
           expr: max(cilium_unreachable_nodes) > 0
@@ -106,3 +110,4 @@ spec:
             dashboard_url: "/d/cilium-agent"
             summary: "Cilium eBPF map >80% full ({{ $value | humanizePercentage }})"
             description: "Eine eBPF-Map nähert sich der Kapazität. Bei 100% scheitern neue Pods/Connections/Policies/Services LAUTLOS zu programmieren. Welche Map: cilium_bpf_map_pressure by (map_name) im Grafana."
+            action: "Grafana 'cilium_bpf_map_pressure by (map_name)' → identify the full map; reduce policy/endpoint count or raise the map size."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/ingress.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/ingress.yaml
@@ -22,6 +22,7 @@ spec:
             dashboard_url: "/d/envoy-global"
             summary: "All Cloudflared tunnels down"
             description: "External access via Cloudflare Tunnel completely down — all public services unreachable."
+            action: "kubectl -n cloudflared get pod -l app=cloudflared + logs; check the tunnel token secret + Cloudflare dashboard tunnel status."
 
     # ── TICKET ──
     - name: ingress-ticket
@@ -38,6 +39,7 @@ spec:
             dashboard_url: "/d/envoy-global"
             summary: "Envoy Gateway controller down"
             description: "Gateway config updates blocked >3min (existing routes keep serving)."
+            action: "kubectl -n envoy-gateway-system rollout restart deploy/envoy-gateway; existing routes keep serving meanwhile."
 
         - alert: EnvoyGateway5xxRateHigh
           expr: |
@@ -54,6 +56,7 @@ spec:
             dashboard_url: "/d/envoy-global"
             summary: "Envoy Gateway 5xx rate >5% ({{ $value | humanize }}%)"
             description: "Edge proxy seeing high upstream errors — backend services degraded, users see failures."
+            action: "Find the failing upstream in the envoy-global dashboard; check that backend's pods/health + any recent deploy."
 
         - alert: EnvoyGatewayNoEndpoints
           expr: |
@@ -74,3 +77,4 @@ spec:
             dashboard_url: "/d/envoy-global"
             summary: "Envoy Gateway: no healthy endpoints for {{ $labels.envoy_cluster_name }}"
             description: "User-facing upstream has 0 healthy endpoints >10min — traffic dropped."
+            action: "kubectl get endpoints -n {{ $labels.namespace }} {{ $labels.envoy_cluster_name }} — backend has 0 ready pods; check the deployment + readiness probe."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/observability/alertmanager-fixed.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/observability/alertmanager-fixed.yaml
@@ -34,6 +34,7 @@ spec:
             dashboard_url: "/d/alertmanager-state"
             summary: "Alertmanager {{ $labels.pod }} failed to send notifications via {{ $labels.integration }}"
             description: "Alertmanager {{ $labels.namespace }}/{{ $labels.pod }} failed to send {{ $value | humanizePercentage }} of notifications to {{ $labels.integration }}."
+            action: "Check the {{ $labels.integration }} integration (token/webhook); kubectl logs -n monitoring {{ $labels.pod }}."
 
         - alert: AlertmanagerClusterFailedToSendAlerts
           expr: |
@@ -56,3 +57,4 @@ spec:
             dashboard_url: "/d/alertmanager-state"
             summary: "All Alertmanager instances failed to send {{ $labels.integration }} notifications"
             description: "ALL Alertmanager instances failed to send {{ $value | humanizePercentage }} of {{ $labels.integration }} notifications. Notification pipeline broken."
+            action: "ALL AMs failing {{ $labels.integration }} — the token/webhook secret is broken cluster-wide; check + re-seal it."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/observability/health.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/observability/health.yaml
@@ -27,6 +27,7 @@ spec:
             dashboard_url: "/d/prometheus-stats"
             summary: "Prometheus replica missing — metrics stopped"
             description: "Fewer ready Prometheus pods than desired >5min (often Phase=Succeeded after upgrade-eviction). All SLO/Rollout alerts blind until restarted."
+            action: "kubectl get pod -n monitoring -l app.kubernetes.io/name=prometheus; if Phase=Succeeded after eviction: 'kubectl delete pod ... --force'."
 
         - alert: AlertmanagerPodMissing
           expr: |
@@ -40,6 +41,7 @@ spec:
             dashboard_url: "/d/prometheus-stats"
             summary: "Alertmanager replica missing — gossip mesh degraded"
             description: "Fewer ready AM pods than desired >10min. A single dead AM can stay invisible (HA majority). Fix: kubectl delete pod -n monitoring <name> --force."
+            action: "kubectl delete pod -n monitoring -l app.kubernetes.io/name=alertmanager --force (a single dead AM hides behind HA majority)."
 
     # ── TICKET — degradation (digest channel) ──────────────────────────────
     - name: observability-ticket
@@ -56,6 +58,7 @@ spec:
             dashboard_url: "/d/prometheus-stats"
             summary: "Scrape target down: {{ $labels.job }}/{{ $labels.instance }}"
             description: "Prometheus cannot scrape {{ $labels.instance }} for >15min."
+            action: "Check {{ $labels.instance }} ({{ $labels.job }}): is the exporter/pod up? ServiceMonitor selector + network policy?"
 
         - alert: GrafanaDown
           expr: up{job="grafana"} == 0
@@ -68,6 +71,7 @@ spec:
             dashboard_url: "/d/prometheus-stats"
             summary: "Grafana is down"
             description: "Grafana unreachable >5min — dashboards unavailable (alerting unaffected)."
+            action: "kubectl -n monitoring rollout restart deploy/grafana; check logs + its DB/datasources."
 
         - alert: RolloutAborted
           expr: rollout_phase{phase="Degraded"} == 1
@@ -80,6 +84,7 @@ spec:
             dashboard_url: "/d/prometheus-stats"
             summary: "Argo Rollout aborted — {{ $labels.namespace }}/{{ $labels.name }}"
             description: "Rollout Degraded >5min (AnalysisTemplate fail, canary health-check, image-pull). New release stuck; users on old version."
+            action: "kubectl argo rollouts get rollout {{ $labels.name }} -n {{ $labels.namespace }}; check the AnalysisRun/canary; retry or abort."
 
         - alert: EnvoyGatewayPodCompletedLoop
           expr: |
@@ -93,6 +98,7 @@ spec:
             dashboard_url: "/d/prometheus-stats"
             summary: "Envoy-gateway pod restart-loop (>10 in 1h)"
             description: "Repeated cold-starts hurt user-facing latency. If Reason=Completed: likely Talos-eviction race."
+            action: "kubectl -n gateway describe pod -l app.kubernetes.io/name=envoy; if Reason=Completed it's a Talos-eviction race — check node pressure."
 
         - alert: LokiDown
           expr: up{job=~".*loki.*"} == 0
@@ -105,6 +111,7 @@ spec:
             dashboard_url: "/d/prometheus-stats"
             summary: "Loki {{ $labels.job }} down"
             description: "Log store unreachable >10min — log ingestion/query unavailable (metrics-alerting unaffected)."
+            action: "kubectl -n monitoring get pod -l app.kubernetes.io/name=loki + logs; check its object-store (Ceph-RGW) backend."
 
         - alert: VectorPipelineDown
           expr: up{job=~".*vector.*"} == 0
@@ -117,6 +124,7 @@ spec:
             dashboard_url: "/d/prometheus-stats"
             summary: "Vector log-shipper {{ $labels.instance }} down"
             description: "Vector agent/aggregator down >10min — pod logs not shipped to Loki/Elasticsearch."
+            action: "kubectl -n elastic-system get pod -l app.kubernetes.io/name=vector + logs; restart the agent/aggregator."
 
         - alert: VectorSinkDroppingEvents
           expr: |
@@ -130,3 +138,4 @@ spec:
             dashboard_url: "/d/prometheus-stats"
             summary: "Vector sink {{ $labels.component_id }} dropping events"
             description: "Vector is discarding events at the {{ $labels.component_id }} sink for >15min — poison docs (ES mapping conflict), template-render failures or batch rejects. Logs silently lost. Check: kubectl logs -n elastic-system deploy/vector-aggregator | grep -v '^{' | grep ERROR"
+            action: "kubectl logs -n elastic-system deploy/vector-aggregator | grep -v '^{' | grep ERROR — poison doc (ES mapping conflict) or sink backpressure; check ES disk/health."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/observability/tempo.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/observability/tempo.yaml
@@ -22,3 +22,4 @@ spec:
             dashboard_url: "/d/tempo-service-graph"
             summary: "Tempo distributor down — traces being dropped"
             description: "Apps cannot push traces; OTel-Collector queue grows. (Tracing only — no user impact.)"
+            action: "kubectl -n tempo get pod -l app.kubernetes.io/component=distributor + logs; the OTel queue grows until restored (tracing only)."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/observability/tracing.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/observability/tracing.yaml
@@ -22,3 +22,4 @@ spec:
             dashboard_url: "/d/jaeger-internals"
             summary: "OTel-Collector failing to export spans"
             description: "Spans dropped — backend (Jaeger/Tempo) unreachable or rate-limited. All tracing affected."
+            action: "kubectl logs -n opentelemetry -l app.kubernetes.io/component=opentelemetry-collector | grep -i export; check Jaeger/Tempo reachability."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/argocd.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/argocd.yaml
@@ -24,6 +24,7 @@ spec:
             dashboard_url: "/d/argocd-overview"
             summary: "ArgoCD application-controller down"
             description: "GitOps reconciliation halted >5min — no auto-deploy/self-heal until restored."
+            action: "kubectl -n argocd rollout restart statefulset/argocd-application-controller; check its logs + resource limits."
 
         - alert: ArgoCDAppUnhealthy
           expr: argocd_app_info{health_status=~"Degraded|Missing"} == 1
@@ -36,6 +37,7 @@ spec:
             dashboard_url: "/d/argocd-overview"
             summary: "ArgoCD app unhealthy: {{ $labels.name }} ({{ $labels.health_status }})"
             description: "App resources Degraded/Missing >30min — distinct from expected manual-sync drift. Check the app."
+            action: "argocd app get {{ $labels.name }} (or kubectl describe app -n argocd {{ $labels.name }}); check the failing resource."
 
         - alert: LLDAPBootstrapCronJobFailing
           expr: |

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/cert-manager.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/cert-manager.yaml
@@ -23,6 +23,7 @@ spec:
             dashboard_url: "/d/cert-manager"
             summary: "TLS cert expires in <7d: {{ $labels.name }}"
             description: "Certificate {{ $labels.name }} in {{ $labels.namespace }} expires in {{ $value | humanizeDuration }} — service will break."
+            action: "kubectl describe certificate {{ $labels.name }} -n {{ $labels.namespace }}; check the Issuer + cert-manager logs; force renewal if stuck."
 
     # ── TICKET ──
     - name: cert-manager-ticket
@@ -39,6 +40,7 @@ spec:
             dashboard_url: "/d/cert-manager"
             summary: "TLS cert expires in <30d: {{ $labels.name }}"
             description: "Renewal should happen automatically — verify cert-manager is healthy."
+            action: "Renewal is automatic — verify cert-manager pods healthy + the (Cluster)Issuer is Ready."
 
         - alert: CertManagerDown
           expr: up{job="cert-manager"} == 0
@@ -51,3 +53,4 @@ spec:
             dashboard_url: "/d/cert-manager"
             summary: "cert-manager controller down"
             description: "Unreachable >5min — certificate renewals + new issuance blocked."
+            action: "kubectl -n cert-manager rollout restart deploy/cert-manager; check logs + webhook availability."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/operators.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/operators.yaml
@@ -22,6 +22,7 @@ spec:
             dashboard_url: "/d/argocd-overview"
             summary: "Sealed-Secrets controller down"
             description: "New SealedSecrets cannot be decrypted while the controller is down — deployments referencing fresh secrets will stall."
+            action: "kubectl -n sealed-secrets rollout restart deploy/sealed-secrets-controller; verify its decrypt key is present."
 
         - alert: CloudNativePGOperatorDown
           expr: up{job="cloudnative-pg-operator"} == 0
@@ -34,3 +35,4 @@ spec:
             dashboard_url: "/d/argocd-overview"
             summary: "CloudNativePG operator down"
             description: "PostgreSQL cluster management blocked (failover/scaling/backup orchestration) — running DBs keep serving."
+            action: "kubectl -n cnpg-system rollout restart deploy/cnpg-controller-manager; running DBs keep serving meanwhile."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/csi.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/csi.yaml
@@ -24,6 +24,7 @@ spec:
             dashboard_url: "/d/ceph-cluster"
             summary: "PVC {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} <10% free ({{ $value | humanizePercentage }})"
             description: "Disk nearly full — app may fail / data loss. Expand the PVC now."
+            action: "Expand the PVC (edit spec.resources.requests.storage — Ceph RBD online-grows), or free space inside the volume."
 
     # ── TICKET ──
     - name: csi-ticket
@@ -56,6 +57,7 @@ spec:
             dashboard_url: "/d/ceph-cluster"
             summary: "Ceph CSI provisioner {{ $labels.deployment }} has 0 replicas"
             description: "PVC creation/deletion blocked cluster-wide while provisioner is down."
+            action: "kubectl -n rook-ceph rollout restart deploy/csi-rbdplugin-provisioner; check provisioner + rook-ceph-operator logs."
 
         - alert: ReleasedPVsAccumulating
           expr: sum(kube_persistentvolume_status_phase{phase="Released"}) > 15
@@ -68,6 +70,7 @@ spec:
             dashboard_url: "/d/ceph-cluster"
             summary: "{{ $value }} Released PVs — CSI cleanup not keeping up"
             description: "Released PVs accumulate when CSI deletion sticks on omap-locks. Hourly cleanup CronJob should handle it."
+            action: "Check the hourly released-PV cleanup CronJob; manually 'kubectl get pv | grep Released' and delete stale ones after verifying data."
 
         - alert: CephOSDFlapping
           expr: changes(ceph_osd_up[10m]) > 2
@@ -80,3 +83,4 @@ spec:
             dashboard_url: "/d/ceph-cluster"
             summary: "Ceph OSD {{ $labels.ceph_daemon }} flapping (>2 state changes in 10min)"
             description: "OSD bouncing up/down — investigate disk health, network, or memory pressure."
+            action: "Toolbox: 'ceph osd df' for the daemon; check its disk SMART + node memory/network pressure."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/rook-ceph.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/rook-ceph.yaml
@@ -24,6 +24,7 @@ spec:
             dashboard_url: "/d/ceph-cluster"
             summary: "Ceph cluster HEALTH_ERR"
             description: "Rook-Ceph reports HEALTH_ERR — data integrity at risk."
+            action: "Toolbox: 'ceph health detail' → root cause; often full OSD or inconsistent PG ('ceph pg repair <id>')."
 
         - alert: CephQuorumLost
           expr: (ceph_osd_up + ceph_osd_in) / (ceph_osd_up + ceph_osd_down) < 0.5
@@ -35,6 +36,7 @@ spec:
             dashboard_url: "/d/ceph-cluster"
             summary: "Ceph lost quorum — majority of OSDs down"
             description: "More than 50% of OSDs down — DATA LOSS RISK, storage unavailable."
+            action: "kubectl -n rook-ceph get pod -l app=rook-ceph-osd; check node/disk of down OSDs; do NOT restart all OSDs at once."
 
     # ── TICKET ──
     - name: ceph-ticket
@@ -51,6 +53,7 @@ spec:
             dashboard_url: "/d/ceph-cluster"
             summary: "Ceph OSD {{ $labels.ceph_daemon }} down"
             description: "OSD down >10min — replication degraded (replica=2, msa2 still holds copies)."
+            action: "kubectl -n rook-ceph logs -l app=rook-ceph-osd; check host SSD SMART (smartctl); reschedule OSD pod if node-local."
 
         - alert: CephPGsNotActive
           # Targeted replacement for the dropped (noisy) blanket HEALTH_WARN: fires ONLY when
@@ -67,6 +70,7 @@ spec:
             dashboard_url: "/d/ceph-cluster"
             summary: "Ceph {{ $value }} PGs not active for 15m — data availability degraded"
             description: "PGs stuck inactive/peering — clients on them block (slow-ops cascade → RGW/CNPG timeouts). Check 'ceph pg dump_stuck inactive' + cross-node OSD heartbeats / Cilium NodeEncryption."
+            action: "Toolbox: 'ceph pg dump_stuck inactive'; check cross-node OSD heartbeats + Cilium NodeEncryption (encrypt-node deadlock 2026-05-24)."
 
         - alert: CephOSDNearFull
           expr: ceph_osd_stat_bytes_used / ceph_osd_stat_bytes > 0.75
@@ -79,6 +83,7 @@ spec:
             dashboard_url: "/d/ceph-cluster"
             summary: "Ceph OSD {{ $labels.ceph_daemon }} >75% full"
             description: "OSD at {{ $value | humanizePercentage }} — add capacity before it blocks writes."
+            action: "Toolbox: 'ceph osd df'; 'ceph osd reweight-by-utilization' if imbalanced, else add capacity."
 
         - alert: RookCephOperatorDown
           expr: up{job="rook-ceph-operator"} == 0
@@ -91,6 +96,7 @@ spec:
             dashboard_url: "/d/ceph-cluster"
             summary: "Rook-Ceph operator down"
             description: "Operator unreachable >5min — Ceph reconcile/management operations blocked."
+            action: "kubectl -n rook-ceph rollout restart deploy/rook-ceph-operator; check operator logs."
 
         - alert: RGWBucketQuotaWarning
           expr: |
@@ -105,3 +111,4 @@ spec:
             dashboard_url: "/d/ceph-cluster"
             summary: "RGW bucket {{ $labels.bucket }} >85% of quota"
             description: "Bucket fills soon — Velero/CNPG/Loki/Tempo writes will fail at 100%."
+            action: "Raise quota ('radosgw-admin quota set') or prune old objects (Velero/Loki/Tempo retention)."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/tenants/drova/apps.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/tenants/drova/apps.yaml
@@ -24,6 +24,8 @@ spec:
           annotations:
             summary: "Drova service down: {{ $labels.deployment }}"
             description: "0 ready replicas for {{ $labels.deployment }} >2min."
+            dashboard_url: "https://grafana.timourhomelab.org/d/drova-service-detail?var-service={{ $labels.deployment }}"
+            action: "kubectl -n drova get pod -l app={{ $labels.deployment }} + logs; check deps (Kafka/CNPG/gRPC upstream)."
 
         - alert: DrovaPodCrashLooping
           expr: rate(kube_pod_container_status_restarts_total{namespace="drova",container=~"api-gateway|user-service|trip-service|driver-service|chat-service|payment-service"}[5m]) * 60 > 0.5
@@ -37,3 +39,4 @@ spec:
             summary: "Drova {{ $labels.container }} crash-looping"
             description: "Container {{ $labels.container }} in {{ $labels.pod }} restarting >0.5/min"
             dashboard_url: "https://grafana.timourhomelab.org/d/drova-service-detail?var-service={{ $labels.container }}"
+            action: "kubectl logs -n drova -l app={{ $labels.container }} --previous; check config/deps; recent canary deploy?"

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/tenants/drova/kafka.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/tenants/drova/kafka.yaml
@@ -28,3 +28,4 @@ spec:
             summary: "Drova {{ $labels.service_name }} failing Kafka event processing"
             description: "{{ $labels.service_name }} has Kafka publish/consume errors (messaging_*{status=\"error\"}) sustained >10min — events route to drova.retry.* or are dropped. Check the consumer/producer handler."
             dashboard_url: "https://grafana.timourhomelab.org/d/drova-overview"
+            action: "kubectl logs -n drova -l app={{ $labels.service_name }} | grep -i kafka; check the consume/publish handler + the drova.retry.* topics."


### PR DESCRIPTION
Closes the actionability gap in the alert system — the notification template already renders an *Action* slot, but only 16/286 alerts populated it.

- **`action:` on 114 operational alerts** (~96% of operational coverage): every alert now carries a concrete first-step remediation (kubectl/talosctl/ceph/etc.), not filler.
- **Label-templated, dynamic**: actions use `{{ $labels.cluster/namespace/node/pod/device/... }}` → Prometheus renders them at eval time, so the firing alert shows e.g. `kubectl cnpg status drova-postgres -n drova` — copy-paste-ready for the firing instance.
- **+1 missing `dashboard_url`** (drova DrovaServiceDown) → dashboard_url now 100% on custom alerts.
- **Intentionally skipped**: the 20 SLO burn-rate alerts (the dashboard *is* the action) and runbook_url coverage (button has a fallback to the runbooks dir).

All 46 PrometheusRule files parse; 114 action templates brace-balanced.