### PR TITLE
ceph slow-ops alert

### DIFF
--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/rook-ceph.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/rook-ceph.yaml
@@ -112,3 +112,19 @@ spec:
             summary: "RGW bucket {{ $labels.bucket }} >85% of quota"
             description: "Bucket fills soon — Velero/CNPG/Loki/Tempo writes will fail at 100%."
             action: "Raise quota ('radosgw-admin quota set') or prune old objects (Velero/Loki/Tempo retention)."
+
+        - alert: CephSlowOps
+          # Service-level signal for BlueStore slow-ops (HEALTH_WARN). Replaces the noisy
+          # upstream NodeDiskIOSaturation (disabled in values-prod) which false-fires on
+          # Ceph disks. Ticket-tier: slow-ops = degraded performance, not an outage.
+          expr: ceph_healthcheck_slow_ops > 0
+          for: 15m
+          labels:
+            severity: warning
+            component: storage
+            priority: P2
+          annotations:
+            dashboard_url: "/d/ceph-cluster"
+            summary: "Ceph BlueStore slow operations ({{ $value }})"
+            description: "Slow-ops sustained >15min — OSDs can't keep up (usually consumer-SSD write pressure, e.g. msa2 Crucial running 3 OSDs). Degraded, not failure."
+            action: "Toolbox: 'ceph health detail' (which OSDs) + 'ceph osd perf' (latency); check disk SMART + the heaviest write-load on that node."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/rook-ceph.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/rook-ceph.yaml
@@ -117,7 +117,7 @@ spec:
           # Service-level signal for BlueStore slow-ops (HEALTH_WARN). Replaces the noisy
           # upstream NodeDiskIOSaturation (disabled in values-prod) which false-fires on
           # Ceph disks. Ticket-tier: slow-ops = degraded performance, not an outage.
-          expr: ceph_healthcheck_slow_ops > 0
+          expr: ceph_health_detail{name="BLUESTORE_SLOW_OP_ALERT"} > 0
           for: 15m
           labels:
             severity: warning
@@ -125,6 +125,21 @@ spec:
             priority: P2
           annotations:
             dashboard_url: "/d/ceph-cluster"
-            summary: "Ceph BlueStore slow operations ({{ $value }})"
+            summary: "Ceph BlueStore slow operations on OSDs"
             description: "Slow-ops sustained >15min — OSDs can't keep up (usually consumer-SSD write pressure, e.g. msa2 Crucial running 3 OSDs). Degraded, not failure."
             action: "Toolbox: 'ceph health detail' (which OSDs) + 'ceph osd perf' (latency); check disk SMART + the heaviest write-load on that node."
+
+        - alert: CephMonClockSkew
+          # mon clock skew → quorum instability + cert/SVID/SA-token auth risk (same NTP root
+          # as TalosNodeClockSkew / SPIRE). Service-level via ceph_health_detail.
+          expr: ceph_health_detail{name="MON_CLOCK_SKEW"} > 0
+          for: 10m
+          labels:
+            severity: warning
+            component: storage
+            priority: P2
+          annotations:
+            dashboard_url: "/d/ceph-cluster"
+            summary: "Ceph mon clock skew detected"
+            description: "A Ceph mon's clock drifted — risks quorum instability + cert/token auth. Same NTP root cause as TalosNodeClockSkew."
+            action: "Toolbox: 'ceph time-sync-status'; check NTP on the Proxmox hosts + Talos nodes ('talosctl time')."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
@@ -174,6 +174,9 @@ defaultRules:
   disabled:
     AlertmanagerFailedToSendAlerts: true
     AlertmanagerClusterFailedToSendAlerts: true
+    # Noisy on a Ceph cluster — rbd/OSD disks are IO-busy by design (aqu-sq>10 false-fires).
+    # Replaced by the service-level CephSlowOps alert (base/alerts/storage/rook-ceph.yaml).
+    NodeDiskIOSaturation: true
   rules:
     alertmanager: true
     configReloaders: true


### PR DESCRIPTION
Closes the Ceph alerting gap: HEALTH_WARN was dropped as noise, leaving slow-ops only visible via the flappy upstream NodeDiskIOSaturation (which false-fires on Ceph disks — rbd/OSD are IO-busy by design).

- **Disabled upstream NodeDiskIOSaturation** (defaultRules) — wrong layer for a Ceph cluster, structural false-positive.
- **Added service-level CephSlowOps** (`ceph_healthcheck_slow_ops > 0`, 15m, ticket-tier) — the proper signal for the BlueStore slow-ops degradation. Verified the metric exists + is currently >0 (catches the live msa2-Crucial WARN).

Enterprise pattern: alert on what the service reports, not the raw disk-queue symptom. Lean (one good alert replaces a noisy one), ticket-tier (slow-ops = degraded, not outage).