### PR TITLE
ceph clock drift tolerance

### DIFF
--- a/kubernetes/infrastructure/storage/rook-ceph/base/cluster.yaml
+++ b/kubernetes/infrastructure/storage/rook-ceph/base/cluster.yaml
@@ -47,6 +47,7 @@ spec:
       osd_heartbeat_grace: "120"          # Default: 20s, increased for VM I/O latency
       osd_heartbeat_interval: "15"        # Default: 6s
       mon_osd_down_out_interval: "600"    # Wait 10 min before marking OSD out
+      mon_clock_drift_allowed: "0.1"      # Default: 0.05s — homelab NTP jitter (Proxmox, no PTP)
 
       # VM/Proxmox BlueStore tuning (prevents SLOW_OPS warnings)
       # CRITICAL: Aggressive VM tuning for Proxmox shared storage


### PR DESCRIPTION
mon_clock_drift_allowed 0.05→0.1s — homelab NTP jitter (Proxmox, no PTP) cleared MON_CLOCK_SKEW WARN. Was set imperatively, now GitOps-persistent.