### PR TITLE
vendor sealed-secrets chart

### DIFF
--- a/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/.helmignore
+++ b/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/Chart.yaml
+++ b/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/Chart.yaml
@@ -1,0 +1,19 @@
+annotations:
+  category: DeveloperTools
+apiVersion: v2
+appVersion: 0.35.0
+description: Helm chart for the sealed-secrets controller.
+home: https://github.com/bitnami-labs/sealed-secrets
+icon: https://bitnami.com/assets/stacks/sealed-secrets/img/sealed-secrets-stack-220x234.png
+keywords:
+- secrets
+- sealed-secrets
+kubeVersion: '>=1.16.0-0'
+maintainers:
+- name: Bitnami
+  url: https://github.com/bitnami-labs/sealed-secrets
+name: sealed-secrets
+sources:
+- https://github.com/bitnami-labs/sealed-secrets
+type: application
+version: 2.18.1

--- a/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/README.md
+++ b/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/README.md
@@ -1,0 +1,313 @@
+# Sealed Secrets
+
+Sealed Secrets are "one-way" encrypted K8s Secrets that can be created by anyone, but can only be decrypted by the controller running in the target cluster recovering the original object.
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [TL;DR](#tldr)
+- [Introduction](#introduction)
+- [Prerequisites](#prerequisites)
+- [Installing the Chart](#installing-the-chart)
+- [Uninstalling the Chart](#uninstalling-the-chart)
+- [Parameters](#parameters)
+  - [Common parameters](#common-parameters)
+  - [Sealed Secrets Parameters](#sealed-secrets-parameters)
+  - [Traffic Exposure Parameters](#traffic-exposure-parameters)
+  - [Other Parameters](#other-parameters)
+  - [Metrics parameters](#metrics-parameters)
+- [Using kubeseal](#using-kubeseal)
+- [Configuration and installation details](#configuration-and-installation-details)
+- [Troubleshooting](#troubleshooting)
+- [Upgrading](#upgrading)
+  - [To 2.0.0](#to-200)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto-update -->
+
+## TL;DR
+
+```console
+$ helm repo add sealed-secrets https://bitnami-labs.github.io/sealed-secrets
+$ helm install my-release sealed-secrets/sealed-secrets
+```
+
+## Introduction
+
+Bitnami charts for Helm are carefully engineered, actively maintained and are the quickest and easiest way to deploy containers on a Kubernetes cluster that are ready to handle production workloads.
+
+This chart bootstraps a [Sealed Secret Controller](https://github.com/bitnami-labs/sealed-secrets) Deployment in [Kubernetes](http://kubernetes.io) using the [Helm](https://helm.sh) package manager.
+
+Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for the deployment and management of Helm Charts in clusters.
+
+## Prerequisites
+
+- Kubernetes 1.16+
+- Helm 3.1.0
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+helm install my-release sealed-secrets/sealed-secrets
+```
+
+The command deploys the Sealed Secrets controller on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Parameters
+
+### Common parameters
+
+| Name                | Description                                             | Value |
+| ------------------- | ------------------------------------------------------- | ----- |
+| `kubeVersion`       | Override Kubernetes version                             | `""`  |
+| `nameOverride`      | String to partially override sealed-secrets.fullname    | `""`  |
+| `fullnameOverride`  | String to fully override sealed-secrets.fullname        | `""`  |
+| `namespace`         | Namespace where to deploy the Sealed Secrets controller | `""`  |
+| `extraDeploy`       | Array of extra objects to deploy with the release       | `[]`  |
+| `commonAnnotations` | Annotations to add to all deployed resources            | `{}`  |
+| `commonLabels`      | Labels to add to all deployed resources                 | `{}`  |
+
+### Sealed Secrets Parameters
+
+| Name                                              | Description                                                                                                        | Value                               |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ----------------------------------- |
+| `image.registry`                                  | Sealed Secrets image registry                                                                                      | `docker.io`                         |
+| `image.repository`                                | Sealed Secrets image repository                                                                                    | `bitnami/sealed-secrets-controller` |
+| `image.tag`                                       | Sealed Secrets image tag (immutable tags are recommended)                                                          | `0.35.0`                            |
+| `image.pullPolicy`                                | Sealed Secrets image pull policy                                                                                   | `IfNotPresent`                      |
+| `image.pullSecrets`                               | Sealed Secrets image pull secrets                                                                                  | `[]`                                |
+| `revisionHistoryLimit`                            | Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)              | `""`                                |
+| `createController`                                | Specifies whether the Sealed Secrets controller should be created                                                  | `true`                              |
+| `secretName`                                      | The name of an existing TLS secret containing the key used to encrypt secrets                                      | `sealed-secrets-key`                |
+| `updateStatus`                                    | Specifies whether the Sealed Secrets controller should update the status subresource                               | `true`                              |
+| `skipRecreate`                                    | Specifies whether the Sealed Secrets controller should skip recreating removed secrets                             | `false`                             |
+| `keyrenewperiod`                                  | Specifies key renewal period. Default 30 days                                                                      | `""`                                |
+| `keyttl`                                          | Specifies the certificate validity duration. Default 10 years.                                                     | `""`                                |
+| `keycutofftime`                                   | Specifies a date at which the controller should generate a new certificate. Useful in early key renewal scenarios. | `""`                                |
+| `rateLimit`                                       | Number of allowed sustained request per second for verify endpoint                                                 | `""`                                |
+| `rateLimitBurst`                                  | Number of requests allowed to exceed the rate limit per second for verify endpoint                                 | `""`                                |
+| `additionalNamespaces`                            | List of namespaces used to manage the Sealed Secrets                                                               | `[]`                                |
+| `privateKeyAnnotations`                           | Map of annotations to be set on the sealing keypairs                                                               | `{}`                                |
+| `privateKeyLabels`                                | Map of labels to be set on the sealing keypairs                                                                    | `{}`                                |
+| `logInfoStdout`                                   | Specifies whether the Sealed Secrets controller will log info to stdout                                            | `false`                             |
+| `logLevel`                                        | Specifies log level of controller (INFO,ERROR)                                                                     | `""`                                |
+| `logFormat`                                       | Specifies log format (text,json)                                                                                   | `""`                                |
+| `maxRetries`                                      | Number of maximum retries                                                                                          | `""`                                |
+| `watchForSecrets`                                 | Specifies whether the Sealed Secrets controller will watch for new secrets                                         | `false`                             |
+| `kubeClientQPS`                                   | Kubeclient QPS (negative value disables ratelimiting)                                                              | `""`                                |
+| `kubeClientBurst`                                 | Kubeclient Burst                                                                                                   | `""`                                |
+| `command`                                         | Override default container command                                                                                 | `[]`                                |
+| `args`                                            | Override default container args                                                                                    | `[]`                                |
+| `livenessProbe.enabled`                           | Enable livenessProbe on Sealed Secret containers                                                                   | `true`                              |
+| `livenessProbe.initialDelaySeconds`               | Initial delay seconds for livenessProbe                                                                            | `0`                                 |
+| `livenessProbe.periodSeconds`                     | Period seconds for livenessProbe                                                                                   | `10`                                |
+| `livenessProbe.timeoutSeconds`                    | Timeout seconds for livenessProbe                                                                                  | `1`                                 |
+| `livenessProbe.failureThreshold`                  | Failure threshold for livenessProbe                                                                                | `3`                                 |
+| `livenessProbe.successThreshold`                  | Success threshold for livenessProbe                                                                                | `1`                                 |
+| `readinessProbe.enabled`                          | Enable readinessProbe on Sealed Secret containers                                                                  | `true`                              |
+| `readinessProbe.initialDelaySeconds`              | Initial delay seconds for readinessProbe                                                                           | `0`                                 |
+| `readinessProbe.periodSeconds`                    | Period seconds for readinessProbe                                                                                  | `10`                                |
+| `readinessProbe.timeoutSeconds`                   | Timeout seconds for readinessProbe                                                                                 | `1`                                 |
+| `readinessProbe.failureThreshold`                 | Failure threshold for readinessProbe                                                                               | `3`                                 |
+| `readinessProbe.successThreshold`                 | Success threshold for readinessProbe                                                                               | `1`                                 |
+| `startupProbe.enabled`                            | Enable startupProbe on Sealed Secret containers                                                                    | `false`                             |
+| `startupProbe.initialDelaySeconds`                | Initial delay seconds for startupProbe                                                                             | `0`                                 |
+| `startupProbe.periodSeconds`                      | Period seconds for startupProbe                                                                                    | `10`                                |
+| `startupProbe.timeoutSeconds`                     | Timeout seconds for startupProbe                                                                                   | `1`                                 |
+| `startupProbe.failureThreshold`                   | Failure threshold for startupProbe                                                                                 | `3`                                 |
+| `startupProbe.successThreshold`                   | Success threshold for startupProbe                                                                                 | `1`                                 |
+| `customLivenessProbe`                             | Custom livenessProbe that overrides the default one                                                                | `{}`                                |
+| `customReadinessProbe`                            | Custom readinessProbe that overrides the default one                                                               | `{}`                                |
+| `customStartupProbe`                              | Custom startupProbe that overrides the default one                                                                 | `{}`                                |
+| `resources.limits`                                | The resources limits for the Sealed Secret containers                                                              | `{}`                                |
+| `resources.requests`                              | The requested resources for the Sealed Secret containers                                                           | `{}`                                |
+| `podSecurityContext.enabled`                      | Enabled Sealed Secret pods' Security Context                                                                       | `true`                              |
+| `podSecurityContext.fsGroup`                      | Set Sealed Secret pod's Security Context fsGroup                                                                   | `65534`                             |
+| `containerSecurityContext.enabled`                | Enabled Sealed Secret containers' Security Context                                                                 | `true`                              |
+| `containerSecurityContext.readOnlyRootFilesystem` | Whether the Sealed Secret container has a read-only root filesystem                                                | `true`                              |
+| `containerSecurityContext.runAsNonRoot`           | Indicates that the Sealed Secret container must run as a non-root user                                             | `true`                              |
+| `containerSecurityContext.runAsUser`              | Set Sealed Secret containers' Security Context runAsUser                                                           | `1001`                              |
+| `containerSecurityContext.capabilities`           | Adds and removes POSIX capabilities from running containers (see `values.yaml`)                                    |                                     |
+| `podLabels`                                       | Extra labels for Sealed Secret pods                                                                                | `{}`                                |
+| `podAnnotations`                                  | Annotations for Sealed Secret pods                                                                                 | `{}`                                |
+| `priorityClassName`                               | Sealed Secret pods' priorityClassName                                                                              | `""`                                |
+| `runtimeClassName`                                | Sealed Secret pods' runtimeClassName                                                                               | `""`                                |
+| `affinity`                                        | Affinity for Sealed Secret pods assignment                                                                         | `{}`                                |
+| `nodeSelector`                                    | Node labels for Sealed Secret pods assignment                                                                      | `{}`                                |
+| `tolerations`                                     | Tolerations for Sealed Secret pods assignment                                                                      | `[]`                                |
+| `additionalVolumes`                               | Extra Volumes for the Sealed Secrets Controller Deployment                                                         | `{}`                                |
+| `additionalVolumeMounts`                          | Extra volumeMounts for the Sealed Secrets Controller container                                                     | `{}`                                |
+| `hostNetwork`                                     | Sealed Secrets pods' hostNetwork                                                                                   | `false`                             |
+| `containerPorts.http`                             | Controller HTTP Port on the Host and Container                                                                     | `8080`                              |
+| `containerPorts.metrics`                          | Metrics HTTP Port on the Host and Container                                                                        | `8081`                              |
+| `hostPorts.http`                                  | Controller HTTP Port on the Host                                                                                   | `""`                                |
+| `hostPorts.metrics`                               | Metrics HTTP Port on the Host                                                                                      | `""`                                |
+| `dnsPolicy`                                       | Sealed Secrets pods' dnsPolicy                                                                                     | `""`                                |
+
+### Traffic Exposure Parameters
+
+| Name                               | Description                                                                                                                      | Value                    |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `service.type`                     | Sealed Secret service type                                                                                                       | `ClusterIP`              |
+| `service.loadBalancerClass`        | Sealed Secret service loadBalancerClass                                                                                          | `""`                     |
+| `service.port`                     | Sealed Secret service HTTP port                                                                                                  | `8080`                   |
+| `service.nodePort`                 | Node port for HTTP                                                                                                               | `""`                     |
+| `service.annotations`              | Additional custom annotations for Sealed Secret service                                                                          | `{}`                     |
+| `ingress.enabled`                  | Enable ingress record generation for Sealed Secret                                                                               | `false`                  |
+| `ingress.pathType`                 | Ingress path type                                                                                                                | `ImplementationSpecific` |
+| `ingress.apiVersion`               | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |
+| `ingress.ingressClassName`         | IngressClass that will be be used to implement the Ingress                                                                       | `""`                     |
+| `ingress.hostname`                 | Default host for the ingress record                                                                                              | `sealed-secrets.local`   |
+| `ingress.path`                     | Default path for the ingress record                                                                                              | `/v1/cert.pem`           |
+| `ingress.annotations`              | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                     |
+| `ingress.tls`                      | Enable TLS configuration for the host defined at `ingress.hostname` parameter                                                    | `false`                  |
+| `ingress.selfSigned`               | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                     | `false`                  |
+| `ingress.extraHosts`               | An array with additional hostname(s) to be covered with the ingress record                                                       | `[]`                     |
+| `ingress.extraPaths`               | An array with additional arbitrary paths that may need to be added to the ingress under the main host                            | `[]`                     |
+| `ingress.extraTls`                 | TLS configuration for additional hostname(s) to be covered with this ingress record                                              | `[]`                     |
+| `ingress.secrets`                  | Custom TLS certificates as secrets                                                                                               | `[]`                     |
+| `networkPolicy.enabled`            | Specifies whether a NetworkPolicy should be created                                                                              | `false`                  |
+| `networkPolicy.egress.enabled`     | Specifies wheter a egress is set in the NetworkPolicy                                                                            | `false`                  |
+| `networkPolicy.egress.kubeapiCidr` | Specifies the kubeapiCidr, which is the only egress allowed. If not set, kubeapiCidr will be found using Helm lookup             | `""`                     |
+| `networkPolicy.egress.kubeapiPort` | Specifies the kubeapiPort, which is the only egress allowed. If not set, kubeapiPort will be found using Helm lookup             | `""`                     |
+
+### Other Parameters
+
+| Name                           | Description                                                                                              | Value                                                                                    |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `serviceAccount.annotations`   | Annotations for Sealed Secret service account                                                            | `{}`                                                                                     |
+| `serviceAccount.create`        | Specifies whether a ServiceAccount should be created                                                     | `true`                                                                                   |
+| `serviceAccount.labels`        | Extra labels to be added to the ServiceAccount                                                           | `{}`                                                                                     |
+| `serviceAccount.name`          | The name of the ServiceAccount to use.                                                                   | `""`                                                                                     |
+| `rbac.create`                  | Specifies whether RBAC resources should be created                                                       | `true`                                                                                   |
+| `rbac.clusterRole`             | Specifies whether the Cluster Role resource should be created                                            | `true`                                                                                   |
+| `rbac.clusterRoleName`         | Specifies the name for the Cluster Role resource                                                         | `secrets-unsealer`                                                                       |
+| `rbac.namespacedRoles`         | Specifies whether the namespaced Roles should be created (in each of the specified additionalNamespaces) | `false`                                                                                  |
+| `rbac.namespacedRolesName`     | Specifies the name for the namespaced Role resource                                                      | `secrets-unsealer`                                                                       |
+| `rbac.labels`                  | Extra labels to be added to RBAC resources                                                               | `{}`                                                                                     |
+| `rbac.pspEnabled`              | PodSecurityPolicy                                                                                        | `false`                                                                                  |
+| `rbac.serviceProxier.create`   | Specifies whether to create the "proxier" role, to allow external users to access the SealedSecret API   | `true`                                                                                   |
+| `rbac.serviceProxier.bind`     | Specifies whether to create a RoleBinding for the "proxier" role                                         | `true`                                                                                   |
+| `rbac.serviceProxier.subjects` | Specifies the RBAC subjects to grant the "proxier" role to, in the created RoleBinding                   | <pre><code>- apiGroup: rbac.authorization.k8s.io<br>  kind: Group<br>  name: system:authenticated</code></pre> |
+
+### Metrics parameters
+
+| Name                                       | Description                                                                            | Value       |
+| ------------------------------------------ | -------------------------------------------------------------------------------------- | ----------- |
+| `metrics.serviceMonitor.enabled`           | Specify if a ServiceMonitor will be deployed for Prometheus Operator                   | `false`     |
+| `metrics.serviceMonitor.namespace`         | Namespace where Prometheus Operator is running in                                      | `""`        |
+| `metrics.serviceMonitor.labels`            | Extra labels for the ServiceMonitor                                                    | `{}`        |
+| `metrics.serviceMonitor.annotations`       | Extra annotations for the ServiceMonitor                                               | `{}`        |
+| `metrics.serviceMonitor.interval`          | How frequently to scrape metrics                                                       | `""`        |
+| `metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                                | `""`        |
+| `metrics.serviceMonitor.honorLabels`       | Specify if ServiceMonitor endPoints will honor labels                                  | `true`      |
+| `metrics.serviceMonitor.metricRelabelings` | Specify additional relabeling of metrics                                               | `[]`        |
+| `metrics.serviceMonitor.relabelings`       | Specify general relabeling                                                             | `[]`        |
+| `metrics.dashboards.create`                | Specifies whether a ConfigMap with a Grafana dashboard configuration should be created | `false`     |
+| `metrics.dashboards.labels`                | Extra labels to be added to the Grafana dashboard ConfigMap                            | `{}`        |
+| `metrics.dashboards.annotations`           | Annotations to be added to the Grafana dashboard ConfigMap                             | `{}`        |
+| `metrics.dashboards.namespace`             | Namespace where Grafana dashboard ConfigMap is deployed                                | `""`        |
+| `metrics.service.type`                     | Sealed Secret Metrics service type                                                     | `ClusterIP` |
+| `metrics.service.loadBalancerClass`        | Sealed Secret Metrics service loadBalancerClass                                        | `""`        |
+| `metrics.service.port`                     | Sealed Secret service Metrics HTTP port                                                | `8081`      |
+| `metrics.service.nodePort`                 | Node port for HTTP                                                                     | `""`        |
+| `metrics.service.annotations`              | Additional custom annotations for Sealed Secret Metrics service                        | `{}`        |
+
+### PodDisruptionBudget Parameters
+
+| Name                 | Description                                                 | Value   |
+| -------------------- | ----------------------------------------------------------- | ------- |
+| `pdb.create`         | Specifies whether a PodDisruptionBudget should be created   | `false` |
+| `pdb.minAvailable`   | The minimum number of pods (non number to omit)             | `1`     |
+| `pdb.maxUnavailable` | The maximum number of unavailable pods (non number to omit) | `""`    |
+
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install my-release \
+  --set resources.requests.cpu=25m \
+    sealed-secrets/sealed-secrets
+```
+
+The above command sets the `resources.requests.cpu` parameter to `25m`.
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+helm install my-release -f values.yaml sealed-secrets/sealed-secrets
+```
+
+## Using kubeseal
+
+Install the kubeseal CLI by downloading the binary from [sealed-secrets/releases](https://github.com/bitnami-labs/sealed-secrets/releases).
+
+Fetch the public key by passing the release name and namespace:
+
+```bash
+kubeseal --fetch-cert \
+--controller-name=my-release \
+--controller-namespace=my-release-namespace \
+> pub-cert.pem
+```
+
+Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-labs/sealed-secrets#usage).
+
+NOTE: the helm chart by default installs the controller with the name `sealed-secrets`, while the `kubeseal` command line interface (CLI) tries to access the controller with the name `sealed-secrets-controller`. You can explicitly pass `--controller-name` to the CLI:
+
+```bash
+kubeseal --controller-name sealed-secrets <args>
+```
+
+Alternatively, you can override `fullnameOverride` on the helm chart install.
+
+## Configuration and installation details
+
+- In the case that **serviceAccount.create** is `false` and **rbac.create** is `true` it is expected for a ServiceAccount with the name **serviceAccount.name** to exist _in the same namespace as this chart_ before the installation.
+- If **rbac.create** is `true, by default *clusterRoles* are created. To switch to namespaced *Roles*:
+  1. set the required namespaces in **additionalNamespaces**
+  2. set **rbac.clusterRole** to `false`
+  3. set **rbac.namespacedRoles** to `true`
+- If **serviceAccount.create** is `true` there cannot be an existing service account with the name **serviceAccount.name**.
+- If a secret with name **secretName** does not exist _in the same namespace as this chart_, then on install one will be created. If a secret already exists with this name the keys inside will be used.
+- OpenShift: unset the runAsUser and fsGroup like this when installing in a custom namespace:
+
+```yaml
+podSecurityContext:
+  fsGroup:
+
+containerSecurityContext:
+  runAsUser:
+```
+
+## Troubleshooting
+
+Find more information about how to deal with common errors related to Bitnami's Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
+
+## Upgrading
+
+### To 2.0.0
+
+A major refactoring of the chart has been performed to adopt several common practices for Helm charts. Upgrades from previous chart versions should work, however, the values structure experienced several changes and you'll have to adapt your custom values/parameters so they're aligned with the new structure. For instance, these are a couple of examples:
+
+- `controller.create` renamed as `createController`.
+- `securityContext.*` parameters are deprecated in favor of `podSecurityContext.*`, and `containerSecurityContext.*` ones.
+- `image.repository` changed to `image.registry`/`image.repository`.
+- `ingress.hosts[0]` changed to `ingress.hostname`.
+
+Consult the [Parameters](#parameters) section to obtain more info about the available parameters.
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this new major version is no longer compatible with Helm v2.

--- a/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
+++ b/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
@@ -1,0 +1,168 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: sealedsecrets.bitnami.com
+spec:
+  group: bitnami.com
+  names:
+    kind: SealedSecret
+    listKind: SealedSecretList
+    plural: sealedsecrets
+    singular: sealedsecret
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[0].message
+      name: Status
+      type: string
+    - jsonPath: .status.conditions[0].status
+      name: Synced
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          SealedSecret is the K8s representation of a "sealed Secret" - a
+          regular k8s Secret that has been sealed (encrypted) using the
+          controller's key.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SealedSecretSpec is the specification of a SealedSecret.
+            properties:
+              data:
+                description: Data is deprecated and will be removed eventually. Use
+                  per-value EncryptedData instead.
+                format: byte
+                type: string
+              encryptedData:
+                additionalProperties:
+                  type: string
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              template:
+                description: |-
+                  Template defines the structure of the Secret that will be
+                  created from this sealed secret.
+                properties:
+                  data:
+                    additionalProperties:
+                      type: string
+                    description: Keys that should be templated using decrypted data.
+                    nullable: true
+                    type: object
+                  immutable:
+                    description: |-
+                      Immutable, if set to true, ensures that data stored in the Secret cannot
+                      be updated (only object metadata can be modified).
+                      If not set to true, the field can be modified at any time.
+                      Defaulted to nil.
+                    type: boolean
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+                    nullable: true
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      finalizers:
+                        items:
+                          type: string
+                        type: array
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  type:
+                    description: Used to facilitate programmatic handling of secret
+                      data.
+                    type: string
+                type: object
+            required:
+            - encryptedData
+            type: object
+          status:
+            description: SealedSecretStatus is the most recently observed status of
+              the SealedSecret.
+            properties:
+              conditions:
+                description: Represents the latest available observations of a sealed
+                  secret's current state.
+                items:
+                  description: SealedSecretCondition describes the state of a sealed
+                    secret at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: |-
+                        Status of the condition for a sealed secret.
+                        Valid values for "Synced": "True", "False", or "Unknown".
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition for a sealed secret.
+                        Valid value: "Synced"
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration reflects the generation most recently
+                  observed by the sealed-secrets controller.
+                format: int64
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/dashboards/sealed-secrets-controller.json
+++ b/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/dashboards/sealed-secrets-controller.json
@@ -1,0 +1,302 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            }
+        ]
+    },
+    "description": "Sealed Secrets Controller",
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "id": 3,
+    "iteration": 1585599163503,
+    "links": [
+        {
+            "icon": "external link",
+            "tags": [],
+            "title": "GitHub",
+            "tooltip": "View Project on GitHub",
+            "type": "link",
+            "url": "https://github.com/bitnami-labs/sealed-secrets"
+        }
+    ],
+    "panels": [
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "description": "Rate of requests to unseal a SealedSecret.\n\nThis can include non-obvious operations such as deleting a SealedSecret.",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 0
+            },
+            "hiddenSeries": false,
+            "id": 2,
+            "legend": {
+                "avg": true,
+                "current": false,
+                "max": true,
+                "min": true,
+                "show": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(rate(sealed_secrets_controller_unseal_requests_total{}[1m]))",
+                    "format": "time_series",
+                    "instant": false,
+                    "intervalFactor": 1,
+                    "legendFormat": "rps",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Unseal Request Rate/s",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "description": "Rate of errors when unsealing a SealedSecret. \n\nReason for error included as label value, eg:\n- unseal = cryptography issue (key/namespace) or RBAC\n- unmanaged = destination Secret wasn't created by SealedSecrets\n- update = potentially RBAC\n- status = potentially RBAC\n- fetch = potentially RBAC\n",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 0
+            },
+            "hiddenSeries": false,
+            "id": 3,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "hideEmpty": false,
+                "hideZero": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(rate(sealed_secrets_controller_unseal_errors_total{pod=~\"$pod\"}[1m])) by (reason)",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "{{ reason }}",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Unseal Error Rate/s",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        }
+    ],
+    "refresh": false,
+    "schemaVersion": 22,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [
+            {
+                "current": {
+                    "text": "prometheus",
+                    "value": "prometheus"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "datasource",
+                "options": [],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "type": "datasource"
+            },
+            {
+                "allValue": null,
+                "current": {
+                    "selected": false,
+                    "text": "All",
+                    "value": "$__all"
+                },
+                "datasource": "$datasource",
+                "definition": "label_values(kube_pod_info, pod)",
+                "hide": 0,
+                "includeAll": true,
+                "label": null,
+                "multi": false,
+                "name": "pod",
+                "options": [],
+                "query": "label_values(kube_pod_info, pod)",
+                "refresh": 1,
+                "regex": "/^sealed-secrets-controller.*$/",
+                "skipUrlSync": false,
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            }
+        ]
+    },
+    "time": {
+        "from": "now-1h",
+        "to": "now"
+    },
+    "timepicker": {
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "",
+    "title": "Sealed Secrets Controller",
+    "uid": "UuEtZCVWz",
+    "version": 2
+}

--- a/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/NOTES.txt
+++ b/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/NOTES.txt
@@ -1,0 +1,46 @@
+{{ if .Values.createController -}}
+
+** Please be patient while the chart is being deployed **
+
+You should now be able to create sealed secrets.
+
+1. Install the client-side tool (kubeseal) as explained in the docs below:
+
+    https://github.com/bitnami-labs/sealed-secrets#installation-from-source
+
+2. Create a sealed secret file running the command below:
+
+    kubectl create secret generic secret-name --dry-run=client --from-literal=foo=bar -o [json|yaml] | \
+    kubeseal \
+      --controller-name={{ include "sealed-secrets.fullname" . }} \
+      --controller-namespace={{ include "sealed-secrets.namespace" . }} \
+      --format yaml > mysealedsecret.[json|yaml]
+
+The file mysealedsecret.[json|yaml] is a commitable file.
+
+If you would rather not need access to the cluster to generate the sealed secret you can run:
+
+    kubeseal \
+      --controller-name={{ include "sealed-secrets.fullname" . }} \
+      --controller-namespace={{ include "sealed-secrets.namespace" . }} \
+      --fetch-cert > mycert.pem
+
+to retrieve the public cert used for encryption and store it locally. You can then run 'kubeseal --cert mycert.pem' instead to use the local cert e.g.
+
+    kubectl create secret generic secret-name --dry-run=client --from-literal=foo=bar -o [json|yaml] | \
+    kubeseal \
+      --controller-name={{ include "sealed-secrets.fullname" . }} \
+      --controller-namespace={{ include "sealed-secrets.namespace" . }} \
+      --format [json|yaml] --cert mycert.pem > mysealedsecret.[json|yaml]
+
+3. Apply the sealed secret
+
+    kubectl create -f mysealedsecret.[json|yaml]
+
+Running 'kubectl get secret secret-name -o [json|yaml]' will show the decrypted secret that was generated from the sealed secret.
+
+Both the SealedSecret and generated Secret must have the same name and namespace.
+{{- else }}
+Sealed Secrets controller not installed, You need to install controller before
+sealed secrets can be created.
+{{- end }}

--- a/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/_helpers.tpl
+++ b/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/_helpers.tpl
@@ -1,0 +1,203 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sealed-secrets.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "sealed-secrets.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Expand to the namespace sealed-secrets installs into.
+*/}}
+{{- define "sealed-secrets.namespace" -}}
+{{- default .Release.Namespace .Values.namespace -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "sealed-secrets.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "sealed-secrets.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "sealed-secrets.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Kubernetes standard labels
+*/}}
+{{- define "sealed-secrets.labels" -}}
+app.kubernetes.io/name: {{ include "sealed-secrets.name" . }}
+helm.sh/chart: {{ include "sealed-secrets.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/part-of: sealed-secrets
+{{- end -}}
+
+{{/*
+Labels to use on deploy.spec.selector.matchLabels and svc.spec.selector
+*/}}
+{{- define "sealed-secrets.matchLabels" -}}
+app.kubernetes.io/name: {{ include "sealed-secrets.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Return true if cert-manager required annotations for TLS signed certificates are set in the Ingress annotations
+Ref: https://cert-manager.io/docs/usage/ingress/#supported-annotations
+*/}}
+{{- define "sealed-secrets.ingress.certManagerRequest" -}}
+{{ if or (hasKey . "cert-manager.io/cluster-issuer") (hasKey . "cert-manager.io/issuer") }}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "sealed-secrets.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "sealed-secrets.render" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}
+
+{{/*
+Return the target Kubernetes version
+*/}}
+{{- define "sealed-secrets.kubeVersion" -}}
+{{- if .Values.global }}
+    {{- if .Values.global.kubeVersion }}
+    {{- .Values.global.kubeVersion -}}
+    {{- else }}
+    {{- default .Capabilities.KubeVersion.Version .Values.kubeVersion -}}
+    {{- end -}}
+{{- else }}
+{{- default .Capabilities.KubeVersion.Version .Values.kubeVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "sealed-secrets.deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" (include "sealed-secrets.kubeVersion" .) -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "sealed-secrets.ingress.apiVersion" -}}
+{{- if .Values.ingress -}}
+{{- if .Values.ingress.apiVersion -}}
+{{- .Values.ingress.apiVersion -}}
+{{- else if semverCompare "<1.14-0" (include "sealed-secrets.kubeVersion" .) -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "<1.19-0" (include "sealed-secrets.kubeVersion" .) -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end }}
+{{- else if semverCompare "<1.14-0" (include "sealed-secrets.kubeVersion" .) -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "<1.19-0" (include "sealed-secrets.kubeVersion" .) -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for networkpolicy.
+*/}}
+{{- define "sealed-secrets.networkPolicy.apiVersion" -}}
+{{- if semverCompare "<1.7-0" (include "sealed-secrets.kubeVersion" .) -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}
+
+Usage:
+{{ include "sealed-secrets.backend" (dict "serviceName" "backendName" "servicePort" "backendPort" "context" $) }}
+
+Params:
+  - serviceName - String. Name of an existing service backend
+  - servicePort - String/Int. Port name (or number) of the service. It will be translated to different yaml depending if it is a string or an integer.
+  - context - Dict - Required. The context for the template evaluation.
+*/}}
+{{- define "sealed-secrets.backend" -}}
+{{- $apiVersion := (include "sealed-secrets.ingress.apiVersion" .context) -}}
+{{- if or (eq $apiVersion "extensions/v1beta1") (eq $apiVersion "networking.k8s.io/v1beta1") -}}
+serviceName: {{ .serviceName }}
+servicePort: {{ .servicePort }}
+{{- else -}}
+service:
+  name: {{ .serviceName }}
+  port:
+    {{- if typeIs "string" .servicePort }}
+    name: {{ .servicePort }}
+    {{- else if or (typeIs "int" .servicePort) (typeIs "float64" .servicePort) }}
+    number: {{ .servicePort | int }}
+    {{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Print "true" if the API pathType field is supported
+Usage:
+{{ include "sealed-secrets.supportsPathType" . }}
+*/}}
+{{- define "sealed-secrets.supportsPathType" -}}
+{{- if (semverCompare "<1.18-0" (include "sealed-secrets.kubeVersion" .)) -}}
+{{- print "false" -}}
+{{- else -}}
+{{- print "true" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns true if the ingressClassname field is supported
+Usage:
+{{ include "sealed-secrets.supportsIngressClassname" . }}
+*/}}
+{{- define "sealed-secrets.supportsIngressClassname" -}}
+{{- if semverCompare "<1.18-0" (include "sealed-secrets.kubeVersion" .) -}}
+{{- print "false" -}}
+{{- else -}}
+{{- print "true" -}}
+{{- end -}}
+{{- end -}}

--- a/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/cluster-role-binding.yaml
+++ b/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/cluster-role-binding.yaml
@@ -1,0 +1,26 @@
+{{ if and .Values.rbac.create (not .Values.rbac.namespacedRoles)}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "sealed-secrets.fullname" . }}
+  labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
+    {{- if .Values.rbac.labels }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.rbac.labels "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.rbac.clusterRoleName }}
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ include "sealed-secrets.serviceAccountName" . }}
+    namespace: {{ include "sealed-secrets.namespace" . }}
+{{ end }}

--- a/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/cluster-role.yaml
+++ b/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/cluster-role.yaml
@@ -1,0 +1,60 @@
+{{ if and (and .Values.rbac.create .Values.rbac.clusterRole) (not .Values.rbac.namespacedRoles) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.rbac.clusterRoleName }}
+  labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
+    {{- if .Values.rbac.labels }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.rbac.labels "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+rules:
+  - apiGroups:
+      - bitnami.com
+    resources:
+      - sealedsecrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - bitnami.com
+    resources:
+      - sealedsecrets/status
+    verbs:
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  {{- if .Values.additionalNamespaces }}
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    resourceNames:
+      {{- include "sealed-secrets.render" (dict "value" .Values.additionalNamespaces "context" $) | nindent 6 }}
+    verbs:
+      - get
+  {{- end }}
+{{ end }}

--- a/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/configmap-dashboards.yaml
+++ b/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/configmap-dashboards.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.metrics.dashboards.create }}
+{{- $namespace := .Values.metrics.dashboards.namespace | default $.Release.Namespace }}
+{{- range $path, $_ :=  .Files.Glob  "dashboards/*.json" }}
+{{- $filename := trimSuffix (ext $path) (base $path) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-%s" (include "sealed-secrets.fullname" $) $filename }}
+  namespace: {{ $namespace }}
+  labels: {{- include "sealed-secrets.labels" $ | nindent 4 }}
+    {{- if $.Values.metrics.dashboards.labels }}
+    {{- include "sealed-secrets.render" ( dict "value" $.Values.metrics.dashboards.labels "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if $.Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" $.Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if $.Values.metrics.dashboards.annotations }}
+    {{- include "sealed-secrets.render" ( dict "value" $.Values.metrics.dashboards.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if $.Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+data:
+  {{ base $path }}: |-
+{{ $.Files.Get $path | indent 4 }}
+---
+{{- end }}
+{{- end }}

--- a/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/deployment.yaml
+++ b/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/deployment.yaml
@@ -1,0 +1,237 @@
+{{- if .Values.createController }}
+apiVersion: {{ include "sealed-secrets.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ include "sealed-secrets.fullname" . }}
+  namespace: {{ include "sealed-secrets.namespace" . }}
+  labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+spec:
+  replicas: 1
+  {{- if .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
+  selector:
+    matchLabels: {{- include "sealed-secrets.matchLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- if .Values.podAnnotations }}
+      annotations: {{- toYaml .Values.podAnnotations | nindent 8 }}
+      {{- end }}
+      labels: {{- include "sealed-secrets.matchLabels" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity: {{- toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations: {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.runtimeClassName }}
+      runtimeClassName: {{ .Values.runtimeClassName | quote }}
+      {{- end }}
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "sealed-secrets.serviceAccountName" . }}
+      {{- if .Values.hostNetwork }}
+      hostNetwork: true
+      {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- end }}
+      containers:
+        - name: controller
+          command:
+          {{- if .Values.command }}
+            {{- include "sealed-secrets.render" (dict "value" .Values.command "context" $) | nindent 12 }}
+          {{- else }}
+            - controller
+          {{- end }}
+          args:
+          {{- if .Values.args }}
+            {{- include "sealed-secrets.render" (dict "value" .Values.args "context" $) | nindent 12 }}
+          {{- else }}
+            {{- if .Values.updateStatus }}
+            - --update-status
+            {{- end }}
+            {{- if .Values.skipRecreate }}
+            - --skip-recreate
+            {{- end }}
+            {{- if ne (.Values.keyrenewperiod | toString) "" }}
+            - --key-renew-period
+            - {{ .Values.keyrenewperiod | quote }}
+            {{- end }}
+            {{- if .Values.keyttl }}
+            - --key-ttl
+            - {{ .Values.keyttl | quote }}
+            {{- end }}
+            {{- if .Values.keycutofftime }}
+            - --key-cutoff-time
+            - {{ .Values.keycutofftime | quote }}
+            {{- end }}
+            {{- if .Values.rateLimit }}
+            - --rate-limit
+            - {{ .Values.rateLimit | quote }}
+            {{- end }}
+            {{- if .Values.rateLimitBurst }}
+            - --rate-limit-burst
+            - {{ .Values.rateLimitBurst | quote }}
+            {{- end }}
+            - --key-prefix
+            - {{ .Values.secretName | quote }}
+            {{- if .Values.additionalNamespaces }}
+            - --additional-namespaces
+            - {{ join "," .Values.additionalNamespaces | quote }}
+            {{- end }}
+            {{- if $.Values.privateKeyAnnotations }}
+            {{- $privatekeyAnnotations := ""}}
+            {{- range $k, $v := $.Values.privateKeyAnnotations }}
+              {{- if not (and $v (kindIs "string" $v)) }}
+                {{ fail "Annotation values have to be strings"}}
+              {{- end }}
+              {{- $privatekeyAnnotations = printf "%s=%s,%s" $k $v $privatekeyAnnotations}}
+            {{- end }}
+            - --privatekey-annotations
+            - {{ trimSuffix "," $privatekeyAnnotations | quote }}
+            {{- end }}
+            {{- if $.Values.privateKeyLabels }}
+            {{- $privateKeyLabels := ""}}
+            {{- range $k, $v := $.Values.privateKeyLabels }}
+              {{- if not (and $v (kindIs "string" $v)) }}
+                {{ fail "Label values have to be strings"}}
+              {{- end }}
+              {{- $privateKeyLabels = printf "%s=%s,%s" $k $v $privateKeyLabels}}
+            {{- end }}
+            - --privatekey-labels
+            - {{ trimSuffix "," $privateKeyLabels | quote }}
+            {{- end }}
+            {{- if .Values.logInfoStdout }}
+            - --log-info-stdout
+            {{- end }}
+            {{- if .Values.logLevel }}
+            - --log-level
+            - {{ .Values.logLevel }}
+            {{- end }}
+            {{- if .Values.logFormat }}
+            - --log-format
+            - {{ .Values.logFormat }}
+            {{- end }}
+            {{- if .Values.containerPorts.http }}
+            - --listen-addr
+            - {{ printf ":%s" (.Values.containerPorts.http | toString ) }}
+            {{- end }}
+            {{- if .Values.containerPorts.metrics }}
+            - --listen-metrics-addr
+            - {{ printf ":%s" (.Values.containerPorts.metrics | toString) }}
+            {{- end }}
+            {{- if .Values.maxRetries }}
+            - --max-unseal-retries
+            - {{ .Values.maxRetries | quote }}
+            {{- end }}
+            {{- if .Values.watchForSecrets }}
+            - --watch-for-secrets
+            {{- end }}
+            {{- if .Values.kubeClientQPS }}
+            - --kubeclient-qps
+            - {{ .Values.kubeClientQPS | quote }}
+            {{- end }}
+            {{- if .Values.kubeClientBurst }}
+            - --kubeclient-burst
+            - {{ .Values.kubeClientBurst | quote }}
+            {{- end }}
+          {{- end }}
+          image: {{ printf "%s/%s:%s" .Values.image.registry .Values.image.repository .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            {{- if (.Values.resources.limits).cpu }}
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+                  divisor: "1"
+            {{- end }}
+            {{- if (.Values.resources.limits).memory }}
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+                  divisor: "1"
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPorts.http | default "8080" }}
+              {{- if .Values.hostNetwork }}
+              hostPort: {{ .Values.containerPorts.http }}
+              {{- else if .Values.hostPorts.http }}
+              hostPort: {{ .Values.hostPorts.http }}
+              {{- end }}
+            - name: metrics
+              containerPort: {{ .Values.containerPorts.metrics | default "8081" }}
+              {{- if .Values.hostNetwork }}
+              hostPort: {{ .Values.containerPorts.metrics }}
+              {{- else if .Values.hostPorts.metrics }}
+              hostPort: {{ .Values.hostPorts.metrics }}
+              {{- end }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe: {{- include "sealed-secrets.render" (dict "value" (omit .Values.startupProbe "enabled") "context" $) | nindent 12 }}
+            tcpSocket:
+              port: http
+          {{- else if .Values.customStartupProbe }}
+          startupProbe: {{- include "sealed-secrets.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe: {{- include "sealed-secrets.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
+            httpGet:
+              path: /healthz
+              port: http
+          {{- else if .Values.customLivenessProbe }}
+          livenessProbe: {{- include "sealed-secrets.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe: {{- include "sealed-secrets.render" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 12 }}
+            httpGet:
+              path: /healthz
+              port: http
+          {{- else if .Values.customReadinessProbe }}
+          readinessProbe: {{- include "sealed-secrets.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.resources }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            {{- if .Values.additionalVolumeMounts }}
+              {{- toYaml .Values.additionalVolumeMounts | nindent 12 }}
+            {{- end }}
+            - mountPath: /tmp
+              name: tmp
+      volumes:
+      {{- if .Values.additionalVolumes }}
+        {{- toYaml .Values.additionalVolumes | nindent 8 }}
+      {{- end }}
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/extra-list.yaml
+++ b/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/extra-list.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "sealed-secrets.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/ingress.yaml
+++ b/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/ingress.yaml
@@ -1,0 +1,57 @@
+{{- if and .Values.createController .Values.ingress.enabled }}
+apiVersion: {{ include "sealed-secrets.ingress.apiVersion" . }}
+kind: Ingress
+metadata:
+  name: {{ include "sealed-secrets.fullname" . }}
+  namespace: {{ include "sealed-secrets.namespace" . }}
+  labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.ingress.annotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if and .Values.ingress.ingressClassName (eq "true" (include "sealed-secrets.supportsIngressClassname" .)) }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- end }}
+  rules:
+    {{- if .Values.ingress.hostname }}
+    - host: {{ .Values.ingress.hostname }}
+      http:
+        paths:
+          {{- if .Values.ingress.extraPaths }}
+          {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
+          {{- end }}
+          - path: {{ .Values.ingress.path }}
+            {{- if eq "true" (include "sealed-secrets.supportsPathType" .) }}
+            pathType: {{ .Values.ingress.pathType }}
+            {{- end }}
+            backend: {{- include "sealed-secrets.backend" (dict "serviceName" (include "sealed-secrets.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
+    {{- end }}
+    {{- range .Values.ingress.extraHosts }}
+    - host: {{ .name | quote }}
+      http:
+        paths:
+          - path: {{ default "/" .path }}
+            {{- if eq "true" (include "sealed-secrets.supportsPathType" $) }}
+            pathType: {{ default "ImplementationSpecific" .pathType }}
+            {{- end }}
+            backend: {{- include "sealed-secrets.backend" (dict "serviceName" (include "sealed-secrets.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
+    {{- end }}
+  {{- if or (and .Values.ingress.tls (or (include "sealed-secrets.ingress.certManagerRequest" .Values.ingress.annotations) .Values.ingress.selfSigned)) .Values.ingress.extraTls }}
+  tls:
+    {{- if and .Values.ingress.tls (or (include "sealed-secrets.ingress.certManagerRequest" .Values.ingress.annotations) .Values.ingress.selfSigned) }}
+    - hosts:
+        - {{ .Values.ingress.hostname | quote }}
+      secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
+    {{- end }}
+    {{- if .Values.ingress.extraTls }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.ingress.extraTls "context" $) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/networkpolicy.yaml
+++ b/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/networkpolicy.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: {{ include "sealed-secrets.networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: {{ include "sealed-secrets.fullname" . }}
+  namespace: {{ include "sealed-secrets.namespace" . }}
+  labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+spec:
+  podSelector:
+    matchLabels: {{- include "sealed-secrets.matchLabels" . | nindent 6 }}
+  ingress:
+    - ports:
+      - port: {{ .Values.service.port }}
+      - port: {{ .Values.metrics.service.port }}
+  {{- if .Values.networkPolicy.egress.enabled }}
+  egress:
+    - to:
+      {{- if not .Values.networkPolicy.egress.kubeapiCidr }}
+      {{- $kubernetesEndpoint := lookup "v1" "Endpoints" "default" "kubernetes" }}
+      {{- if $kubernetesEndpoint }}
+        {{- range $kubernetesAddress := (first $kubernetesEndpoint.subsets).addresses }}
+      - ipBlock:
+          cidr: {{ $kubernetesAddress.ip }}/32
+        {{- end}}      
+      ports:
+        {{- range $kubernetesPort := (first $kubernetesEndpoint.subsets).ports }}
+        - protocol: {{ $kubernetesPort.protocol }}
+          port: {{ $kubernetesPort.port }}
+        {{- end }}
+      {{- end}}
+      {{- else }}
+      - ipBlock:
+          cidr: {{ .Values.networkPolicy.egress.kubeapiCidr }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.egress.kubeapiPort }}
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/pdb.yaml
+++ b/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/pdb.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.pdb.create }}
+kind: PodDisruptionBudget
+apiVersion: policy/v1
+metadata:
+  name: {{ include "sealed-secrets.fullname" . }}
+  namespace: {{ include "sealed-secrets.namespace" . }}
+  labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if regexMatch "64$" (typeOf .Values.pdb.minAvailable) }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  {{- if regexMatch "64$" (typeOf .Values.pdb.maxUnavailable) }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels: {{- include "sealed-secrets.matchLabels" . | nindent 6 }}
+{{- end }}

--- a/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/psp-clusterrole.yaml
+++ b/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/psp-clusterrole.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.rbac.pspEnabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ printf "%s-psp" (include "sealed-secrets.fullname" .) }}
+  labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
+    {{- if .Values.rbac.labels }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.rbac.labels "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+rules:
+  - apiGroups: ['extensions']
+    resources: ['podsecuritypolicies']
+    verbs:     ['use']
+    resourceNames:
+      - {{ include "sealed-secrets.fullname" . }}
+{{- end }}

--- a/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/psp-clusterrolebinding.yaml
+++ b/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/psp-clusterrolebinding.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ printf "%s-psp" (include "sealed-secrets.fullname" .) }}
+  labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
+    {{- if .Values.rbac.labels }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.rbac.labels "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ printf "%s-psp" (include "sealed-secrets.fullname" .) }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "sealed-secrets.serviceAccountName" . }}
+    namespace: {{ include "sealed-secrets.namespace" . }}
+{{- end }}

--- a/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/psp.yaml
+++ b/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/psp.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "sealed-secrets.fullname" . }}
+  labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  allowedCapabilities: []
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+  {{- if not .Values.hostNetwork }}
+  hostNetwork: false
+  {{- end }}
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+{{- end }}

--- a/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/role-binding.yaml
+++ b/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/role-binding.yaml
@@ -1,0 +1,80 @@
+{{ if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ printf "%s-key-admin" (include "sealed-secrets.fullname" .) }}
+  namespace: {{ include "sealed-secrets.namespace" . }}
+  labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
+    {{- if .Values.rbac.labels }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.rbac.labels "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ printf "%s-key-admin" (include "sealed-secrets.fullname" .) }}
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ include "sealed-secrets.serviceAccountName" . }}
+    namespace: {{ include "sealed-secrets.namespace" . }}
+---
+{{ end }}
+{{ if and (and .Values.rbac.create .Values.rbac.serviceProxier.create) .Values.rbac.serviceProxier.bind }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ printf "%s-service-proxier" (include "sealed-secrets.fullname" .) }}
+  namespace: {{ include "sealed-secrets.namespace" . }}
+  labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
+    {{- if .Values.rbac.labels }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.rbac.labels "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ printf "%s-service-proxier" (include "sealed-secrets.fullname" .) }}
+subjects:
+  {{- include "sealed-secrets.render" (dict "value" .Values.rbac.serviceProxier.subjects "context" $) | nindent 2 }}
+---
+{{ end }}
+{{ if and (and .Values.rbac.create .Values.rbac.namespacedRoles) (not $.Values.rbac.clusterRole) }}
+  {{- range $additionalNamespace := $.Values.additionalNamespaces }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "sealed-secrets.fullname" $ }}
+  namespace: {{ $additionalNamespace }}
+  labels: {{- include "sealed-secrets.labels" $ | nindent 4 }}
+    {{- if $.Values.rbac.labels }}
+    {{- include "sealed-secrets.render" ( dict "value" $.Values.rbac.labels "context" $) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if $.Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $.Values.rbac.namespacedRolesName }}
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ include "sealed-secrets.serviceAccountName" $ }}
+    namespace: {{ include "sealed-secrets.namespace" $ }}
+---
+  {{ end }}
+{{ end }}

--- a/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/role.yaml
+++ b/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/role.yaml
@@ -1,0 +1,125 @@
+{{ if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ printf "%s-key-admin" (include "sealed-secrets.fullname" .) }}
+  namespace: {{ include "sealed-secrets.namespace" . }}
+  labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
+    {{- if .Values.rbac.labels }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.rbac.labels "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+rules:
+  - apiGroups:
+      - ""
+    resourceNames:
+      - {{ .Values.secretName }}
+    resources:
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - list
+---
+{{- end }}
+{{- if and .Values.rbac.create .Values.rbac.serviceProxier.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ printf "%s-service-proxier" (include "sealed-secrets.fullname" .) }}
+  namespace: {{ include "sealed-secrets.namespace" . }}
+  labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
+    {{- if .Values.rbac.labels }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.rbac.labels "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+rules:
+  - apiGroups:
+      - ""
+    resourceNames:
+      - {{ include "sealed-secrets.fullname" . }}
+    resources:
+      - services
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - 'http:{{ include "sealed-secrets.fullname" . }}:'
+      - 'http:{{ include "sealed-secrets.fullname" . }}:http'
+      - {{ include "sealed-secrets.fullname" . }}
+    resources:
+      - services/proxy
+    verbs:
+      - create
+      - get
+---
+{{- end }}
+{{ if and (and .Values.rbac.create .Values.rbac.namespacedRoles) (not $.Values.rbac.clusterRole) }}
+  {{- range $additionalNamespace := $.Values.additionalNamespaces }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $.Values.rbac.namespacedRolesName }}
+  namespace: {{ $additionalNamespace }}
+  labels: {{- include "sealed-secrets.labels" $ | nindent 4 }}
+    {{- if $.Values.rbac.labels }}
+    {{- include "sealed-secrets.render" ( dict "value" $.Values.rbac.labels "context" $) | nindent 4 }}
+    {{- end }}
+rules:
+  - apiGroups:
+      - bitnami.com
+    resources:
+      - sealedsecrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - bitnami.com
+    resources:
+      - sealedsecrets/status
+    verbs:
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    resourceNames:
+      {{- include "sealed-secrets.render" (dict "value" $.Values.additionalNamespaces "context" $) | nindent 6 }}
+    verbs:
+      - get
+---
+  {{- end }}
+{{ end }}

--- a/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/service-account.yaml
+++ b/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/service-account.yaml
@@ -1,0 +1,23 @@
+{{ if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "sealed-secrets.serviceAccountName" . }}
+  namespace: {{ include "sealed-secrets.namespace" . }}
+  {{- if or (.Values.commonAnnotations) (.Values.serviceAccount.annotations) }}
+  annotations: 
+    {{- if .Values.commonAnnotations }}
+    {{- toYaml .Values.commonAnnotations | nindent 4 }}
+    {{- end}}
+    {{- if .Values.serviceAccount.annotations }}
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+    {{- end}}
+  {{- end }}
+  labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
+    {{- if .Values.serviceAccount.labels }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.serviceAccount.labels "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+{{ end }}

--- a/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/service.yaml
+++ b/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/service.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.createController -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sealed-secrets.fullname" . }}
+  namespace: {{ include "sealed-secrets.namespace" . }}
+  {{- if or .Values.service.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.service.annotations }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
+    {{- if .Values.service.labels }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.service.labels "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- with .Values.service.loadBalancerClass }}
+  loadBalancerClass: {{ . }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePort)) }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- else if eq .Values.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+  selector: {{- include "sealed-secrets.matchLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sealed-secrets.fullname" . }}-metrics
+  namespace: {{ include "sealed-secrets.namespace" . }}
+  {{- if or .Values.metrics.service.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.metrics.service.annotations }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.metrics.service.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
+    {{- if .Values.metrics.service.labels }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.metrics.service.labels "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+    app.kubernetes.io/component: metrics
+spec:
+  type: {{ .Values.metrics.service.type }}
+  {{- with .Values.metrics.service.loadBalancerClass }}
+  loadBalancerClass: {{ . }}
+  {{- end }}
+  ports:
+    - name: metrics
+      port: {{ .Values.metrics.service.port }}
+      targetPort: metrics
+      {{- if and (or (eq .Values.metrics.service.type "NodePort") (eq .Values.metrics.service.type "LoadBalancer")) (not (empty .Values.metrics.service.nodePort)) }}
+      nodePort: {{ .Values.metrics.service.nodePort }}
+      {{- else if eq .Values.metrics.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+  selector: {{- include "sealed-secrets.matchLabels" . | nindent 4 }}
+{{- end }}

--- a/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/servicemonitor.yaml
+++ b/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/servicemonitor.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "sealed-secrets.fullname" . }}
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ include "sealed-secrets.namespace" . }}
+  {{- end }}
+  labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
+    {{- if .Values.metrics.serviceMonitor.labels }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.metrics.serviceMonitor.labels "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.metrics.serviceMonitor.annotations }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.metrics.serviceMonitor.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      {{- if .Values.metrics.serviceMonitor.honorLabels }}
+      honorLabels: {{ .Values.metrics.serviceMonitor.honorLabels }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{ toYaml .Values.metrics.serviceMonitor.metricRelabelings | nindent 8 }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.relabelings }}
+      relabelings: {{ toYaml .Values.metrics.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ include "sealed-secrets.namespace" . }}
+  selector:
+    matchLabels:
+      {{- include "sealed-secrets.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: metrics
+{{- end }}

--- a/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/tls-secret.yaml
+++ b/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/templates/tls-secret.yaml
@@ -1,0 +1,46 @@
+{{- if and .Values.createController .Values.ingress.enabled }}
+{{- if .Values.ingress.secrets }}
+{{- range .Values.ingress.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name }}
+  namespace: {{ include "sealed-secrets.namespace" $ | quote }}
+  labels: {{- include "sealed-secrets.labels" $ | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .certificate | b64enc }}
+  tls.key: {{ .key | b64enc }}
+---
+{{- end }}
+{{- end }}
+{{- if and .Values.ingress.tls .Values.ingress.selfSigned }}
+{{- $ca := genCA "sealed-secrets-ca" 365 }}
+{{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-tls" .Values.ingress.hostname }}
+  namespace: {{ include "sealed-secrets.namespace" . }}
+  labels: {{- include "sealed-secrets.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "sealed-secrets.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "sealed-secrets.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $cert.Cert | b64enc | quote }}
+  tls.key: {{ $cert.Key | b64enc | quote }}
+  ca.crt: {{ $ca.Cert | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/values.yaml
+++ b/kubernetes/infrastructure/secrets/sealed-secrets/base/charts/sealed-secrets-2.18.1/sealed-secrets/values.yaml
@@ -1,0 +1,554 @@
+## @section Common parameters
+
+## @param kubeVersion Override Kubernetes version
+##
+kubeVersion: ""
+## @param nameOverride String to partially override sealed-secrets.fullname
+##
+nameOverride: ""
+## @param fullnameOverride String to fully override sealed-secrets.fullname
+##
+fullnameOverride: ""
+## @param namespace Namespace where to deploy the Sealed Secrets controller
+##
+namespace: ""
+
+## @param extraDeploy [array] Array of extra objects to deploy with the release
+##
+extraDeploy: []
+## @param commonAnnotations [object] Annotations to add to all deployed resources
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+commonAnnotations: {}
+
+## @param commonLabels [object] Labels to add to all deployed resources
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+## 
+commonLabels: {}
+
+## @section Sealed Secrets Parameters
+
+## Sealed Secrets image
+## ref: https://hub.docker.com/r/bitnami/sealed-secrets-controller/tags
+## @param image.registry Sealed Secrets image registry
+## @param image.repository Sealed Secrets image repository
+## @param image.tag Sealed Secrets image tag (immutable tags are recommended)
+## @param image.pullPolicy Sealed Secrets image pull policy
+## @param image.pullSecrets [array]  Sealed Secrets image pull secrets
+##
+image:
+  registry: docker.io
+  repository: bitnami/sealed-secrets-controller
+  tag: 0.35.0
+  ## Specify a imagePullPolicy
+  ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## e.g:
+  ## pullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  pullSecrets: []
+## @param revisionHistoryLimit Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)
+## e.g:
+revisionHistoryLimit: ""
+## @param createController Specifies whether the Sealed Secrets controller should be created
+##
+createController: true
+## @param secretName The name of an existing TLS secret containing the key used to encrypt secrets
+##
+secretName: "sealed-secrets-key"
+## @param updateStatus Specifies whether the Sealed Secrets controller should update the status subresource
+##
+updateStatus: true
+## @param skipRecreate Specifies whether the Sealed Secrets controller should skip recreating removed secrets
+## Setting it to true allows to optionally restore backward compatibility in low priviledge
+## environments when old versions of the controller did not require watch permissions on secrets
+## for secret re-creation.
+##
+skipRecreate: false
+## @param keyrenewperiod Specifies key renewal period. Default 30 days
+## e.g
+## keyrenewperiod: "720h30m"
+## To disable use "0", with quotes!
+##
+keyrenewperiod: ""
+## @param keyttl Specifies the certificate validity duration. Default 10 years.
+## e.g for one year
+## keyttl: "8760h00m00s"
+##
+keyttl: ""
+## @param keycutofftime Specifies a date at which the controller should generate a new certificate. Useful in early key renewal scenarios.
+## Takes a date formated according to RFC1123. Can be obtained with the 'date -R' command on a unix system.
+## e.g 
+## keycutofftime: "Mon, 14 Oct 2024 21:45:30 +0200"
+##
+keycutofftime: ""
+## @param rateLimit Number of allowed sustained request per second for verify endpoint
+##
+rateLimit: ""
+## @param rateLimitBurst Number of requests allowed to exceed the rate limit per second for verify endpoint
+##
+rateLimitBurst: ""
+## @param additionalNamespaces List of namespaces used to manage the Sealed Secrets
+##
+additionalNamespaces: []
+## @param privateKeyAnnotations Map of annotations to be set on the sealing keypairs
+## 
+privateKeyAnnotations: {}
+## @param privateKeyLabels Map of labels to be set on the sealing keypairs
+## 
+privateKeyLabels: {}
+## @param logInfoStdout Specifies whether the Sealed Secrets controller will log info to stdout
+##
+logInfoStdout: false
+## @param logLevel Specifies log level of controller (INFO,ERROR)
+##
+logLevel: ""
+## @param logFormat Specifies log format (text,json)
+##
+logFormat: ""
+## @param maxRetries Number of maximum retries
+##
+maxRetries: ""
+## @param watchForSecrets Specifies whether the Sealed Secrets controller will watch for new secrets
+##
+watchForSecrets: false
+## @param kubeClientQPS Kubeclient QPS (negative value disables ratelimiting)
+##
+kubeClientQPS: ""
+## @param kubeClientBurst Kubeclient Burst
+##
+kubeClientBurst: ""
+## @param command Override default container command
+##
+command: []
+## @param args Override default container args
+##
+args: []
+## Configure extra options for Sealed Secret containers' liveness, readiness and startup probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+## @param livenessProbe.enabled Enable livenessProbe on Sealed Secret containers
+## @param livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+## @param livenessProbe.periodSeconds Period seconds for livenessProbe
+## @param livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+## @param livenessProbe.failureThreshold Failure threshold for livenessProbe
+## @param livenessProbe.successThreshold Success threshold for livenessProbe
+##
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  timeoutSeconds: 1
+  failureThreshold: 3
+  successThreshold: 1
+## @param readinessProbe.enabled Enable readinessProbe on Sealed Secret containers
+## @param readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+## @param readinessProbe.periodSeconds Period seconds for readinessProbe
+## @param readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+## @param readinessProbe.failureThreshold Failure threshold for readinessProbe
+## @param readinessProbe.successThreshold Success threshold for readinessProbe
+##
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  timeoutSeconds: 1
+  failureThreshold: 3
+  successThreshold: 1
+## @param startupProbe.enabled Enable startupProbe on Sealed Secret containers
+## @param startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+## @param startupProbe.periodSeconds Period seconds for startupProbe
+## @param startupProbe.timeoutSeconds Timeout seconds for startupProbe
+## @param startupProbe.failureThreshold Failure threshold for startupProbe
+## @param startupProbe.successThreshold Success threshold for startupProbe
+##
+startupProbe:
+  enabled: false
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  timeoutSeconds: 1
+  failureThreshold: 3
+  successThreshold: 1
+## @param customLivenessProbe Custom livenessProbe that overrides the default one
+##
+customLivenessProbe: {}
+## @param customReadinessProbe Custom readinessProbe that overrides the default one
+##
+customReadinessProbe: {}
+## @param customStartupProbe Custom startupProbe that overrides the default one
+##
+customStartupProbe: {}
+## Sealed Secret resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+## @param resources.limits [object] The resources limits for the Sealed Secret containers
+## @param resources.requests [object] The requested resources for the Sealed Secret containers
+##
+resources:
+  limits: {}
+  requests: {}
+## Configure Pods Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+## @param podSecurityContext.enabled Enabled Sealed Secret pods' Security Context
+## @param podSecurityContext.fsGroup Set Sealed Secret pod's Security Context fsGroup
+##
+podSecurityContext:
+  enabled: true
+  fsGroup: 65534
+## Configure Container Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+## @param containerSecurityContext.enabled Enabled Sealed Secret containers' Security Context
+## @param containerSecurityContext.readOnlyRootFilesystem Whether the Sealed Secret container has a read-only root filesystem
+## @param containerSecurityContext.runAsNonRoot Indicates that the Sealed Secret container must run as a non-root user
+## @param containerSecurityContext.runAsUser Set Sealed Secret containers' Security Context runAsUser
+## @extra containerSecurityContext.capabilities Adds and removes POSIX capabilities from running containers (see `values.yaml`)
+## @skip  containerSecurityContext.capabilities.drop
+##
+containerSecurityContext:
+  enabled: true
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1001
+  capabilities:
+    drop:
+      - ALL
+
+## @param podLabels [object] Extra labels for Sealed Secret pods
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+##
+podLabels: {}
+## @param podAnnotations [object] Annotations for Sealed Secret pods
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+## @param priorityClassName Sealed Secret pods' priorityClassName
+##
+priorityClassName: ""
+## @param runtimeClassName Sealed Secret pods' runtimeClassName
+##
+runtimeClassName: ""
+## @param affinity [object] Affinity for Sealed Secret pods assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+##
+affinity: {}
+## @param nodeSelector [object] Node labels for Sealed Secret pods assignment
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+## @param tolerations [array] Tolerations for Sealed Secret pods assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+## @param additionalVolumes [object] Extra Volumes for the Sealed Secrets Controller Deployment
+## ref: https://kubernetes.io/docs/concepts/storage/volumes/
+##
+additionalVolumes: []
+## @param additionalVolumeMounts [object] Extra volumeMounts for the Sealed Secrets Controller container
+## ref: https://kubernetes.io/docs/concepts/storage/volumes/
+##
+additionalVolumeMounts: []
+## @param hostNetwork Sealed Secrets pods' hostNetwork
+hostNetwork: false
+## Sealed Secrets controller ports to open
+## If hostNetwork true: the hostPort is set identical to the containerPort
+## @param containerPorts.http Controller HTTP Port on the Host and Container
+## @param containerPorts.metrics Metrics HTTP Port on the Host and Container
+##
+containerPorts:
+  http: 8080
+  metrics: 8081
+## Sealed Secrets controller ports to be exposed as hostPort
+## If hostNetwork is false, only the ports specified here will be exposed (or not if set to an empty string)
+## @param hostPorts.http Controller HTTP Port on the Host
+## @param hostPorts.metrics Metrics HTTP Port on the Host
+##
+hostPorts:
+  http: ""
+  metrics: ""
+
+## @param dnsPolicy Sealed Secrets pods' dnsPolicy
+dnsPolicy: ""
+## @section Traffic Exposure Parameters
+
+## Sealed Secret service parameters
+##
+service:
+  ## @param service.type Sealed Secret service type
+  ##
+  type: ClusterIP
+  ## @param service.loadBalancerClass Sealed Secret service loadBalancerClass
+  ##
+  loadBalancerClass: ""
+  ## @param service.port Sealed Secret service HTTP port
+  ##
+  port: 8080
+  ## @param service.nodePort Node port for HTTP
+  ## Specify the nodePort value for the LoadBalancer and NodePort service types
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+  ## NOTE: choose port between <30000-32767>
+  ##
+  nodePort: ""
+  ## @param service.annotations [object] Additional custom annotations for Sealed Secret service
+  ##
+  annotations: {}
+## Sealed Secret ingress parameters
+## ref: http://kubernetes.io/docs/user-guide/ingress/
+##
+ingress:
+  ## @param ingress.enabled Enable ingress record generation for Sealed Secret
+  ##
+  enabled: false
+  ## @param ingress.pathType Ingress path type
+  ##
+  pathType: ImplementationSpecific
+  ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
+  ##
+  apiVersion: ""
+  ## @param ingress.ingressClassName IngressClass that will be be used to implement the Ingress
+  ## This is supported in Kubernetes 1.18+ and required if you have more than one IngressClass marked as the default for your cluster.
+  ## ref: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/
+  ##
+  ingressClassName: ""
+  ## @param ingress.hostname Default host for the ingress record
+  ##
+  hostname: sealed-secrets.local
+  ## @param ingress.path Default path for the ingress record
+  ##
+  path: /v1/cert.pem
+  ## @param ingress.annotations [object] Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.
+  ## Use this parameter to set the required annotations for cert-manager, see
+  ## ref: https://cert-manager.io/docs/usage/ingress/#supported-annotations
+  ## e.g:
+  ## annotations:
+  ##   kubernetes.io/ingress.class: nginx
+  ##   cert-manager.io/cluster-issuer: cluster-issuer-name
+  ##
+  annotations: {}
+  ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+  ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
+  ## You can:
+  ##   - Use the `ingress.secrets` parameter to create this TLS secret
+  ##   - Relay on cert-manager to create it by setting the corresponding annotations
+  ##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
+  ##
+  tls: false
+  ## @param ingress.selfSigned Create a TLS secret for this ingress record using self-signed certificates generated by Helm
+  ##
+  selfSigned: false
+  ## @param ingress.extraHosts [array] An array with additional hostname(s) to be covered with the ingress record
+  ## e.g:
+  ## extraHosts:
+  ##   - name: sealed-secrets.local
+  ##     path: /
+  ##
+  extraHosts: []
+  ## @param ingress.extraPaths [array] An array with additional arbitrary paths that may need to be added to the ingress under the main host
+  ## e.g:
+  ## extraPaths:
+  ## - path: /*
+  ##   backend:
+  ##     serviceName: ssl-redirect
+  ##     servicePort: use-annotation
+  ##
+  extraPaths: []
+  ## @param ingress.extraTls [array] TLS configuration for additional hostname(s) to be covered with this ingress record
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ## e.g:
+  ## extraTls:
+  ## - hosts:
+  ##     - sealed-secrets.local
+  ##   secretName: sealed-secrets.local-tls
+  ##
+  extraTls: []
+  ## @param ingress.secrets [array] Custom TLS certificates as secrets
+  ## NOTE: 'key' and 'certificate' are expected in PEM format
+  ## NOTE: 'name' should line up with a 'secretName' set further up
+  ## If it is not set and you're using cert-manager, this is unneeded, as it will create a secret for you with valid certificates
+  ## If it is not set and you're NOT using cert-manager either, self-signed certificates will be created valid for 365 days
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  ## e.g:
+  ## secrets:
+  ##   - name: sealed-secrets.local-tls
+  ##     key: |-
+  ##       -----BEGIN RSA PRIVATE KEY-----
+  ##       ...
+  ##       -----END RSA PRIVATE KEY-----
+  ##     certificate: |-
+  ##       -----BEGIN CERTIFICATE-----
+  ##       ...
+  ##       -----END CERTIFICATE-----
+  ##
+  secrets: []
+## Network policies
+## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+##
+networkPolicy:
+  ## @param networkPolicy.enabled Specifies whether a NetworkPolicy should be created
+  ##
+  enabled: false
+  ## NetworkPolicy Egress configuration
+  ##
+  egress:
+    ## @param networkPolicy.egress.enabled Specifies wheter a egress is set in the NetworkPolicy
+    ##
+    enabled: false
+    ## @param networkPolicy.egress.kubeapiCidr Specifies the kubeapiCidr, which is the only egress allowed. If not set, kubeapiCidr will be found using Helm lookup
+    ##
+    kubeapiCidr: ""
+    ## @param networkPolicy.egress.kubeapiPort Specifies the kubeapiPort, which is the only egress allowed. If not set, kubeapiPort will be found using Helm lookup
+    ##
+    kubeapiPort: ""
+
+## @section Other Parameters
+
+## ServiceAccount configuration
+##
+serviceAccount:
+  ## @param serviceAccount.annotations [object] Annotations for Sealed Secret service account
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  annotations: {}
+  ## @param serviceAccount.create Specifies whether a ServiceAccount should be created
+  ##
+  create: true
+  ## @param serviceAccount.labels Extra labels to be added to the ServiceAccount
+  ##
+  labels: {}
+  ## @param serviceAccount.name The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the sealed-secrets.fullname template
+  ##
+  name: ""
+## RBAC configuration
+##
+rbac:
+  ## @param rbac.create Specifies whether RBAC resources should be created
+  ##
+  create: true
+  ## @param rbac.clusterRole Specifies whether the Cluster Role resource should be created
+  ##
+  clusterRole: true
+  ## @param rbac.clusterRoleName Specifies the name for the Cluster Role resource
+  ##
+  clusterRoleName: "secrets-unsealer"
+  ## @param rbac.namespacedRoles Specifies whether the namespaced Roles should be created (in each of the specified additionalNamespaces)
+  ##
+  namespacedRoles: false
+  ## @param rbac.namespacedRolesName Specifies the name for the namespaced Role resource
+  ##
+  namespacedRolesName: "secrets-unsealer"
+  ## @param rbac.labels Extra labels to be added to RBAC resources
+  ##
+  labels: {}
+  ## @param rbac.pspEnabled PodSecurityPolicy
+  ##
+  pspEnabled: false
+  ## "Proxier" RBAC Role configuration
+  ##
+  serviceProxier:
+    ## @param rbac.serviceProxier.create Specifies whether to create the "proxier" role, to allow external users to access the SealedSecret API
+    ##
+    create: true
+    ## @param rbac.serviceProxier.bind Specifies whether to create a RoleBinding for the "proxier" role
+    ##
+    bind: true
+    ## @param rbac.serviceProxier.subjects Specifies the RBAC subjects to grant the "proxier" role to, in the created RoleBinding
+    ## It is best to change this to something narrower, as the default binding gives `system:authenticated` access, which is very broad
+    ##
+    subjects: |
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:authenticated
+
+## @section Metrics parameters
+
+metrics:
+  ## Prometheus Operator ServiceMonitor configuration
+  ##
+  serviceMonitor:
+    ## @param metrics.serviceMonitor.enabled Specify if a ServiceMonitor will be deployed for Prometheus Operator
+    ##
+    enabled: false
+    ## @param metrics.serviceMonitor.namespace Namespace where Prometheus Operator is running in
+    ##
+    namespace: ""
+    ## @param metrics.serviceMonitor.labels Extra labels for the ServiceMonitor
+    ##
+    labels: {}
+    ## @param metrics.serviceMonitor.annotations Extra annotations for the ServiceMonitor
+    ##
+    annotations: {}
+    ## @param metrics.serviceMonitor.interval How frequently to scrape metrics
+    ## e.g:
+    ## interval: 10s
+    ##
+    interval: ""
+    ## @param metrics.serviceMonitor.scrapeTimeout Timeout after which the scrape is ended
+    ## e.g:
+    ## scrapeTimeout: 10s
+    ##
+    scrapeTimeout: ""
+    ## @param metrics.serviceMonitor.honorLabels Specify if ServiceMonitor endPoints will honor labels
+    ##
+    honorLabels: true
+    ## @param metrics.serviceMonitor.metricRelabelings [array] Specify additional relabeling of metrics
+    ##
+    metricRelabelings: []
+    ## @param metrics.serviceMonitor.relabelings [array] Specify general relabeling
+    ##
+    relabelings: []
+  ## Grafana dashboards configuration
+  ##
+  dashboards:
+    ## @param metrics.dashboards.create Specifies whether a ConfigMap with a Grafana dashboard configuration should be created
+    ## ref https://github.com/helm/charts/tree/master/stable/grafana#configuration
+    ##
+    create: false
+    ## @param metrics.dashboards.labels Extra labels to be added to the Grafana dashboard ConfigMap
+    ##
+    labels: {}
+    ## @param metrics.dashboards.annotations Annotations to be added to the Grafana dashboard ConfigMap
+    ##
+    annotations: {}
+    ## @param metrics.dashboards.namespace Namespace where Grafana dashboard ConfigMap is deployed
+    ##
+    namespace: ""
+
+  ## Sealed Secret Metrics service parameters
+  ##
+  service:
+    ## @param metrics.service.type Sealed Secret Metrics service type
+    ##
+    type: ClusterIP
+    ## @param metrics.service.loadBalancerClass Sealed Secret Metrics service loadBalancerClass
+    ##
+    loadBalancerClass: ""
+    ## @param metrics.service.port Sealed Secret service Metrics HTTP port
+    ##
+    port: 8081
+    ## @param metrics.service.nodePort Node port for HTTP
+    ## Specify the nodePort value for the LoadBalancer and NodePort service types
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+    ## NOTE: choose port between <30000-32767>
+    ##
+    nodePort: ""
+    ## @param metrics.service.annotations [object] Additional custom annotations for Sealed Secret Metrics service
+    ##
+    annotations: {}
+
+## @section PodDisruptionBudget Parameters
+
+pdb:
+  ## @param pdb.create Specifies whether a PodDisruptionBudget should be created
+  ##
+  create: false
+  ## @param pdb.minAvailable The minimum number of pods (non number to omit)
+  ##
+  minAvailable: 1
+  ## @param pdb.maxUnavailable The maximum number of unavailable pods (non number to omit)
+  ##
+  maxUnavailable: ""


### PR DESCRIPTION
Bitnami helm repo (bitnami-labs.github.io/sealed-secrets) liefert dauerhaft 404 (Broadcom-Sunset) → kustomize build kann das Chart nicht mehr pullen → CI blockt jeden PR. Fix: Chart vendored (lokal committed), bootstrap-kritisch. Build läuft ohne Netzwerk-Pull.