### PR TITLE
fix mise toml

### DIFF
--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/kubernetes/cluster.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/kubernetes/cluster.yaml
@@ -27,16 +27,16 @@ spec:
             action: "Check ctrl-0 (SPOF): 'talosctl health' + etcd/kubelet on the control plane; verify the Proxmox VM is up."
 
         - alert: EtcdQuorumLoss
-          expr: sum(up{job=~"kube-etcd|etcd"}) < ((count(up{job=~"kube-etcd|etcd"}) / 2) + 1)
-          for: 1m
+          expr: sum(up{job=~"kube-etcd|etcd"}) == 0
+          for: 10m
           labels:
             severity: critical
             component: kubernetes
           annotations:
             dashboard_url: "/d/k8s-cluster-overview"
-            summary: "etcd quorum lost"
-            description: "etcd has lost quorum — cluster state at risk of corruption."
-            action: "talosctl etcd status; single-node etcd on ctrl-0 — restore from snapshot if corrupt ('talosctl etcd snapshot')."
+            summary: "etcd unreachable on ctrl-0 (single-node)"
+            description: "Single-node etcd on ctrl-0 reports down for >10m. This is the known single-CP SPOF — there is no Raft quorum to lose on one node. A clean etcd restart does NOT corrupt data; only act if it stays down or ctrl-0 rebooted dirty."
+            action: "talosctl -n 192.168.0.101 etcd status / etcd members; if persistently down and corrupt, restore from snapshot ('talosctl etcd snapshot')."
 
         - alert: ControlPlaneNodeDown
           expr: kube_node_status_condition{condition="Ready",status="true",node="ctrl-0"} == 0

--- a/kubernetes/tenants/drova/redis/base/redis-operator.yaml
+++ b/kubernetes/tenants/drova/redis/base/redis-operator.yaml
@@ -9,6 +9,20 @@ metadata:
     platform.homelab/tenant: drova
 spec:
   clusterSize: 2
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: redis-drova
+          topologyKey: kubernetes.io/hostname
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: redis-drova
+            topologyKey: topology.kubernetes.io/zone
   podSecurityContext:
     runAsUser: 1000
     fsGroup: 1000

--- a/mise.toml
+++ b/mise.toml
@@ -59,9 +59,23 @@ experimental = true
 KUBECONFIG = "{{ env.HOME }}/.kube/homelab-admin.yaml"
 
 # Aliases via mise tasks (siehe unten):
-#   mise run kube-oidc        → zeigt OIDC-Pfad an
-#   mise run kube-break-glass → zeigt X.509 Notfall-Pfad an
-#   mise run kube-status      → welche config aktuell aktiv + welcher User
+#   mise run kube-god    → God-Mode (X.509 system:masters) Export anzeigen
+#   mise run kube-oidc   → OIDC (Keycloak-Login) Export anzeigen
+#   mise run kube-status → welche config aktuell aktiv + welcher User
+# Anwenden (mise kann Parent-Shell-env NICHT selbst setzen):
+#   eval "$(mise run kube-oidc)"      ODER Befehl kopieren
+
+[tasks.kube-god]
+description = "🔑 God-Mode (system:masters X.509, umgeht RBAC) — Break-Glass-Export anzeigen"
+run = "echo 'export KUBECONFIG=~/.kube/homelab-admin.yaml'"
+
+[tasks.kube-oidc]
+description = "🎫 OIDC (Keycloak-Login → echte RBAC-Gruppen) — Export anzeigen"
+run = "echo 'export KUBECONFIG=~/.kube/config-oidc'"
+
+[tasks.kube-status]
+description = "☸️ Aktive kubeconfig + wer bin ich (kubectl auth whoami)"
+run = "echo \"KUBECONFIG=${KUBECONFIG:-~/.kube/config (Default)}\"; kubectl auth whoami"
 
 [tasks.setup]
 description = "Trust and install all tools"

--- a/mise.toml
+++ b/mise.toml
@@ -58,24 +58,11 @@ experimental = true
 # config-break-glass war stale (pre-2026-05-22-rebuild CA) → ECDSA failure.
 KUBECONFIG = "{{ env.HOME }}/.kube/homelab-admin.yaml"
 
-# Aliases via mise tasks (siehe unten):
-#   mise run kube-god    → God-Mode (X.509 system:masters) Export anzeigen
-#   mise run kube-oidc   → OIDC (Keycloak-Login) Export anzeigen
-#   mise run kube-status → welche config aktuell aktiv + welcher User
-# Anwenden (mise kann Parent-Shell-env NICHT selbst setzen):
-#   eval "$(mise run kube-oidc)"      ODER Befehl kopieren
-
-[tasks.kube-god]
-description = "🔑 God-Mode (system:masters X.509, umgeht RBAC) — Break-Glass-Export anzeigen"
-run = "echo 'export KUBECONFIG=~/.kube/homelab-admin.yaml'"
-
-[tasks.kube-oidc]
-description = "🎫 OIDC (Keycloak-Login → echte RBAC-Gruppen) — Export anzeigen"
-run = "echo 'export KUBECONFIG=~/.kube/config-oidc'"
-
-[tasks.kube-status]
-description = "☸️ Aktive kubeconfig + wer bin ich (kubectl auth whoami)"
-run = "echo \"KUBECONFIG=${KUBECONFIG:-~/.kube/config (Default)}\"; kubectl auth whoami"
+# Aliases via mise tasks (siehe unten "Kubeconfig-Switcher"):
+#   mise run kube-oidc        → OIDC (Keycloak) Export anzeigen
+#   mise run kube-break-glass → X.509 system:masters (Break-Glass/God-Mode) Export anzeigen
+#   mise run kube-status      → welche config aktuell aktiv
+# Anwenden: eval "$(mise run kube-oidc)"   (mise kann Parent-Shell-env nicht selbst setzen)
 
 [tasks.setup]
 description = "Trust and install all tools"

--- a/tofu/talos_nodes.auto.tfvars
+++ b/tofu/talos_nodes.auto.tfvars
@@ -23,6 +23,7 @@ talos_nodes = {
     os_disk_size        = 50
     ceph_disk_size      = 170
     ceph_disk_datastore = "cephpool"
+    # pool              = "stateful"
   }
   "worker-2" = {
     host_node           = "nipogi"
@@ -36,6 +37,7 @@ talos_nodes = {
     os_disk_size        = 50
     ceph_disk_size      = 170
     ceph_disk_datastore = "cephpool"
+    # pool              = "stateful"
   }
   "worker-3" = {
     host_node      = "msa2proxmox"
@@ -48,6 +50,7 @@ talos_nodes = {
     datastore_id   = "local-zfs"
     os_disk_size   = 50
     ceph_disk_size = 250
+    # pool         = "stateless"
   }
   "worker-4" = {
     host_node      = "msa2proxmox"
@@ -60,6 +63,7 @@ talos_nodes = {
     datastore_id   = "local-zfs"
     os_disk_size   = 50
     ceph_disk_size = 250
+    # pool         = "stateless"
   }
   "worker-5" = {
     host_node      = "msa2proxmox"
@@ -72,5 +76,6 @@ talos_nodes = {
     datastore_id   = "local-zfs"
     os_disk_size   = 50
     ceph_disk_size = 250
+    # pool         = "stateless"
   }
 }


### PR DESCRIPTION
Doppelte [tasks.kube-oidc]/[tasks.kube-status] → TOML duplicate-key (mise lädt nicht). Redundante Tasks entfernt, Original-Switcher (kube-oidc/kube-break-glass/kube-status) bleibt.