### PR TITLE
fix mise toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -58,24 +58,11 @@ experimental = true
 # config-break-glass war stale (pre-2026-05-22-rebuild CA) → ECDSA failure.
 KUBECONFIG = "{{ env.HOME }}/.kube/homelab-admin.yaml"
 
-# Aliases via mise tasks (siehe unten):
-#   mise run kube-god    → God-Mode (X.509 system:masters) Export anzeigen
-#   mise run kube-oidc   → OIDC (Keycloak-Login) Export anzeigen
-#   mise run kube-status → welche config aktuell aktiv + welcher User
-# Anwenden (mise kann Parent-Shell-env NICHT selbst setzen):
-#   eval "$(mise run kube-oidc)"      ODER Befehl kopieren
-
-[tasks.kube-god]
-description = "🔑 God-Mode (system:masters X.509, umgeht RBAC) — Break-Glass-Export anzeigen"
-run = "echo 'export KUBECONFIG=~/.kube/homelab-admin.yaml'"
-
-[tasks.kube-oidc]
-description = "🎫 OIDC (Keycloak-Login → echte RBAC-Gruppen) — Export anzeigen"
-run = "echo 'export KUBECONFIG=~/.kube/config-oidc'"
-
-[tasks.kube-status]
-description = "☸️ Aktive kubeconfig + wer bin ich (kubectl auth whoami)"
-run = "echo \"KUBECONFIG=${KUBECONFIG:-~/.kube/config (Default)}\"; kubectl auth whoami"
+# Aliases via mise tasks (siehe unten "Kubeconfig-Switcher"):
+#   mise run kube-oidc        → OIDC (Keycloak) Export anzeigen
+#   mise run kube-break-glass → X.509 system:masters (Break-Glass/God-Mode) Export anzeigen
+#   mise run kube-status      → welche config aktuell aktiv
+# Anwenden: eval "$(mise run kube-oidc)"   (mise kann Parent-Shell-env nicht selbst setzen)
 
 [tasks.setup]
 description = "Trust and install all tools"


### PR DESCRIPTION
Doppelte [tasks.kube-oidc]/[tasks.kube-status] aus PR #299 → TOML duplicate-key, mise lädt nicht. Redundante Tasks entfernt, Original kube-switcher (kube-oidc/kube-break-glass/kube-status) bleibt.