### PR TITLE
fix monitoring issues

### DIFF
--- a/kubernetes/platform/identity/keycloak/db/base/scheduled-backup.yaml
+++ b/kubernetes/platform/identity/keycloak/db/base/scheduled-backup.yaml
@@ -11,4 +11,6 @@ spec:
   backupOwnerReference: self
   cluster:
     name: keycloak-db
-  method: barmanObjectStore
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io


### PR DESCRIPTION
## keycloak-db Backup repariert (Daten-Risiko)
ScheduledBackup nutzte method=barmanObjectStore (legacy), Cluster ist aber auf Barman-Cloud-Plugin migriert → jede Backup failte ('cluster has no backup section'), LastBackupSucceeded=False. Fix: method=plugin + pluginConfiguration (wie n8n/drova).

## Noch offen (separate, tiefere Diagnose nötig)
- CNPG-Metriken (cnpg_collector_*) kommen GAR NICHT in Prometheus an → CNPG-Dashboards + Backup/Replication-Alerts blind. PodMonitors existieren, Selector leer, Pods exponieren :9187, n8n-prod ohne NetworkPolicy — Scrape-Endpoint antwortet trotzdem nicht. Braucht Targets-Analyse.