### PR TITLE
hardening appproject

### DIFF
--- a/kubernetes/projects/apps.yaml
+++ b/kubernetes/projects/apps.yaml
@@ -29,8 +29,12 @@ spec:
       server: 'https://kubernetes.default.svc'
     - namespace: '*-prod'
       server: 'https://kubernetes.default.svc'
-    # Legacy direct namespaces
-    - namespace: '*'
+    # Direkte Namespaces ohne env-Suffix (kein Wildcard)
+    - namespace: 'cloudbeaver'
+      server: 'https://kubernetes.default.svc'
+    - namespace: 'drova'
+      server: 'https://kubernetes.default.svc'
+    - namespace: 'uptime-kuma'
       server: 'https://kubernetes.default.svc'
 
   # CLUSTER RESOURCES: Application-specific (Security )

--- a/kubernetes/projects/infrastructure.yaml
+++ b/kubernetes/projects/infrastructure.yaml
@@ -19,9 +19,6 @@ spec:
     - 'https://kubernetes-sigs.github.io/external-dns/'  # external-dns Helm Repository
 
   destinations:
-    # Pure Kustomize Control - Kustomize determines namespaces
-    - namespace: '*'
-      server: 'https://kubernetes.default.svc'
     # Core System Namespaces
     - namespace: 'kube-system'
       server: 'https://kubernetes.default.svc'
@@ -110,6 +107,28 @@ spec:
 
     # VPN Infrastructure
     - namespace: 'tailscale'
+      server: 'https://kubernetes.default.svc'
+
+    # Live-genutzte NS (Plugin/Operator-Namespaces) — Ersatz fürs entfernte Wildcard
+    - namespace: 'cnpg-system'
+      server: 'https://kubernetes.default.svc'
+    - namespace: 'kafka'
+      server: 'https://kubernetes.default.svc'
+    - namespace: 'keycloak'
+      server: 'https://kubernetes.default.svc'
+    - namespace: 'monitoring'
+      server: 'https://kubernetes.default.svc'
+    - namespace: 'elastic-system'
+      server: 'https://kubernetes.default.svc'
+    - namespace: 'netbird'
+      server: 'https://kubernetes.default.svc'
+    - namespace: 'external-dns'
+      server: 'https://kubernetes.default.svc'
+    - namespace: 'redis-operator-system'
+      server: 'https://kubernetes.default.svc'
+    - namespace: 'reloader'
+      server: 'https://kubernetes.default.svc'
+    - namespace: 'renovate-operator'
       server: 'https://kubernetes.default.svc'
 
   clusterResourceWhitelist:

--- a/kubernetes/projects/platform.yaml
+++ b/kubernetes/projects/platform.yaml
@@ -11,9 +11,15 @@ metadata:
 spec:
   description: " Enterprise Platform Services - Google/AWS/Netflix Level"
 
-  # Platform services can deploy to any namespace
+  # Platform layer — auf echte Namespaces gescoped (kein Wildcard)
   destinations:
-    - namespace: '*'
+    - namespace: drova
+      server: https://kubernetes.default.svc
+    - namespace: keycloak
+      server: https://kubernetes.default.svc
+    - namespace: lldap
+      server: https://kubernetes.default.svc
+    - namespace: n8n-prod
       server: https://kubernetes.default.svc
 
   # Platform can use platform layer resources

--- a/kubernetes/projects/security.yaml
+++ b/kubernetes/projects/security.yaml
@@ -11,9 +11,11 @@ metadata:
 spec:
   description: " Enterprise Security Foundation - Zero Trust Architecture"
 
-  # Security policies can deploy to any namespace
+  # Security layer — auf echte Namespaces gescoped (kein Wildcard)
   destinations:
-    - namespace: '*'
+    - namespace: argocd
+      server: https://kubernetes.default.svc
+    - namespace: kyverno
       server: https://kubernetes.default.svc
 
   # Security layer resources

--- a/kubernetes/projects/storage.yaml
+++ b/kubernetes/projects/storage.yaml
@@ -7,7 +7,7 @@ spec:
   sourceRepos:
     - 'https://github.com/Tim275/talos-homelab.git'
   destinations:
-    - namespace: '*'
+    - namespace: 'kube-system'
       server: 'https://kubernetes.default.svc'
   clusterResourceWhitelist:
     - group: '*'


### PR DESCRIPTION
## AppProject-Härtung — destinations von Wildcard auf echte Namespaces gescoped (DAX-Multi-Tenancy)

Vorher: apps/infrastructure hatten bare `namespace: '*'` (defeats die NS-Liste), platform/security/storage standen komplett auf `'*'` → jede App durfte in JEDEN Namespace.

Nachher (auf live-genutzte NS gescoped, kein Breakage — verifiziert):
- **apps** → env-Patterns (*-dev/staging/prod) + cloudbeaver/drova/uptime-kuma
- **platform** → drova/keycloak/lldap/n8n-prod
- **security** → argocd/kyverno
- **storage** → kube-system
- **infrastructure** → bare * raus + 10 fehlende Live-NS ergänzt (cnpg-system/kafka/keycloak/monitoring/elastic-system/netbird/external-dns/redis-operator-system/reloader/renovate-operator); die Liste war stale (hatte cloudnative-pg statt cnpg-system etc.)

sourceRepos waren schon sauber. clusterResourceWhitelist (noch `*`) = bewusst Phase 2 (riskanter zu tightenen, Operatoren brauchen CRDs/ClusterRoles).

Verifiziert: server-dry-run ok + jede Live-App-NS ist abgedeckt → kein OutOfSync/Reject.