### PR TITLE
Fix AppProject destinations — security + infrastructure sync rejections

### DIFF
--- a/kubernetes/projects/infrastructure.yaml
+++ b/kubernetes/projects/infrastructure.yaml
@@ -38,6 +38,10 @@ spec:
     # Network Infrastructure
     - namespace: 'cilium'
       server: 'https://kubernetes.default.svc'
+    - namespace: 'cilium-spire'
+      server: 'https://kubernetes.default.svc'
+    - namespace: 'cilium-secrets'
+      server: 'https://kubernetes.default.svc'
     - namespace: 'istio-system'
       server: 'https://kubernetes.default.svc'
     - namespace: 'istio-base'

--- a/kubernetes/projects/security.yaml
+++ b/kubernetes/projects/security.yaml
@@ -11,11 +11,34 @@ metadata:
 spec:
   description: " Enterprise Security Foundation - Zero Trust Architecture"
 
-  # Security layer — auf echte Namespaces gescoped (kein Wildcard)
+  # Security layer — security-foundation/compliance verteilen NetworkPolicies, Rate-Limits,
+  # mTLS-Policies + Tetragon/Honeypot über viele Namespaces → alle Ziel-NS explizit gelistet.
   destinations:
     - namespace: argocd
       server: https://kubernetes.default.svc
     - namespace: kyverno
+      server: https://kubernetes.default.svc
+    - namespace: security
+      server: https://kubernetes.default.svc
+    - namespace: kube-system
+      server: https://kubernetes.default.svc
+    - namespace: honeytoken
+      server: https://kubernetes.default.svc
+    - namespace: drova
+      server: https://kubernetes.default.svc
+    - namespace: gateway
+      server: https://kubernetes.default.svc
+    - namespace: monitoring
+      server: https://kubernetes.default.svc
+    - namespace: grafana
+      server: https://kubernetes.default.svc
+    - namespace: jaeger
+      server: https://kubernetes.default.svc
+    - namespace: keycloak
+      server: https://kubernetes.default.svc
+    - namespace: elastic-system
+      server: https://kubernetes.default.svc
+    - namespace: uptime-kuma
       server: https://kubernetes.default.svc
 
   # Security layer resources


### PR DESCRIPTION
## Problem
After the destination hardening (#303), `security-foundation`, `security-compliance` and `cilium` fail to sync: `namespace X is not permitted in project Y`. The hardening scoped destinations too tightly and missed namespaces these apps legitimately deploy into. The earlier '62/62 Synced' was misleading — resources were already applied; the rejection only fires on the next re-sync (triggered by #304).

## Fix
- **security** project: `argocd, kyverno` → + drova, elastic-system, gateway, grafana, honeytoken, jaeger, keycloak, kube-system, monitoring, security, uptime-kuma. security-foundation distributes mTLS/default-deny CiliumNetworkPolicies + BackendTrafficPolicy rate-limits, compliance deploys Tetragon/kube-bench/honeypot — all cross-namespace by design.
- **infrastructure** project: + cilium-spire, cilium-secrets (Cilium deploys SPIRE + TLS-interception RBAC there).

Namespaces derived from `kubectl kustomize` of the actual manifests (complete set). Restores Synced on the affected apps.