### PR TITLE
Fix false-positive alerts (SRE: symptom-based, not cause-based)

### DIFF
--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/host-sensors.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/host-sensors.yaml
@@ -14,7 +14,9 @@ spec:
       rules:
         - alert: HostCPUTemperatureCritical
           expr: node_hwmon_temp_celsius > 95
-          for: 2m
+          # 2m war zu kurz: msa2 k10temp (CPU) spitzt unter Ceph-Last transient >95°C und
+          # resolved selbst → Flap-Noise. 15m = nur SUSTAINED Hitze (echte Gefahr) alarmiert.
+          for: 15m
           labels:
             severity: warning
             component: hardware

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/kubernetes/cluster.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/kubernetes/cluster.yaml
@@ -26,6 +26,9 @@ spec:
             description: "API server unreachable for >2 minutes. All cluster operations halted."
             action: "Check ctrl-0 (SPOF): 'talosctl health' + etcd/kubelet on the control plane; verify the Proxmox VM is up."
 
+        # DORMANT: the kube-etcd scrape target is disabled (unscrapable on Talos — see
+        # kube-prometheus-stack values), so this never fires. Real single-node etcd failure
+        # surfaces as ClusterAPIServerDown (above). Re-enable etcd scraping to reactivate.
         - alert: EtcdQuorumLoss
           expr: sum(up{job=~"kube-etcd|etcd"}) == 0
           for: 10m

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/argocd.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/argocd.yaml
@@ -26,8 +26,12 @@ spec:
             description: "GitOps reconciliation halted >5min — no auto-deploy/self-heal until restored."
             action: "kubectl -n argocd rollout restart statefulset/argocd-application-controller; check its logs + resource limits."
 
+        # lldap excluded: its hourly bootstrap CronJob churns app-health (job exits 1 on
+        # ≥3 dual-store-bug users → app Degraded across hours) — already covered by the
+        # dedicated LLDAPBootstrapCronJobFailing below, and an lldap-service outage surfaces
+        # via the Keycloak SSO alerts. Generic app-health flapping on it = pure noise.
         - alert: ArgoCDAppUnhealthy
-          expr: argocd_app_info{health_status=~"Degraded|Missing"} == 1
+          expr: argocd_app_info{health_status=~"Degraded|Missing", name!="lldap"} == 1
           for: 30m
           labels:
             severity: warning

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
@@ -100,45 +100,24 @@ prometheus:
           #     app: prometheus
 
 # https://github.com/siderolabs/talos/discussions/7214
+# Control-plane scrape DISABLED on this single-node Talos: kcm/scheduler/etcd are not
+# reachable for scraping by default (the discussions/7214 relabelings alone don't fix
+# reachability) → permanent up==0 = false TargetDown + EtcdQuorumLoss noise with zero data.
+# Their component-alerting is already off (defaultRules below). Real control-plane failure
+# surfaces as ClusterAPIServerDown + ControlPlaneNodeDown (symptom, not cause).
+# Re-enable needs proper Talos metrics-exposure (+ etcd client-cert for kubeEtcd).
 kubeControllerManager:
-  enabled: true
-  serviceMonitor:
-    relabelings:
-      - sourceLabels: [ __meta_kubernetes_pod_node_name ]
-        separator: ;
-        regex: ^(.*)$
-        targetLabel: nodename
-        replacement: $1
-        action: replace
-    metricRelabelings:
-      - action: labeldrop
-        regex: pod
+  enabled: false
 
 kubeEtcd:
-  enabled: true
-  service:
-    selector:
-      # etcd doesn't run as a container,
-      # but most probably runs on the same nodes that host a controller
-      k8s-app: kube-controller-manager
-  serviceMonitor:
-    relabelings:
-      - sourceLabels: [ __meta_kubernetes_pod_node_name ]
-        separator: ;
-        regex: ^(.*)$
-        targetLabel: nodename
-        replacement: $1
-        action: replace
-    metricRelabelings:
-      - action: labeldrop
-        regex: pod
+  enabled: false  # unscrapable on Talos w/o etcd client-cert → was the EtcdQuorumLoss false-source
 
 kubeProxy:
   # Cilium replaces Kube Proxy
   enabled: false
 
 kubeScheduler:
-  enabled: true
+  enabled: false  # see kubeControllerManager note — unscrapable on Talos
   serviceMonitor:
     relabelings:
       - sourceLabels: [ __meta_kubernetes_pod_node_name ]


### PR DESCRIPTION
Alerts were firing on *causes* (scrape `up==0`) for healthy components — the SRE anti-pattern. All targets verified healthy (`/healthz: [+]etcd ok`, kcm/scheduler Running, lldap 15d). Fixes:

## EtcdQuorumLoss (CRITICAL → phone, hourly for >24h) — FALSE
Fired on `sum(up{kube-etcd})==0`, i.e. etcd **scrape** down — but etcd is healthy. Root: kcm/scheduler/etcd are unscrapable on this single-node Talos (discussions/7214 relabelings don't fix reachability) → permanent `up==0`.
- Disabled the 3 unscrapable scrape targets (`kubeControllerManager/kubeScheduler/kubeEtcd.enabled: false`) — their component-alerting was already off; this removes the dead `up==0` series at the source.
- EtcdQuorumLoss now dormant (no metric); real single-node etcd failure surfaces as ClusterAPIServerDown + ControlPlaneNodeDown (symptom).

## TargetDown / PrometheusTargetDown (kube-controller-manager) — FALSE
Same root (the unscrapable targets). Disabling them removes the `up==0` → both stop firing for kcm/scheduler/etcd.

## HostCPUTemperatureCritical (msa2, flapping ~95°C) — FLAP
msa2 k10temp spikes transiently >95°C under Ceph load and self-resolves. `for: 2m` → `for: 15m` so only **sustained** thermal (real danger) alerts.

## ArgoCDAppUnhealthy: lldap (flapping Degraded) — REDUNDANT
lldap deployment healthy 15d; the hourly bootstrap CronJob churns app-health. Already covered by the dedicated `LLDAPBootstrapCronJobFailing`. Excluded lldap from the generic alert.

NOT included (real issue, separate fix): VectorSinkDroppingEvents — the Loki sink genuinely drops non-pod logs (missing `kubernetes.pod_name` in the label template). That's a correct alert + a real bug to fix in the Vector config.