### PR TITLE
Close observability gaps: Vector log-drop + lldap service alert

### DIFF
--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/argocd.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/argocd.yaml
@@ -57,3 +57,18 @@ spec:
             summary: "LLDAP bootstrap CronJob hasn't succeeded in 3h"
             description: "User reconciliation broken — Keycloak login may fail."
             action: "kubectl get cronjob -n lldap; kubectl logs -n lldap -l cronjob=lldap-bootstrap"
+
+        # Restores lldap-SERVICE coverage after lldap was excluded from the generic
+        # ArgoCDAppUnhealthy above — this watches the DEPLOYMENT, not the noisy bootstrap job.
+        - alert: LLDAPDown
+          expr: kube_deployment_status_replicas_available{namespace="lldap",deployment="lldap"} == 0
+          for: 5m
+          labels:
+            severity: warning
+            component: identity
+            priority: P2
+          annotations:
+            dashboard_url: "/d/argocd-overview"
+            summary: "LLDAP directory down — Keycloak LDAP federation will fail"
+            description: "lldap Deployment has 0 available replicas >5min → LDAP-backed Keycloak logins start failing (SSO impact)."
+            action: "kubectl -n lldap get pod,deploy; kubectl -n lldap logs deploy/lldap; check its PVC/SQLite + the node."

--- a/kubernetes/infrastructure/observability/vector/base/vector-aggregator.toml
+++ b/kubernetes/infrastructure/observability/vector/base/vector-aggregator.toml
@@ -301,6 +301,12 @@ if exists(.user_id) {
 if exists(.error) {
   ."error.message" = string!(.error)
 }
+
+# Loki labels template {{ kubernetes.pod_name }} + {{ kubernetes.container_name }} — non-pod
+# events (proxmox/talos syslog, kube-audit) lack these → label-render fails → Loki silently
+# DROPS the event (root cause of VectorSinkDroppingEvents). Default so every event ships.
+if !exists(.kubernetes.pod_name) { .kubernetes.pod_name = "none" }
+if !exists(.kubernetes.container_name) { .kubernetes.container_name = "none" }
 '''
 
 # Sample logs to reduce volume (optional)


### PR DESCRIPTION
Follow-up to the alert-fix PR, closing two of the gaps surfaced in the honest review.

## VectorSinkDroppingEvents — REAL log-drop, FIXED (P1)
The Loki sink labels template `{{ kubernetes.pod_name }}` + `{{ kubernetes.container_name }}`; non-pod events (proxmox/talos syslog, kube-audit) lack those fields → label-render fails → Loki **silently drops** the event. Added defaults in the `enrich_logs` transform so every event has these fields → no more drops. (`.service_name`/`.namespace`/`.level` were already set universally.)

## lldap service coverage — RESTORED (P2)
The previous PR excluded lldap from the generic ArgoCDAppUnhealthy (to kill the bootstrap-CronJob flap). Added a targeted **LLDAPDown** alert on the *Deployment* availability (`kube_deployment_status_replicas_available{namespace=lldap,deployment=lldap} == 0`) — symptom-based, immune to the bootstrap churn, restores SSO-backend coverage.

## Still open (honest)
- CNPG-backup-alerts blind (#33): NOT a scrape fix — the barman-cloud **plugin** does backups out-of-band, so the core CNPG collector never populates `cnpg_collector_last_available_backup_timestamp`. The alert is structurally blind. Needs a redesign (watch the Backup CR status), separate task.
- External observer: needs an external dead-man-switch endpoint (Healthchecks.io/UptimeRobot) — needs an account, then wire Alertmanager Watchdog to it.
- Control-plane scrape (kcm/scheduler/etcd): needs Talos metrics-exposure; single-node symptom coverage (ClusterAPIServerDown + ControlPlaneNodeDown) is adequate.