### PR TITLE
Alert audit: fix 5 dead-metric alerts + wire ES-SLM + prune 2 unwireable

### DIFF
--- a/kubernetes/infrastructure/observability/elasticsearch/base/cluster/elasticsearch-exporter-deployment.yaml
+++ b/kubernetes/infrastructure/observability/elasticsearch/base/cluster/elasticsearch-exporter-deployment.yaml
@@ -31,6 +31,9 @@ spec:
             - '--es.uri=https://production-cluster-es-http:9200'
             - '--es.ssl-skip-verify'
             - '--web.listen-address=:9114'
+            # --es.slm enables SLM stats (ES uses the daily-snapshots SLM policy) →
+            # populates elasticsearch_slm_* for the ElasticsearchSnapshotStale alert.
+            - '--es.slm'
           env:
             - name: ES_USERNAME
               valueFrom:

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/apps/keycloak.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/apps/keycloak.yaml
@@ -30,19 +30,6 @@ spec:
             description: "All Keycloak replicas not ready — OIDC login broken cluster-wide (ArgoCD, Grafana, n8n, etc.)."
             action: "kubectl -n keycloak get pod -l app=keycloak + logs (watch OOMKill — 23x crashloop 2026-05-24); check the CNPG keycloak-db."
 
-    # ── TICKET ──
-    - name: keycloak-ticket
-      interval: 60s
-      rules:
-        - alert: KeycloakLoginFailureSpike
-          expr: sum by (realm) (rate(keycloak_failed_login_attempts[5m])) > 0.5
-          for: 5m
-          labels:
-            severity: warning
-            component: keycloak
-            priority: P2
-          annotations:
-            dashboard_url: "/d/keycloak-health"
-            summary: "Keycloak realm {{ $labels.realm }} elevated failed-login rate"
-            description: "{{ $value }} failed logins/sec — possible credential-stuffing or brute-force."
-            action: "Check keycloak logs for realm {{ $labels.realm }}; if credential-stuffing: rate-limit + block the source IPs."
+    # KeycloakLoginFailureSpike removed: keycloak_failed_login_attempts needs the 3rd-party
+    # keycloak-metrics-spi (not deployed) → was permanently blind. Re-add via that SPI, OR a
+    # Vector log_to_metric over keycloak login-failure events (like waf_coraza_detections_total).

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/compliance/trivy.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/compliance/trivy.yaml
@@ -12,6 +12,9 @@ spec:
     - name: trivy
       interval: 5m
       rules:
+        # DORMANT until trivy-operator is deployed (task #23): trivy_image_vulnerabilities
+        # only exists once the operator runs. Harmless (absent metric never fires) — activates
+        # automatically when #23 lands. Don't mistake "no CVE alerts" for "no CVEs" until then.
         - alert: TrivyCriticalCVEFound
           expr: |
             sum by (namespace) (trivy_image_vulnerabilities{severity="Critical"}) > 0

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/data/kafka.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/data/kafka.yaml
@@ -28,7 +28,7 @@ spec:
             action: "kubectl -n {{ $labels.namespace }} get pod -l strimzi.io/controller-role=true + logs; do NOT delete all controllers (KRaft quorum)."
 
         - alert: KafkaUnderMinISR
-          expr: kafka_cluster_partition_under_min_isr{pod=~".*kafka.*"} > 0
+          expr: kafka_cluster_partition_underminisr{pod=~".*kafka.*"} > 0
           for: 3m
           labels:
             severity: warning

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/data/postgres.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/data/postgres.yaml
@@ -25,9 +25,11 @@ spec:
             description: "PostgreSQL primary not serving traffic for >2min."
             action: "kubectl cnpg status {{ $labels.cluster }} -n {{ $labels.namespace }}; check pods; 'kubectl cnpg promote' a healthy replica if the primary is lost."
 
+        # Source: cnpg_backup_stopped_at_timestamp_seconds (kube-state-metrics custom-resource-
+        # state over the Backup CR) — the plugin doesn't feed the legacy collector metric.
         - alert: CNPGBackupStale
           expr: |
-            (time() - max by (namespace, cluster) (cnpg_collector_last_available_backup_timestamp{cluster!=""})) > 86400
+            (time() - max by (namespace, cluster) (cnpg_backup_stopped_at_timestamp_seconds{phase="completed"})) > 90000
           for: 30m
           labels:
             severity: critical
@@ -70,8 +72,7 @@ spec:
 
         - alert: CNPGBackupNeverRan
           expr: |
-            absent_over_time(cnpg_collector_last_available_backup_timestamp[7d])
-            and on() count(kube_customresource_count{customresource_kind="Cluster",customresource_group="postgresql.cnpg.io"} > 0) > 0
+            absent_over_time(cnpg_backup_stopped_at_timestamp_seconds{phase="completed"}[3h])
           for: 1h
           labels:
             severity: warning

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/infrastructure/proxmox.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/infrastructure/proxmox.yaml
@@ -26,19 +26,22 @@ spec:
             action: "Check the Proxmox host ({{ $labels.instance }}) physically; SSH it; its VMs are down too — full-host outage."
 
         - alert: ProxmoxZfsPoolCritical
-          expr: (node_zfs_zpool_alloc{job="proxmox-host-node"} / node_zfs_zpool_size{job="proxmox-host-node"}) > 0.95
+          # node_zfs_zpool_alloc/size don't exist (node-exporter has no pool-capacity gauge).
+          # Repointed to pool HEALTH: faulted/unavail/suspended = data-loss state = page.
+          # (ProxmoxZfsPoolDegraded warns on any state!="online", incl. "degraded".)
+          expr: node_zfs_zpool_state{job="proxmox-host-node",state=~"faulted|unavail|suspended|removed"} == 1
           for: 5m
           labels:
             severity: critical
             component: hypervisor
           annotations:
             dashboard_url: "/d/proxmox-cluster"
-            summary: "ZFS pool {{ $labels.zpool }} >95% full on {{ $labels.instance }}"
-            description: "Pool nearly full — VM-disks will fail writes. Free space or expand immediately."
-            action: "SSH the host; 'zpool list {{ $labels.zpool }}'; free space (old VM disks/snapshots) or expand the pool."
+            summary: "ZFS pool {{ $labels.zpool }} {{ $labels.state }} on {{ $labels.instance }}"
+            description: "Pool in a data-loss state ({{ $labels.state }}) — VMs/Ceph on it at risk."
+            action: "SSH the host; 'zpool status {{ $labels.zpool }}'; check failed disks, replace + resilver."
 
         - alert: ProxmoxDiskSmartFailure
-          expr: smartmon_device_smart_healthy{job="proxmox-host-node"} == 0
+          expr: smartctl_device_smart_status == 0
           for: 5m
           labels:
             severity: critical

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/rook-ceph.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/rook-ceph.yaml
@@ -98,20 +98,8 @@ spec:
             description: "Operator unreachable >5min — Ceph reconcile/management operations blocked."
             action: "kubectl -n rook-ceph rollout restart deploy/rook-ceph-operator; check operator logs."
 
-        - alert: RGWBucketQuotaWarning
-          expr: |
-            (ceph_rgw_bucket_used_bytes / ceph_rgw_bucket_quota_bytes) > 0.85
-            and ceph_rgw_bucket_quota_bytes > 0
-          for: 30m
-          labels:
-            severity: warning
-            component: storage
-            priority: P2
-          annotations:
-            dashboard_url: "/d/ceph-cluster"
-            summary: "RGW bucket {{ $labels.bucket }} >85% of quota"
-            description: "Bucket fills soon — Velero/CNPG/Loki/Tempo writes will fail at 100%."
-            action: "Raise quota ('radosgw-admin quota set') or prune old objects (Velero/Loki/Tempo retention)."
+        # RGWBucketQuotaWarning removed: the Ceph mgr prometheus module doesn't export
+        # ceph_rgw_bucket_* (no per-bucket quota metrics) → was a permanently-blind alert.
 
         - alert: CephSlowOps
           # Service-level signal for BlueStore slow-ops (HEALTH_WARN). Replaces the noisy

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/rook-ceph.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/rook-ceph.yaml
@@ -27,7 +27,7 @@ spec:
             action: "Toolbox: 'ceph health detail' → root cause; often full OSD or inconsistent PG ('ceph pg repair <id>')."
 
         - alert: CephQuorumLost
-          expr: (ceph_osd_up + ceph_osd_in) / (ceph_osd_up + ceph_osd_down) < 0.5
+          expr: sum(ceph_osd_up) / count(ceph_osd_up) < 0.5
           for: 1m
           labels:
             severity: critical

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
@@ -230,6 +230,40 @@ kube-state-metrics:
     timeoutSeconds: 10
     failureThreshold: 6
 
+  # CNPG backup monitoring (#33): the barman-cloud PLUGIN backs up out-of-band, so the core
+  # cnpg collector never populates cnpg_collector_last_available_backup_timestamp (the old
+  # alerts watched a dead metric). Expose the Backup CR's stoppedAt instead — KSM Gauge
+  # auto-parses the RFC3339 value to a unix timestamp. (A bad value is skipped gracefully;
+  # only a malformed config STRUCTURE would crash KSM, so this uses the standard schema.)
+  rbac:
+    extraRules:
+      - apiGroups: ["postgresql.cnpg.io"]
+        resources: ["backups"]
+        verbs: ["list", "watch"]
+  customResourceState:
+    enabled: true
+    config:
+      spec:
+        resources:
+          - groupVersionKind:
+              group: postgresql.cnpg.io
+              version: v1
+              kind: Backup
+            metricNamePrefix: cnpg_backup
+            labelsFromPath:
+              namespace: [metadata, namespace]
+              name: [metadata, name]
+              cluster: [spec, cluster, name]
+            metrics:
+              - name: stopped_at_timestamp_seconds
+                help: "CNPG Backup stoppedAt as a unix timestamp, per Backup CR"
+                each:
+                  type: Gauge
+                  gauge:
+                    path: [status, stoppedAt]
+                    labelsFromPath:
+                      phase: [status, phase]
+
 alertmanager:
   # PodDisruptionBudget — gossip-mesh-resilience (battle-tested 2026-05-14):
   # Heute war alertmanager-0 16h silent-dead nach Talos-upgrade. minAvailable: 2


### PR DESCRIPTION
Closes the last observability gap. The barman-cloud **plugin** backs up out-of-band, so the core cnpg collector never populates `cnpg_collector_last_available_backup_timestamp` → both backup alerts watched a dead metric (doubly blind: the `kube_customresource_count` guard was also absent — KSM had no custom-resource-state config at all).

## Fix
- **kube-state-metrics custom-resource-state**: expose the CNPG `Backup` CR's `status.stoppedAt` (RFC3339 → KSM Gauge auto-parses to unix) as `cnpg_backup_stopped_at_timestamp_seconds{namespace,name,cluster,phase}` + RBAC to list/watch `postgresql.cnpg.io/backups`.
- **Repoint alerts**:
  - `CNPGBackupStale`: `time() - max by(namespace,cluster)(cnpg_backup_stopped_at_timestamp_seconds{phase="completed"}) > 90000` (25h, daily-backup margin).
  - `CNPGBackupNeverRan`: `absent_over_time(cnpg_backup_stopped_at_timestamp_seconds{phase="completed"}[3h])` (whole backup pipeline / CRS dead).

Backups verified working (Backup CRs `phase: completed`, keycloak/n8n ~30m old) — they were just unmonitored. Standard CRS schema (build-verified); a bad value degrades gracefully, only a malformed structure would crash KSM → **KSM health verified immediately post-merge**.