### PR TITLE
argocd slack channel

### DIFF
--- a/kubernetes/infrastructure/argocd/base/values.yaml
+++ b/kubernetes/infrastructure/argocd/base/values.yaml
@@ -1001,6 +1001,7 @@ notifications:
           method: POST
           body: |
             {
+              "channel": "#argocd-deployments",
               "attachments": [{
                 "title": " Application Deployed",
                 "title_link": "https://argo.timourhomelab.org/applications/{{.app.metadata.name}}",


### PR DESCRIPTION
Route ArgoCD deploy-notifications to #argocd-deployments via channel-override (best-effort — only honored if the Slack webhook allows channel override; otherwise needs a dedicated #argocd-deployments webhook).