### PR TITLE
cnpg backup alert fix

### DIFF
--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/data/postgres.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/data/postgres.yaml
@@ -29,7 +29,7 @@ spec:
         # state over the Backup CR) — the plugin doesn't feed the legacy collector metric.
         - alert: CNPGBackupStale
           expr: |
-            (time() - max by (namespace, cluster) (cnpg_backup_stopped_at_timestamp_seconds{phase="completed"})) > 90000
+            (time() - max by (namespace, cluster) (cnpg_backup_stopped_at_timestamp_seconds)) > 90000
           for: 30m
           labels:
             severity: critical
@@ -72,7 +72,7 @@ spec:
 
         - alert: CNPGBackupNeverRan
           expr: |
-            absent_over_time(cnpg_backup_stopped_at_timestamp_seconds{phase="completed"}[3h])
+            absent_over_time(cnpg_backup_stopped_at_timestamp_seconds[3h])
           for: 1h
           labels:
             severity: warning


### PR DESCRIPTION
CNPGBackupStale/NeverRan filtered on {phase="completed"} but the KSM custom-resource-state metric has no phase label → filter matched nothing → false-positive NeverRan. The metric (path [status,stoppedAt]) only exists for backups that have stoppedAt = effectively completed-only, so the filter is redundant. Removed it.