### PR TITLE
Security logging: DNS + pgaudit + cert-manager

### DIFF
--- a/kubernetes/infrastructure/network/coredns/base/coredns-config.yaml
+++ b/kubernetes/infrastructure/network/coredns/base/coredns-config.yaml
@@ -15,7 +15,7 @@ data:
         }
         ready
         log . {
-            class error
+            class all
         }
         prometheus :9153
 

--- a/kubernetes/infrastructure/observability/vector/base/vector-agent.toml
+++ b/kubernetes/infrastructure/observability/vector/base/vector-agent.toml
@@ -56,7 +56,8 @@ condition = '''
 !contains(to_string(.kubernetes.namespace) ?? "", "kube-system")) ||
 contains(to_string(.level) ?? "", "error") ||
 contains(to_string(.level) ?? "", "warn") ||
-starts_with(to_string(.kubernetes.pod_name) ?? "", "tetragon")
+starts_with(to_string(.kubernetes.pod_name) ?? "", "tetragon") ||
+starts_with(to_string(.kubernetes.pod_name) ?? "", "coredns")
 '''
 
 # Kubernetes API server audit logs (control plane nodes only)

--- a/kubernetes/infrastructure/observability/vector/base/vector-aggregator.toml
+++ b/kubernetes/infrastructure/observability/vector/base/vector-aggregator.toml
@@ -336,7 +336,7 @@ inputs = ["sample_logs"]
 # Bleibt 1:1 in Loki (Forensik per grep). Re-enable = tetragon-Klausel unten wieder
 # an die condition anhängen (das `||` davor nicht vergessen):
 #   || (exists(.kubernetes.pod_name) && starts_with(string!(.kubernetes.pod_name), "tetragon"))
-condition = '(exists(.kubernetes.pod_namespace) && includes(["drova","drova-prod","keycloak","lldap","argocd","kyverno","security","cilium-spire","cnpg-system","velero","gateway","netbird","n8n-prod","kafka","cloudbeaver","audiobookshelf-prod","redis-operator-system"], .kubernetes.pod_namespace)) || (exists(.source) && .source == "kubernetes-audit") || (exists(.source) && .source == "hubble")'
+condition = '(exists(.kubernetes.pod_namespace) && includes(["drova","drova-prod","keycloak","lldap","argocd","cert-manager","kyverno","security","cilium-spire","cnpg-system","velero","gateway","netbird","n8n-prod","kafka","cloudbeaver","audiobookshelf-prod","redis-operator-system"], .kubernetes.pod_namespace)) || (exists(.source) && .source == "kubernetes-audit") || (exists(.source) && .source == "hubble")'
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # ES-VOLUME-SCHUTZ: laute INFO-Quellen (kafka/n8n-prod) auf 1/5 samplen.

--- a/kubernetes/platform/identity/keycloak/db/base/postgres-cluster.yaml
+++ b/kubernetes/platform/identity/keycloak/db/base/postgres-cluster.yaml
@@ -15,7 +15,11 @@ spec:
     size: 20Gi
     storageClass: rook-ceph-block-enterprise
   postgresql:
+    # pgaudit-Audit-Logs (ddl,role,write) → Vector → Elasticsearch (SIEM)
+    shared_preload_libraries:
+      - pgaudit
     parameters:
+      pgaudit.log: "ddl,role,write"
       max_connections: '200'
       shared_buffers: 256MB
       effective_cache_size: 1GB

--- a/kubernetes/tenants/n8n-prod/postgres/base/cluster.yaml
+++ b/kubernetes/tenants/n8n-prod/postgres/base/cluster.yaml
@@ -12,6 +12,12 @@ metadata:
 spec:
   instances: 2
   imageName: ghcr.io/cloudnative-pg/postgresql:16.1
+  postgresql:
+    # pgaudit-Audit-Logs (ddl,role,write) → Vector → Elasticsearch (SIEM)
+    shared_preload_libraries:
+      - pgaudit
+    parameters:
+      pgaudit.log: "ddl,role,write"
   plugins:
   - name: barman-cloud.cloudnative-pg.io
     parameters:


### PR DESCRIPTION
## Was
- **CoreDNS Query-Logging** (`class all`) → Loki: welche Domains Pods auflösen (C2/Exfil-Sichtbarkeit + Egress-Ziele)
- **pgaudit** auf keycloak-db + n8n-postgres (`ddl,role,write`) → Elasticsearch
- **cert-manager** → ES-Allowlist (rogue-Cert-Erkennung)
- **vector-agent**: coredns-Ausnahme im kube-system-Noise-Filter (sonst gedroppt)

## Merge-Effekt
- pgaudit restartet die DBs beim Sync: n8n (2 Instanzen = rolling) · keycloak (1 Instanz = kurzer SSO-Blip)
- CoreDNS-Live-Config ist bereits gepatcht (class all aktiv); diese Dateien persistieren es gegen upgrade-k8s