### PR TITLE
feat: keda operator

### DIFF
--- a/kubernetes/applicationsets/infrastructure/controllers-stack.yaml
+++ b/kubernetes/applicationsets/infrastructure/controllers-stack.yaml
@@ -37,6 +37,7 @@ spec:
                 - { component: renovate-jobs,     appName: renovate-jobs,     path: kubernetes/platform/gitops/renovate/base,                        namespace: renovate-operator,     wave: "10" }
                 - { component: keycloak-operator, appName: keycloak-operator, path: kubernetes/infrastructure/operators/keycloak/overlays/prod,       namespace: keycloak,              wave: "-50" }
                 - { component: argo-rollouts,   appName: argo-rollouts,   path: kubernetes/infrastructure/operators/argo-rollouts/overlays/prod,   namespace: argo-rollouts,   wave: "-50" }
+                - { component: keda,            appName: keda,            path: kubernetes/infrastructure/operators/keda/overlays/prod,            namespace: keda,            wave: "-50" }
                 - { component: argocd,          appName: argocd,          path: kubernetes/infrastructure/argocd/overlays/prod,          namespace: argocd,          wave: "90" }
   template:
     metadata:

--- a/kubernetes/infrastructure/operators/keda/base/kustomization.yaml
+++ b/kubernetes/infrastructure/operators/keda/base/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+
+helmCharts:
+  # KEDA: event-driven autoscaling. ScaledObjects (drova tenant) scale
+  # Kafka consumers on consumer-group lag via the Prometheus scaler.
+  - name: keda
+    repo: https://kedacore.github.io/charts
+    version: "2.20.1"
+    releaseName: keda
+    namespace: keda
+    includeCRDs: true

--- a/kubernetes/infrastructure/operators/keda/base/namespace.yaml
+++ b/kubernetes/infrastructure/operators/keda/base/namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: keda
+  labels:
+    app.kubernetes.io/name: keda
+    app.kubernetes.io/component: operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "-5"

--- a/kubernetes/infrastructure/operators/keda/overlays/prod/kustomization.yaml
+++ b/kubernetes/infrastructure/operators/keda/overlays/prod/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base


### PR DESCRIPTION
KEDA-Operator via controllers-stack ApplicationSet (spiegelt reloader-Muster). Helm kedacore/keda 2.20.1, wave -50, ns keda, includeCRDs. Lokal gerendert: 30 Ressourcen. Additiv: installiert CRDs + Operator, aendert kein bestehendes Scaling. Prereq fuer ScaledObjects auf Kafka-Consumern (drova-gitops, separater PR, trip-service zuerst).