### PR TITLE
ceph pools replica 2

### DIFF
--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/rook-ceph.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/rook-ceph.yaml
@@ -73,7 +73,7 @@ spec:
             action: "Toolbox: 'ceph pg dump_stuck inactive'; check cross-node OSD heartbeats + Cilium NodeEncryption (encrypt-node deadlock 2026-05-24)."
 
         - alert: CephOSDNearFull
-          expr: ceph_osd_stat_bytes_used / ceph_osd_stat_bytes > 0.75
+          expr: ceph_osd_stat_bytes_used / ceph_osd_stat_bytes > 0.82
           for: 30m
           labels:
             severity: warning
@@ -81,9 +81,9 @@ spec:
             priority: P2
           annotations:
             dashboard_url: "/d/ceph-cluster"
-            summary: "Ceph OSD {{ $labels.ceph_daemon }} >75% full"
-            description: "OSD at {{ $value | humanizePercentage }} — add capacity before it blocks writes."
-            action: "Toolbox: 'ceph osd df'; 'ceph osd reweight-by-utilization' if imbalanced, else add capacity."
+            summary: "Ceph OSD {{ $labels.ceph_daemon }} >82% full"
+            description: "OSD at {{ $value | humanizePercentage }} — Ceph nearfull at 85%, blocks writes at 95%. Add capacity."
+            action: "Toolbox 'ceph osd df'. Balancer is upmap (already optimal) — reweight won't help on same-disk OSDs; grow/add OSD capacity."
 
         - alert: RookCephOperatorDown
           expr: up{job="rook-ceph-operator"} == 0

--- a/kubernetes/infrastructure/storage/radosgateway/base/ceph-object-store.yaml
+++ b/kubernetes/infrastructure/storage/radosgateway/base/ceph-object-store.yaml
@@ -9,7 +9,9 @@ spec:
       size: 3
   dataPool:
     replicated:
-      size: 3
+      size: 2
+    parameters:
+      min_size: "1"
   preservePoolsOnDelete: false
   gateway:
     port: 80

--- a/kubernetes/infrastructure/storage/rook-ceph/base/pools.yaml
+++ b/kubernetes/infrastructure/storage/rook-ceph/base/pools.yaml
@@ -1,4 +1,7 @@
-# Enterprise RBD Pool - High Performance with 3x Replication
+# Enterprise RBD Pool - 2x Replication
+# size 2 (min_size 1): failureDomain=host is WORKER-level (5 workers, not the 2
+# physical hosts) — a 3rd copy adds no physical-host safety but costs +50% raw.
+# Reduced 3->2 on 2026-07-04 (OSDs nearfull: osd.1 87%, osd.4 86%).
 apiVersion: ceph.rook.io/v1
 kind: CephBlockPool
 metadata:
@@ -9,10 +12,10 @@ metadata:
 spec:
   failureDomain: host
   replicated:
-    size: 3
+    size: 2
     requireSafeReplicaSize: true
   parameters:
-    min_size: "2"
+    min_size: "1"
     # Optimized for enterprise workloads
     compression_algorithm: "lz4"
     compression_mode: "aggressive"


### PR DESCRIPTION
OSDs nearfull (osd.1 87.6%, osd.4 86.4%, 14 pools nearfull). Root cause: replicapool-enterprise + RGW dataPool ran replica 3 — failureDomain=host is worker-level (5 workers on 2 physical hosts), the 3rd copy adds no physical-host safety but costs +50% raw (456 GiB for 152 GiB RGW data).

Reduce both pools to size 2 / min_size 1. Ceph trims excess copies in place — no backfill, no data movement. Expected: 854 -> ~574 GiB raw (78% -> 53%), all nearfull warnings clear.