### PR TITLE
rgw zone replica 2

### DIFF
--- a/kubernetes/infrastructure/storage/radosgateway/base/ceph-object-zone.yaml
+++ b/kubernetes/infrastructure/storage/radosgateway/base/ceph-object-zone.yaml
@@ -53,8 +53,9 @@ spec:
       pg_num_min: "32"
   dataPool:
     replicated:
-      size: 3
+      size: 2
       requireSafeReplicaSize: true
     parameters:
       pg_num_min: "32"
+      min_size: "1"
   # CustomEndpoints are optional - RGW service will be auto-discovered


### PR DESCRIPTION
Follow-up to #331: RGW runs in zone mode — pools are defined by the CephObjectZone, not the CephObjectStore (which Rook ignores when a zone is referenced). #331 edited the wrong CR for the RGW pool; this fixes the actual source: homelab zone dataPool size 3 -> 2 / min_size 1. Frees ~152 GiB raw in homelab.rgw.buckets.data.