### PR TITLE
cnpg zone spread pooler fix

### DIFF
--- a/kubernetes/tenants/drova/postgres/base/postgres-cluster.yaml
+++ b/kubernetes/tenants/drova/postgres/base/postgres-cluster.yaml
@@ -66,6 +66,7 @@ spec:
       labelSelector:
         matchLabels:
           cnpg.io/cluster: drova-postgres
+          cnpg.io/podRole: instance
   # Rook-Ceph disk I/O is slow — replicas need more time for WAL replay on startup
   probes:
     startup:


### PR DESCRIPTION
topologySpread-Selector matchte cnpg.io/cluster=drova-postgres — das trifft auch die 4 pgbouncer-Pooler (auf nipogi). Dadurch balanciert der Spread Postgres+Pooler zusammen → alle 3 DB-Instanzen landen auf msa2 (live verifiziert: postgres-1/4/6 alle msa2 = Totalausfall-Risiko bei msa2-Ausfall).

Fix: Selector auf cnpg.io/podRole=instance eingegrenzt → nur die 3 DB-Instanzen zählen in die Skew-Rechnung.

Rollout nach Merge + sync:
kubectl delete pod drova-postgres-4 -n drova
→ Replica wird neu geschedult, landet jetzt zwingend auf nipogi
→ 2 msa2 + 1 nipogi → msa2-Ausfall überlebbar (Operator promotet die nipogi-Replica).