### PR TITLE
disable cilium spire (→ istio ambient)

### DIFF
--- a/kubernetes/infrastructure/network/cilium/base/kustomization.yaml
+++ b/kubernetes/infrastructure/network/cilium/base/kustomization.yaml
@@ -21,51 +21,55 @@ helmCharts:
 # spire-agent DaemonSet. Override auf 3600s (Talos-upgrade-resilience).
 # Battle-tested 2026-05-14: ohne 1h-TTL läuft Token während Upgrade ab →
 # Agent crash → mTLS cluster-weit broken (war 26h+ unbemerkt!).
-patches:
-  - target:
-      kind: Namespace
-      name: cilium-spire
-    patch: |-
-      apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: cilium-spire
-        labels:
-          pod-security.kubernetes.io/enforce: privileged
-          pod-security.kubernetes.io/audit: privileged
-          pod-security.kubernetes.io/warn: privileged
-  - target:
-      kind: DaemonSet
-      name: spire-agent
-      namespace: cilium-spire
-    patch: |-
-      apiVersion: apps/v1
-      kind: DaemonSet
-      metadata:
-        name: spire-agent
-        namespace: cilium-spire
-        annotations:
-          argocd.argoproj.io/sync-wave: "3"
-      spec:
-        template:
-          spec:
-            volumes:
-              - name: spire-agent
-                projected:
-                  sources:
-                    - serviceAccountToken:
-                        path: spire-agent
-                        audience: spire-server
-                        expirationSeconds: 3600
-  - target:
-      kind: StatefulSet
-      name: spire-server
-      namespace: cilium-spire
-    patch: |-
-      apiVersion: apps/v1
-      kind: StatefulSet
-      metadata:
-        name: spire-server
-        namespace: cilium-spire
-        annotations:
-          argocd.argoproj.io/sync-wave: "2"
+# Cilium-SPIRE deaktiviert (Migration → Istio Ambient). Patches auskommentiert,
+# weil spire-agent/spire-server/cilium-spire ohne SPIRE nicht mehr gerendert werden
+# → Ziel existiert nicht → Build-Fehler. Re-enable: authentication.enabled=true (values.yaml)
+# + diesen Block uncomment.
+# patches:
+#   - target:
+#       kind: Namespace
+#       name: cilium-spire
+#     patch: |-
+#       apiVersion: v1
+#       kind: Namespace
+#       metadata:
+#         name: cilium-spire
+#         labels:
+#           pod-security.kubernetes.io/enforce: privileged
+#           pod-security.kubernetes.io/audit: privileged
+#           pod-security.kubernetes.io/warn: privileged
+#   - target:
+#       kind: DaemonSet
+#       name: spire-agent
+#       namespace: cilium-spire
+#     patch: |-
+#       apiVersion: apps/v1
+#       kind: DaemonSet
+#       metadata:
+#         name: spire-agent
+#         namespace: cilium-spire
+#         annotations:
+#           argocd.argoproj.io/sync-wave: "3"
+#       spec:
+#         template:
+#           spec:
+#             volumes:
+#               - name: spire-agent
+#                 projected:
+#                   sources:
+#                     - serviceAccountToken:
+#                         path: spire-agent
+#                         audience: spire-server
+#                         expirationSeconds: 3600
+#   - target:
+#       kind: StatefulSet
+#       name: spire-server
+#       namespace: cilium-spire
+#     patch: |-
+#       apiVersion: apps/v1
+#       kind: StatefulSet
+#       metadata:
+#         name: spire-server
+#         namespace: cilium-spire
+#         annotations:
+#           argocd.argoproj.io/sync-wave: "2"

--- a/kubernetes/infrastructure/network/cilium/base/values.yaml
+++ b/kubernetes/infrastructure/network/cilium/base/values.yaml
@@ -313,10 +313,10 @@ ingressController:
   enabled: false  # Not used — all routing via Envoy Gateway HTTPRoute
 
 authentication:
-  enabled: true
+  enabled: false   # Cilium-SPIRE-mTLS AUS — Migration → Istio Ambient (war: true)
   mutual:
     spire:
-      enabled: true
+      enabled: false
       # PSAT-Token-TTL (battle-tested 2026-05-14):
       # Default 600s (10min) → Talos-upgrade-rolling-restart läuft länger als
       # token-renewal-window → token expires → SPIRE-agent crash → mTLS broken

--- a/kubernetes/security/foundation/network-policies/tenants/drova/kustomization.yaml
+++ b/kubernetes/security/foundation/network-policies/tenants/drova/kustomization.yaml
@@ -3,7 +3,9 @@ kind: Kustomization
 
 # Drova tenant network policies — co-located for discoverability.
 # Managed by platform-security ApplicationSet (NOT drova-tenant).
-resources:
-  - mtls.yaml             # Drova SPIRE mTLS — production-ready
-  - default-deny.yaml     # Drova Microservices Default-Deny (added 2026-05-08)
+resources: []
+  # Cilium-SPIRE-mTLS deaktiviert (Migration → Istio Ambient).
+  # mtls.yaml braucht SPIRE; ohne mtls.yaml würde default-deny ALLES blocken → beide aus.
+  # - mtls.yaml             # Drova SPIRE mTLS — braucht SPIRE
+  # - default-deny.yaml     # Drova Microservices Default-Deny
   # egress.yaml — parked, will re-enable when stripe/mapbox FQDN-egress validated


### PR DESCRIPTION
Cilium-SPIRE mutual-auth (beta) AUS — Vorbereitung Migration zu Istio Ambient (sidecarless, GA).

Änderungen:
- cilium/base/values.yaml: authentication.enabled false (SPIRE-install weg)
- cilium/base/kustomization.yaml: die 3 spire-agent/server/namespace-Patches auskommentiert
  (ohne SPIRE existiert das Target nicht → würde kustomize-Build brechen)
- network-policies/tenants/drova/kustomization.yaml: mtls.yaml + default-deny.yaml aus
  (mtls braucht SPIRE; ohne mtls würde default-deny ALLES blocken → beide raus)

⚠️ Konsequenzen nach sync:
- SPIRE-Pods (cilium-spire ns) + drova-mtls/default-deny CNPs werden gepruned
- drova-Services reden dann OHNE mTLS-Identität + ohne Ingress-default-deny (interim,
  bis Istio Ambient das mTLS übernimmt). Test-Homelab → ok.
- WireGuard-encryption bleibt AN (separat von SPIRE) → Pod-Traffic weiter verschlüsselt
- Cilium reconfiguriert beim sync (kurzer Agent-Reload möglich)

Validiert: kustomize build ✓ (security + cilium), 0 spire-Ressourcen gerendert.