### PR TITLE
scheduling hardening

### DIFF
--- a/kubernetes/infrastructure/argocd/base/values.yaml
+++ b/kubernetes/infrastructure/argocd/base/values.yaml
@@ -1,5 +1,12 @@
 # ARGOCD CONFIGURATION
 
+global:
+  priorityClassName: platform-critical
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+
 configs:
   # CRITICAL: Secret Management
   # ArgoCD Helm chart auto-generates these secrets on first install:

--- a/kubernetes/infrastructure/certificates/cert-manager/base/values.yaml
+++ b/kubernetes/infrastructure/certificates/cert-manager/base/values.yaml
@@ -6,6 +6,7 @@ crds:
 global:
   leaderElection:
     namespace: cert-manager
+  priorityClassName: platform-critical
 
 # Enable Gateway API support
 extraArgs:
@@ -30,6 +31,14 @@ resources:
 
 webhook:
   replicaCount: 2
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: webhook
+              app.kubernetes.io/instance: cert-manager
+          topologyKey: kubernetes.io/hostname
   podDisruptionBudget:
     enabled: true
     minAvailable: 1
@@ -43,6 +52,14 @@ webhook:
 
 cainjector:
   replicaCount: 2
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: cainjector
+              app.kubernetes.io/instance: cert-manager
+          topologyKey: kubernetes.io/hostname
   podDisruptionBudget:
     enabled: true
     minAvailable: 1

--- a/kubernetes/infrastructure/ingress/gateway/base/envoy-proxy-config.yaml
+++ b/kubernetes/infrastructure/ingress/gateway/base/envoy-proxy-config.yaml
@@ -23,6 +23,14 @@ spec:
                       matchLabels:
                         gateway.envoyproxy.io/owning-gateway-name: envoy-gateway
                     topologyKey: kubernetes.io/hostname
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: topology.kubernetes.io/zone
+              whenUnsatisfiable: DoNotSchedule
+              nodeTaintsPolicy: Honor
+              labelSelector:
+                matchLabels:
+                  gateway.envoyproxy.io/owning-gateway-name: envoy-gateway
       envoyService:
         # MUSS Cluster sein: mit Local announced Cilium-L2 die LB-IP (192.168.0.152) auf
         # einem Node OHNE Envoy-Pod (Pods laufen nur auf Workern, IP landete auf ctrl-0)

--- a/kubernetes/infrastructure/ingress/gateway/base/pdb.yaml
+++ b/kubernetes/infrastructure/ingress/gateway/base/pdb.yaml
@@ -1,25 +1,8 @@
-# PodDisruptionBudgets für Envoy Gateway (battle-tested 2026-05-14).
+# PodDisruptionBudget für Envoy Gateway (battle-tested 2026-05-14).
 #
 # Heute hatte envoy-gateway-envoy-gateway-* 40 Restarts nach Talos-upgrade
 # (Exit Code 0 = "Completed" → ReplicaSet recreate-loop). PDB schützt davor.
 #
-# Envoy-Gateway-Operator vs Envoy-Proxy-Pods:
-#   - envoy-gateway:        Controller (Helm-Chart-Deployment)
-#   - envoy-gateway-envoy-* : Proxy-Pods (Operator-managed, prefixed with gateway-name)
-#
-# minAvailable: 1 → bei single-replica wird kubelet drain-block,
-# bei multi-replica überlebt mindestens 1 Pod.
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: envoy-gateway-controller
-  namespace: gateway
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: gateway-helm
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -32,14 +15,3 @@ spec:
     matchLabels:
       app.kubernetes.io/component: proxy
       app.kubernetes.io/managed-by: envoy-gateway
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: envoy-ratelimit
-  namespace: gateway
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: envoy-ratelimit

--- a/kubernetes/infrastructure/observability/jaeger/base/jaeger-v2.yaml
+++ b/kubernetes/infrastructure/observability/jaeger/base/jaeger-v2.yaml
@@ -144,13 +144,11 @@ spec:
 
   affinity:
     podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 100
-          podAffinityTerm:
-            labelSelector:
-              matchLabels:
-                app.kubernetes.io/name: jaeger
-            topologyKey: kubernetes.io/hostname
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: jaeger
+          topologyKey: kubernetes.io/hostname
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
@@ -3,10 +3,9 @@
 prometheus:
   # PodDisruptionBudget — Talos-upgrade-resilience (battle-tested 2026-05-14):
   # Ohne PDB konnte Talos-upgrade alle prometheus-Pods evicten → "Completed"-loop.
-  # minAvailable: 1 → mindestens 1 Replica überlebt rolling-node-drain.
   podDisruptionBudget:
     enabled: true
-    minAvailable: 1
+    maxUnavailable: 1
   prometheusSpec:
     # 1 Replica — RAM-Spar auf RAM-engen Hosts; Mimir hält die Long-Term-Daten.
     # (war 2 für HA; bei Pod-Restart kurze Scrape-Lücke, sonst nichts verloren.)

--- a/kubernetes/infrastructure/observability/opentelemetry/base/gateway.yaml
+++ b/kubernetes/infrastructure/observability/opentelemetry/base/gateway.yaml
@@ -19,6 +19,19 @@ metadata:
 spec:
   mode: deployment
   replicas: 3
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/instance: opentelemetry.otel-gateway
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/instance: opentelemetry.otel-gateway
   image: otel/opentelemetry-collector-contrib:0.152.0@sha256:f41d7995565df3733b7568702073a9c490792f9c6ac60684fe6a4da21a313f8d
   resources:
     requests:

--- a/kubernetes/infrastructure/observability/tempo/base/values.yaml
+++ b/kubernetes/infrastructure/observability/tempo/base/values.yaml
@@ -138,6 +138,8 @@ distributor:
 # HA: 2 replicas + RF=2 ensures trace-durability if 1 ingester crashes before S3-flush
 ingester:
   replicas: 2
+  podDisruptionBudget:
+    maxUnavailable: 1
   config:
     replication_factor: 2
   persistence:

--- a/kubernetes/infrastructure/observability/tempo/base/values.yaml
+++ b/kubernetes/infrastructure/observability/tempo/base/values.yaml
@@ -138,8 +138,7 @@ distributor:
 # HA: 2 replicas + RF=2 ensures trace-durability if 1 ingester crashes before S3-flush
 ingester:
   replicas: 2
-  podDisruptionBudget:
-    maxUnavailable: 1
+  maxUnavailable: 1
   config:
     replication_factor: 2
   persistence:

--- a/kubernetes/infrastructure/storage/radosgateway/base/ceph-object-store.yaml
+++ b/kubernetes/infrastructure/storage/radosgateway/base/ceph-object-store.yaml
@@ -21,6 +21,14 @@ spec:
     # HA: 2 instances. RGW serves Velero/Loki/Tempo/CNPG-backups + Drova-buckets.
     # 1 instance = SPOF: pod-crash mid-backup-window = ALL backups fail.
     instances: 2
+    placement:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: rook-ceph-rgw
     # NO LIMITS, only requests
     resources:
       requests:

--- a/kubernetes/platform/identity/keycloak/base/keycloak-cr.yaml
+++ b/kubernetes/platform/identity/keycloak/base/keycloak-cr.yaml
@@ -27,6 +27,9 @@ spec:
   image: quay.io/keycloak/keycloak:25.0.6@sha256:82c5b7a110456dbd42b86ea572e728878549954cc8bd03cd65410d75328095d2
   startOptimized: false                     # JIT optimization for first start
 
+  scheduling:
+    priorityClassName: platform-critical
+
   db:
     vendor: postgres
     host: keycloak-db-rw.keycloak.svc.cluster.local

--- a/kubernetes/platform/identity/keycloak/base/pdb.yaml
+++ b/kubernetes/platform/identity/keycloak/base/pdb.yaml
@@ -17,8 +17,7 @@ metadata:
     app.kubernetes.io/part-of: platform-identity
 spec:
   # 2026-05-16 — KC reduced to 1 replica (cache=local + multi-pod broke OIDC).
-  # minAvailable: 1 because PDB can't require more than total replicas.
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: keycloak

--- a/kubernetes/platform/identity/keycloak/db/base/pgbouncer-pooler.yaml
+++ b/kubernetes/platform/identity/keycloak/db/base/pgbouncer-pooler.yaml
@@ -10,6 +10,17 @@ spec:
     name: keycloak-db
   instances: 2
   type: rw
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    cnpg.io/poolerName: keycloak-db-pooler
   pgbouncer:
     poolMode: transaction
     parameters:

--- a/kubernetes/tenants/drova/postgres/base/pgbouncer-pooler-ro.yaml
+++ b/kubernetes/tenants/drova/postgres/base/pgbouncer-pooler-ro.yaml
@@ -13,6 +13,17 @@ spec:
     name: drova-postgres
   instances: 2
   type: ro
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    cnpg.io/poolerName: drova-postgres-pooler-ro
   pgbouncer:
     poolMode: transaction
     parameters:

--- a/kubernetes/tenants/drova/postgres/base/pgbouncer-pooler.yaml
+++ b/kubernetes/tenants/drova/postgres/base/pgbouncer-pooler.yaml
@@ -12,6 +12,19 @@ spec:
     name: drova-postgres
   instances: 2
   type: rw
+  # beide Pooler-Replicas nicht auf denselben Node (worker-1-Klumpen aufloesen).
+  # podAntiAffinity wirkt (im Gegensatz zu topologySpread auf diesem Cluster).
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    cnpg.io/poolerName: drova-postgres-pooler
   pgbouncer:
     poolMode: transaction
     parameters:

--- a/kubernetes/tenants/drova/postgres/base/postgres-cluster.yaml
+++ b/kubernetes/tenants/drova/postgres/base/postgres-cluster.yaml
@@ -66,6 +66,7 @@ spec:
       labelSelector:
         matchLabels:
           cnpg.io/cluster: drova-postgres
+          cnpg.io/podRole: instance
   # Rook-Ceph disk I/O is slow — replicas need more time for WAL replay on startup
   probes:
     startup:

--- a/kubernetes/tenants/n8n-prod/postgres/base/cluster.yaml
+++ b/kubernetes/tenants/n8n-prod/postgres/base/cluster.yaml
@@ -40,7 +40,15 @@ spec:
       secret:
         name: n8n-postgres-credentials
   affinity:
-    podAntiAffinityType: preferred
+    podAntiAffinityType: required
     topologyKey: kubernetes.io/hostname
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          cnpg.io/cluster: n8n-postgres
+          cnpg.io/podRole: instance
   monitoring:
     enablePodMonitor: true

--- a/kubernetes/tenants/n8n-prod/postgres/base/pgbouncer-pooler.yaml
+++ b/kubernetes/tenants/n8n-prod/postgres/base/pgbouncer-pooler.yaml
@@ -10,6 +10,17 @@ spec:
     name: n8n-postgres
   instances: 2
   type: rw
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    cnpg.io/poolerName: n8n-postgres-pooler
   pgbouncer:
     poolMode: transaction
     parameters:


### PR DESCRIPTION
audit ergebnis: replicas liefen teils gestapelt (node/zone) + 8 pdbs blockten jeden drain

- drova-postgres zone-spread selector um cnpg.io/podRole=instance ergaenzt — der spread zaehlte die 4 pooler mit (alle nipogi) und schob deshalb alle db-instanzen nach msa2
- pooler antiaffinity zurueck (revert vom revert) + keycloak-db/n8n-pooler gleich mit
- n8n-postgres: required AA + zone-spread wie drova
- stuck-drain pdbs: gateway-controller + ratelimit pdb raus (single replica), keycloak/prometheus auf maxUnavailable 1, tempo-ingester pdb maxUnavailable 1 (war 0)
- envoy-proxy + rgw + otel-gateway: zone/hostname topologySpread
- jaeger collector + cert-manager webhook/cainjector: required AA (klumpten auf einem node)
- priorityClassName platform-critical fuer argocd, cert-manager, keycloak
- argocd global zone-spread (repo-server/redis-ha lagen komplett auf msa2)

n8n pdbs (main/webhook/worker) leben in der eingefrorenen n8n-prod app (source-pfad existiert nicht mehr) — separat