### PR TITLE
pooler schema fix

### DIFF
--- a/kubernetes/infrastructure/ingress/gateway/base/envoy-proxy-config.yaml
+++ b/kubernetes/infrastructure/ingress/gateway/base/envoy-proxy-config.yaml
@@ -28,6 +28,8 @@ spec:
               topologyKey: topology.kubernetes.io/zone
               whenUnsatisfiable: DoNotSchedule
               nodeTaintsPolicy: Honor
+              matchLabelKeys:
+                - pod-template-hash
               labelSelector:
                 matchLabels:
                   gateway.envoyproxy.io/owning-gateway-name: envoy-gateway

--- a/kubernetes/infrastructure/observability/opentelemetry/base/gateway.yaml
+++ b/kubernetes/infrastructure/observability/opentelemetry/base/gateway.yaml
@@ -23,12 +23,16 @@ spec:
     - maxSkew: 1
       topologyKey: kubernetes.io/hostname
       whenUnsatisfiable: DoNotSchedule
+      matchLabelKeys:
+        - pod-template-hash
       labelSelector:
         matchLabels:
           app.kubernetes.io/instance: opentelemetry.otel-gateway
     - maxSkew: 1
       topologyKey: topology.kubernetes.io/zone
       whenUnsatisfiable: ScheduleAnyway
+      matchLabelKeys:
+        - pod-template-hash
       labelSelector:
         matchLabels:
           app.kubernetes.io/instance: opentelemetry.otel-gateway

--- a/kubernetes/platform/identity/keycloak/base/keycloak-cr.yaml
+++ b/kubernetes/platform/identity/keycloak/base/keycloak-cr.yaml
@@ -27,9 +27,6 @@ spec:
   image: quay.io/keycloak/keycloak:25.0.6@sha256:82c5b7a110456dbd42b86ea572e728878549954cc8bd03cd65410d75328095d2
   startOptimized: false                     # JIT optimization for first start
 
-  scheduling:
-    priorityClassName: platform-critical
-
   db:
     vendor: postgres
     host: keycloak-db-rw.keycloak.svc.cluster.local

--- a/kubernetes/platform/identity/keycloak/db/base/pgbouncer-pooler.yaml
+++ b/kubernetes/platform/identity/keycloak/db/base/pgbouncer-pooler.yaml
@@ -12,6 +12,7 @@ spec:
   type: rw
   template:
     spec:
+      containers: []
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/kubernetes/tenants/drova/postgres/base/pgbouncer-pooler-ro.yaml
+++ b/kubernetes/tenants/drova/postgres/base/pgbouncer-pooler-ro.yaml
@@ -15,6 +15,7 @@ spec:
   type: ro
   template:
     spec:
+      containers: []
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/kubernetes/tenants/drova/postgres/base/pgbouncer-pooler.yaml
+++ b/kubernetes/tenants/drova/postgres/base/pgbouncer-pooler.yaml
@@ -16,6 +16,7 @@ spec:
   # podAntiAffinity wirkt (im Gegensatz zu topologySpread auf diesem Cluster).
   template:
     spec:
+      containers: []
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/kubernetes/tenants/n8n-prod/postgres/base/pgbouncer-pooler.yaml
+++ b/kubernetes/tenants/n8n-prod/postgres/base/pgbouncer-pooler.yaml
@@ -12,6 +12,7 @@ spec:
   type: rw
   template:
     spec:
+      containers: []
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
argocd comparison errors nach #341:

- pooler template braucht containers: [] sonst failt server-side diff (spec.template.spec.containers required) — das war auch der grund fuer den alten revert 81d0c6fa
- keycloak crd (operator version) kennt spec.scheduling nicht → priorityClassName raus
- matchLabelKeys pod-template-hash in envoy/otel spreads (rolling zaehlte alte pods mit → beide envoy landeten auf msa2)