### PR TITLE
keycloak priority

### DIFF
--- a/kubernetes/platform/identity/keycloak/base/keycloak-cr.yaml
+++ b/kubernetes/platform/identity/keycloak/base/keycloak-cr.yaml
@@ -64,6 +64,7 @@ spec:
   unsupported:
     podTemplate:
       spec:
+        priorityClassName: platform-critical
         containers:
           - name: keycloak
             env:


### PR DESCRIPTION
platform-critical via unsupported.podTemplate (der block existiert schon fuer die realm-import env-vars) — spec.scheduling kennt die operator-crd noch nicht