### PR TITLE
descheduler + scheduling policies

### DIFF
--- a/kubernetes/applicationsets/infrastructure/controllers-stack.yaml
+++ b/kubernetes/applicationsets/infrastructure/controllers-stack.yaml
@@ -37,6 +37,7 @@ spec:
                 - { component: renovate-jobs,     appName: renovate-jobs,     path: kubernetes/platform/gitops/renovate/base,                        namespace: renovate-operator,     wave: "10" }
                 - { component: keycloak-operator, appName: keycloak-operator, path: kubernetes/infrastructure/operators/keycloak/overlays/prod,       namespace: keycloak,              wave: "-50" }
                 - { component: argo-rollouts,   appName: argo-rollouts,   path: kubernetes/infrastructure/operators/argo-rollouts/overlays/prod,   namespace: argo-rollouts,   wave: "-50" }
+                - { component: descheduler,     appName: descheduler,     path: kubernetes/infrastructure/operators/descheduler/overlays/prod,     namespace: kube-system,     wave: "0" }
                 - { component: keda,            appName: keda,            path: kubernetes/infrastructure/operators/keda/overlays/prod,            namespace: keda,            wave: "-50" }
                 - { component: argocd,          appName: argocd,          path: kubernetes/infrastructure/argocd/overlays/prod,          namespace: argocd,          wave: "90" }
   template:

--- a/kubernetes/infrastructure/operators/descheduler/base/kustomization.yaml
+++ b/kubernetes/infrastructure/operators/descheduler/base/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+
+helmCharts:
+  - name: descheduler
+    repo: https://kubernetes-sigs.github.io/descheduler/
+    version: 0.36.0
+    releaseName: descheduler
+    namespace: kube-system
+    valuesFile: values.yaml

--- a/kubernetes/infrastructure/operators/descheduler/base/values.yaml
+++ b/kubernetes/infrastructure/operators/descheduler/base/values.yaml
@@ -1,0 +1,38 @@
+kind: CronJob
+schedule: "*/30 * * * *"
+
+# dry-run phase: erst logs lesen, dann flag entfernen
+cmdOptions:
+  v: 3
+  dry-run: true
+
+deschedulerPolicy:
+  profiles:
+    - name: rebalance
+      pluginConfig:
+        - name: DefaultEvictor
+          args:
+            evictSystemCriticalPods: false
+            evictLocalStoragePods: false
+            ignorePvcPods: true
+            nodeFit: true
+            minReplicas: 2
+        - name: RemoveDuplicates
+        - name: RemovePodsViolatingTopologySpreadConstraint
+          args:
+            constraints:
+              - DoNotSchedule
+              - ScheduleAnyway
+      plugins:
+        balance:
+          enabled:
+            - RemoveDuplicates
+            - RemovePodsViolatingTopologySpreadConstraint
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi

--- a/kubernetes/infrastructure/operators/descheduler/overlays/prod/kustomization.yaml
+++ b/kubernetes/infrastructure/operators/descheduler/overlays/prod/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base

--- a/kubernetes/security/compliance/kustomization.yaml
+++ b/kubernetes/security/compliance/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - namespace.yaml
   - kube-bench
   - kyverno-policies.yaml
+  - scheduling-policies.yaml
   # - kubescape   # disabled 2026-05-18 — OOMKill-loop on worker-1
   - tetragon   # re-enabled 2026-06-08: tracefs-mount-fix; agent-first ohne TracingPolicy
   - honeytoken   # 2026-06-08: Decoy-Pod + Tetragon-Canary auf Fake-AWS-Creds

--- a/kubernetes/security/compliance/scheduling-policies.yaml
+++ b/kubernetes/security/compliance/scheduling-policies.yaml
@@ -1,0 +1,114 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-pdb
+  annotations:
+    policies.kyverno.io/title: Require PodDisruptionBudget
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      Workloads mit >=2 Replicas brauchen ein PDB im Namespace,
+      sonst kann ein Node-Drain alle Replicas gleichzeitig evicten.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: pdb-exists-in-namespace
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+      preconditions:
+        all:
+          - key: "{{ request.object.spec.replicas || `1` }}"
+            operator: GreaterThan
+            value: 1
+      context:
+        - name: pdbcount
+          apiCall:
+            urlPath: "/apis/policy/v1/namespaces/{{ request.namespace }}/poddisruptionbudgets"
+            jmesPath: "items | length(@)"
+      validate:
+        message: ">=2 replicas aber kein PodDisruptionBudget im Namespace {{ request.namespace }}"
+        deny:
+          conditions:
+            all:
+              - key: "{{ pdbcount }}"
+                operator: Equals
+                value: 0
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-spread-or-antiaffinity
+  annotations:
+    policies.kyverno.io/title: Require Spread or AntiAffinity
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      Workloads mit >=2 Replicas ohne topologySpreadConstraints und ohne
+      podAntiAffinity koennen komplett auf einem Node/Host landen.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: spread-or-antiaffinity
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+      preconditions:
+        all:
+          - key: "{{ request.object.spec.replicas || `1` }}"
+            operator: GreaterThan
+            value: 1
+      validate:
+        message: ">=2 replicas ohne topologySpreadConstraints und ohne podAntiAffinity"
+        deny:
+          conditions:
+            all:
+              - key: "{{ request.object.spec.template.spec.topologySpreadConstraints[] || `[]` | length(@) }}"
+                operator: Equals
+                value: 0
+              - key: "{{ request.object.spec.template.spec.affinity.podAntiAffinity || `{}` | keys(@) | length(@) }}"
+                operator: Equals
+                value: 0
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-system-priorityclass
+  annotations:
+    policies.kyverno.io/title: Restrict system PriorityClasses
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/description: >-
+      system-node-critical/system-cluster-critical verdraengen ALLES
+      (Preemption) — nur System-Namespaces duerfen sie nutzen.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: no-system-priority-outside-system-ns
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - rook-ceph
+      preconditions:
+        all:
+          - key: "{{ request.object.spec.priorityClassName || '' }}"
+            operator: AnyIn
+            value:
+              - system-node-critical
+              - system-cluster-critical
+      validate:
+        message: "system-* PriorityClass ausserhalb von System-Namespaces"
+        deny: {}


### PR DESCRIPTION
enforcement-schicht zum scheduling-hardening:

- descheduler 0.36 als cronjob alle 30min, ERST DRY-RUN (logs lesen, dann flag raus). plugins: RemoveDuplicates (coredns-klumpen!) + RemovePodsViolatingTopologySpreadConstraint. safety: nodeFit, minReplicas 2, ignorePvcPods, keine system-critical evictions
- 3 kyverno policies (alle Audit): require-pdb (replicas>=2), require-spread-or-antiaffinity (replicas>=2), restrict-system-priorityclass (system-* nur kube-system/rook-ceph)