### PR TITLE
enforce scheduling policies

### DIFF
--- a/kubernetes/infrastructure/certificates/cert-manager/base/values.yaml
+++ b/kubernetes/infrastructure/certificates/cert-manager/base/values.yaml
@@ -17,6 +17,15 @@ extraArgs:
 # Leader-election aktiv im cert-manager-NS → multi-replica-safe.
 replicaCount: 2
 
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: cert-manager
+            app.kubernetes.io/instance: cert-manager
+        topologyKey: kubernetes.io/hostname
+
 podDisruptionBudget:
   enabled: true
   minAvailable: 1

--- a/kubernetes/infrastructure/observability/elasticsearch/base/cluster/elasticsearch-cluster.yaml
+++ b/kubernetes/infrastructure/observability/elasticsearch/base/cluster/elasticsearch-cluster.yaml
@@ -78,7 +78,7 @@ spec:
             app.kubernetes.io/component: elasticsearch
         spec:
           # ENTERPRISE: Critical priority to survive node pressure
-          priorityClassName: system-cluster-critical
+          priorityClassName: platform-critical
           # CEPH STORAGE OPTIMIZATION: Set proper ownership for ES data directory
           # Elasticsearch runs as UID 1000, GID 1000 - fsGroup ensures volume ownership
           # OnRootMismatch: Only change ownership if root dir doesn't match fsGroup (faster on Ceph)

--- a/kubernetes/infrastructure/observability/vector/base/vector-aggregator.yaml
+++ b/kubernetes/infrastructure/observability/vector/base/vector-aggregator.yaml
@@ -21,6 +21,26 @@ spec:
         app.kubernetes.io/component: aggregator
     spec:
       serviceAccountName: vector
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          nodeTaintsPolicy: Honor
+          matchLabelKeys:
+            - pod-template-hash
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: vector
+              app.kubernetes.io/component: aggregator
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          matchLabelKeys:
+            - pod-template-hash
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: vector
+              app.kubernetes.io/component: aggregator
       containers:
         - name: vector
           image: ghcr.io/vectordotdev/vector:0.55.0-debian

--- a/kubernetes/infrastructure/operators/argo-rollouts/base/values.yaml
+++ b/kubernetes/infrastructure/operators/argo-rollouts/base/values.yaml
@@ -3,6 +3,13 @@
 # Controller Configuration
 controller:
   replicas: 2  # HA for enterprise
+  pdb:
+    enabled: true
+    maxUnavailable: 1
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
   resources:
     limits:
       cpu: 500m

--- a/kubernetes/security/compliance/scheduling-policies.yaml
+++ b/kubernetes/security/compliance/scheduling-policies.yaml
@@ -9,7 +9,8 @@ metadata:
       Workloads mit >=2 Replicas brauchen ein PDB im Namespace,
       sonst kann ein Node-Drain alle Replicas gleichzeitig evicten.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: Enforce
+  failurePolicy: Ignore
   background: true
   rules:
     - name: pdb-exists-in-namespace
@@ -19,6 +20,11 @@ spec:
               kinds:
                 - Deployment
                 - StatefulSet
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
       preconditions:
         all:
           - key: "{{ request.object.spec.replicas || `1` }}"
@@ -49,7 +55,8 @@ metadata:
       Workloads mit >=2 Replicas ohne topologySpreadConstraints und ohne
       podAntiAffinity koennen komplett auf einem Node/Host landen.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: Enforce
+  failurePolicy: Ignore
   background: true
   rules:
     - name: spread-or-antiaffinity
@@ -59,6 +66,11 @@ spec:
               kinds:
                 - Deployment
                 - StatefulSet
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
       preconditions:
         all:
           - key: "{{ request.object.spec.replicas || `1` }}"
@@ -87,7 +99,8 @@ metadata:
       system-node-critical/system-cluster-critical verdraengen ALLES
       (Preemption) — nur System-Namespaces duerfen sie nutzen.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: Enforce
+  failurePolicy: Ignore
   background: true
   rules:
     - name: no-system-priority-outside-system-ns
@@ -102,6 +115,7 @@ spec:
               namespaces:
                 - kube-system
                 - rook-ceph
+                - cilium-spire
       preconditions:
         all:
           - key: "{{ request.object.spec.priorityClassName || '' }}"


### PR DESCRIPTION
kyverno audit findings triaged: argo-rollouts pdb+spread, cert-manager controller antiaffinity, vector-aggregator spread, es priority system-cluster-critical -> platform-critical. excludes: kube-system (talos-managed), cilium-spire (node infra). policies audit -> enforce, failurePolicy ignore (fail-open).