### PR TITLE
prometheus pdb helm merge fix

### DIFF
--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
@@ -5,6 +5,7 @@ prometheus:
   # Ohne PDB konnte Talos-upgrade alle prometheus-Pods evicten → "Completed"-loop.
   podDisruptionBudget:
     enabled: true
+    minAvailable: null
     maxUnavailable: 1
   prometheusSpec:
     # 1 Replica — RAM-Spar auf RAM-engen Hosts; Mimir hält die Long-Term-Daten.


### PR DESCRIPTION
chart default minAvailable merged with overlay maxUnavailable -> invalid pdb (both set), rendered manifest broken since #341. null override deletes the key.