### PR TITLE
osd memory target 2gi

### DIFF
--- a/kubernetes/infrastructure/network/cilium/base/values.yaml
+++ b/kubernetes/infrastructure/network/cilium/base/values.yaml
@@ -78,8 +78,8 @@ ipam:
   multiPoolPreAllocation: ""
 
 operator:
-  # HIGH AVAILABILITY - 3 replicas for zero downtime
-  replicas: 3
+  # HIGH AVAILABILITY - 2 replicas for zero downtime
+  replicas: 2
 
   rollOutPods: true
   prometheus:

--- a/kubernetes/infrastructure/storage/rook-ceph/base/cluster.yaml
+++ b/kubernetes/infrastructure/storage/rook-ceph/base/cluster.yaml
@@ -172,7 +172,7 @@ spec:
       # Request MUST be osd_memory_target + ~25% overhead (threads/processes)
       requests:
         cpu: "500m"
-        memory: "3840Mi"  # 3Gi target + 25%; war 5Gi (reservierte ~30Gi, real ~10Gi)
+        memory: "2560Mi"  # 2Gi target + 25%; war 3840Mi/3Gi-target (ns real 15Gi)
     prepareosd:
       requests:
         cpu: "50m"    # 250m → 100m → 50m: light disk-scan, schedules even on saturated nipogi-workers


### PR DESCRIPTION
osd requests 3840Mi -> 2560Mi (rook derives osd_memory_target 3Gi -> 2Gi, ~5GB across 5 osds). samsung osds fine with less cache, msa2 tradeoff accepted. + cilium operator 3 -> 2 replicas.