### PR TITLE
socketlb hostns only

### DIFF
--- a/kubernetes/infrastructure/network/cilium/base/values.yaml
+++ b/kubernetes/infrastructure/network/cilium/base/values.yaml
@@ -373,4 +373,4 @@ cni:
   exclusive: false
 
 socketLB:
-  hostNamespaceOnly: false  # Enable socket-based LB across all namespaces (fixes DNS resolution)
+  hostNamespaceOnly: true  # istio ambient: pod-traffic muss fuer ztunnel sichtbar bleiben (socket-LB nur host-ns)

--- a/tofu/talos/inline-manifests/cilium-values.yaml
+++ b/tofu/talos/inline-manifests/cilium-values.yaml
@@ -74,9 +74,9 @@ gatewayAPI:
   gatewayClass:
     create: "true"
 
-# Fix for DNS resolution issues - ensure socketLB works across all namespaces
+# istio ambient: socket-LB nur im host-ns, pod-traffic geht durch ztunnel
 socketLB:
-  hostNamespaceOnly: false
+  hostNamespaceOnly: true
 
 # DNS Proxy for DNS visibility and FQDN-based policies
 dnsProxy:


### PR DESCRIPTION
istio ambient phase 0: cilium socket-lb scoped to host-ns so ztunnel sees pod traffic. both copies (gitops + talos inline-manifest) in sync. cilium agents roll (rollOutPods).