### PR TITLE
istio ambient control plane

### DIFF
--- a/kubernetes/applicationsets/infrastructure/controllers-stack.yaml
+++ b/kubernetes/applicationsets/infrastructure/controllers-stack.yaml
@@ -37,6 +37,7 @@ spec:
                 - { component: renovate-jobs,     appName: renovate-jobs,     path: kubernetes/platform/gitops/renovate/base,                        namespace: renovate-operator,     wave: "10" }
                 - { component: keycloak-operator, appName: keycloak-operator, path: kubernetes/infrastructure/operators/keycloak/overlays/prod,       namespace: keycloak,              wave: "-50" }
                 - { component: argo-rollouts,   appName: argo-rollouts,   path: kubernetes/infrastructure/operators/argo-rollouts/overlays/prod,   namespace: argo-rollouts,   wave: "-50" }
+                - { component: sail-operator,   appName: sail-operator,   path: kubernetes/infrastructure/operators/sail-operator/overlays/prod,   namespace: sail-operator,   wave: "-50" }
                 - { component: descheduler,     appName: descheduler,     path: kubernetes/infrastructure/operators/descheduler/overlays/prod,     namespace: kube-system,     wave: "0" }
                 - { component: keda,            appName: keda,            path: kubernetes/infrastructure/operators/keda/overlays/prod,            namespace: keda,            wave: "-50" }
                 - { component: argocd,          appName: argocd,          path: kubernetes/infrastructure/argocd/overlays/prod,          namespace: argocd,          wave: "90" }

--- a/kubernetes/applicationsets/infrastructure/network-stack.yaml
+++ b/kubernetes/applicationsets/infrastructure/network-stack.yaml
@@ -23,6 +23,7 @@ spec:
           - list:
               elements:
                 - { component: cilium,        appName: cilium,        path: kubernetes/infrastructure/network/cilium/overlays/prod,        namespace: kube-system,  wave: "0" }
+                - { component: istio,         appName: istio-control-plane, path: kubernetes/infrastructure/network/istio-control-plane,   namespace: istio-system, wave: "5" }
                 - { component: gateway,       appName: gateway,       path: kubernetes/infrastructure/ingress/gateway/overlays/prod,       namespace: gateway,      wave: "70" }
                 - { component: cloudflared,   appName: cloudflared,   path: kubernetes/infrastructure/ingress/cloudflared/overlays/prod,   namespace: cloudflared,  wave: "70" }
                 - { component: redis-gateway, appName: redis-gateway, path: kubernetes/infrastructure/ingress/redis-gateway,               namespace: gateway,      wave: "70" }

--- a/kubernetes/infrastructure/network/istio-control-plane/istio-cni.yaml
+++ b/kubernetes/infrastructure/network/istio-control-plane/istio-cni.yaml
@@ -1,17 +1,17 @@
 apiVersion: sailoperator.io/v1
-kind: ZTunnel
+kind: IstioCNI
 metadata:
   name: default
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   version: v1.30.0
-  namespace: istio-system
-  profile: ambient
+  namespace: istio-cni
   values:
-    resources:
-      requests:
-        cpu: 50m
-        memory: 128Mi
-      limits:
-        memory: 512Mi
+    cni:
+      ambient:
+        enabled: true
+      excludeNamespaces:
+        - istio-system
+        - istio-cni
+        - kube-system

--- a/kubernetes/infrastructure/network/istio-control-plane/istio-control-plane.yaml
+++ b/kubernetes/infrastructure/network/istio-control-plane/istio-control-plane.yaml
@@ -1,75 +1,38 @@
 # Istio Control Plane managed by Sail Operator
-# This replaces the traditional IstioOperator CR
 apiVersion: sailoperator.io/v1
 kind: Istio
 metadata:
   name: default
   namespace: istio-system
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  # REQUIRED: Target namespace for Istio installation
   namespace: istio-system
+  version: v1.30.0
+  profile: ambient
 
-  # Istio Version to deploy
-  version: v1.27.1
-
-  # Update Strategy - RevisionBased for zero-downtime updates
   updateStrategy:
-    type: RevisionBased
+    type: InPlace
 
-  # Istio Configuration (Helm values)
   values:
     global:
       meshID: mesh1
       network: network1
 
-      # Proxy configuration (Envoy sidecar)
-      proxy:
-        resources:
-          limits:
-            cpu: 500m      # Increased for burst traffic (was 100m)
-            memory: 512Mi  # Prevents OOMKill under load (was 128Mi)
-          requests:
-            cpu: 50m       # Higher baseline (was 10m)
-            memory: 128Mi  # Reasonable request (was 40Mi)
-
     pilot:
-      # Resource configuration for Istiod
       resources:
         limits:
           cpu: 500m
-          memory: 2048Mi
+          memory: 1Gi
         requests:
           cpu: 100m
-          memory: 128Mi
-
-      # Single replica for homelab (reduced from 2 to save resources)
+          memory: 512Mi
       replicaCount: 1
+      autoscaleEnabled: false
 
-      # CRITICAL: Spread istiod across nodes (prevents all on one worker)
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  app: istiod
-              topologyKey: kubernetes.io/hostname
-
-      # Autoscaling (HPA) - Homelab settings (disabled for single replica)
-      autoscaleEnabled: false  # Disabled - single replica mode
-      autoscaleMin: 1          # Homelab: reduced from 2
-      autoscaleMax: 2          # Homelab: reduced from 3
-
-      # Environment-specific settings
-      env:
-        PILOT_TRACE_SAMPLING: "0.01"     # 1% sampling (was 100%)
-        PILOT_ENABLE_AMBIENT: "true"     # Ambient mesh support
-        PILOT_ENABLE_CROSS_CLUSTER_WORKLOAD_ENTRY: "true"  # Multi-cluster support
-
-    # Security settings
     meshConfig:
-      defaultConfig:
-        proxyStatsMatcher:
-          inclusionRegexps:
-            - ".*circuit_breakers.*"
-            - ".*upstream_rq_retry.*"
-            - ".*_cx_.*"
+      extensionProviders:
+        - name: opentelemetry
+          opentelemetry:
+            service: otel-collector-collector.opentelemetry.svc.cluster.local
+            port: 4317

--- a/kubernetes/infrastructure/network/istio-control-plane/kustomization.yaml
+++ b/kubernetes/infrastructure/network/istio-control-plane/kustomization.yaml
@@ -1,22 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-# Note: Parent commonAnnotations will override, need to patch
-
-namespace: istio-system
 
 resources:
+  - namespaces.yaml
   - istio-control-plane.yaml
-  - istiod-service-alias.yaml  # Service alias for ztunnel compatibility
-  # - ztunnel.yaml  # DISABLED: Using Sidecar mode instead of Ambient
-  - telemetry-config.yaml  # Istio Telemetry in istio-system
-  - global-peer-authentication.yaml  # Global mTLS STRICT mode
-  # ServiceMonitor moved to infrastructure/monitoring/servicemonitors/
-
-patches:
-  - target:
-      kind: Istio
-      name: default
-    patch: |-
-      - op: replace
-        path: /metadata/annotations/argocd.argoproj.io~1sync-wave
-        value: "2"
+  - istio-cni.yaml
+  - ztunnel.yaml
+  - telemetry-config.yaml
+  # - global-peer-authentication.yaml  # Phase 3: STRICT erst per-Namespace nach Ambient-Enrollment
+  # - istiod-service-alias.yaml  # nur fuer RevisionBased noetig, InPlace erstellt istiod-Service selbst

--- a/kubernetes/infrastructure/network/istio-control-plane/namespaces.yaml
+++ b/kubernetes/infrastructure/network/istio-control-plane/namespaces.yaml
@@ -1,0 +1,18 @@
+# istio-cni node-agent + ztunnel brauchen privileged (NET_ADMIN, hostPath) — Cluster-Default enforce=baseline
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-cni
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/kubernetes/infrastructure/operators/sail-operator/base/kustomization.yaml
+++ b/kubernetes/infrastructure/operators/sail-operator/base/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: sail-operator
+
+helmCharts:
+  - name: sail-operator
+    repo: https://istio-ecosystem.github.io/sail-operator
+    version: 1.30.0
+    releaseName: sail-operator
+    namespace: sail-operator
+    includeCRDs: true

--- a/kubernetes/infrastructure/operators/sail-operator/overlays/prod/kustomization.yaml
+++ b/kubernetes/infrastructure/operators/sail-operator/overlays/prod/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base


### PR DESCRIPTION
phase 1: sail-operator 1.30.0 (controllers-stack) + istio cr v1.30.0 ambient profile inplace + istiocni (chained after cilium, ambient enabled) + ztunnel. peerauth stays permissive (strict = phase 3 per-ns). extensionProvider otel statt jaeger-direkt. privileged pss for istio-system/istio-cni. no namespace enrolled yet - zero workload impact.