### PR TITLE
istio fixes

### DIFF
--- a/kubernetes/infrastructure/network/istio-control-plane/ztunnel.yaml
+++ b/kubernetes/infrastructure/network/istio-control-plane/ztunnel.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   version: v1.30.0
   namespace: istio-system
-  profile: ambient
   values:
     resources:
       requests:

--- a/kubernetes/security/compliance/scheduling-policies.yaml
+++ b/kubernetes/security/compliance/scheduling-policies.yaml
@@ -116,6 +116,8 @@ spec:
                 - kube-system
                 - rook-ceph
                 - cilium-spire
+                - istio-system
+                - istio-cni
       preconditions:
         all:
           - key: "{{ request.object.spec.priorityClassName || '' }}"


### PR DESCRIPTION
ztunnel v1 schema dropped spec.profile. kyverno priorityclass exclude for istio-system/istio-cni (cni node agent + ztunnel legitimately use system-node-critical).