### PR TITLE
mesh + gap observability

### DIFF
--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/istio.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/istio.yaml
@@ -1,0 +1,46 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: network-istio
+  labels:
+    release: kube-prometheus-stack
+spec:
+  # Mesh traegt noch keinen Prod-Traffic (Phase 1-2) → alles warning.
+  # Nach drova-Enrollment (Phase 3): IstiodDown + ZtunnelNodeDown auf critical ziehen.
+  groups:
+    - name: istio-ticket
+      interval: 60s
+      rules:
+        - alert: IstiodDown
+          expr: absent(up{job="istiod"} == 1)
+          for: 5m
+          labels:
+            severity: warning
+            component: network
+            priority: P2
+          annotations:
+            summary: "istiod down — Mesh-Control-Plane weg"
+            description: "Keine xDS-Config/Cert-Ausstellung mehr; laufender ambient-Traffic laeuft weiter, neue Pods/Cert-Rotation blockiert."
+            action: "kubectl -n istio-system rollout restart deploy/istiod; sail-operator Status pruefen."
+        - alert: ZtunnelNodeDown
+          expr: sum(up{job=~".*ztunnel.*"} == 1) < 6
+          for: 10m
+          labels:
+            severity: warning
+            component: network
+            priority: P2
+          annotations:
+            summary: "ztunnel fehlt auf mind. einem Worker"
+            description: "Ambient-mTLS-Datapath auf betroffenem Node tot — enrollte Pods dort verlieren Mesh-Traffic."
+            action: "kubectl -n istio-system get pods -l app=ztunnel -o wide; DaemonSet-Events pruefen."
+        - alert: IstioRootCertExpiringSoon
+          expr: (citadel_server_root_cert_expiry_timestamp - time()) < 30 * 24 * 3600
+          for: 1h
+          labels:
+            severity: warning
+            component: network
+            priority: P2
+          annotations:
+            summary: "Istio Root-CA laeuft in <30d ab"
+            description: "Alle Workload-Identitaeten haengen an dieser CA — Ablauf = Mesh-weiter mTLS-Ausfall."
+            action: "Root-Cert-Rotation planen (istiod self-signed CA, 10y default — Alert = Anomalie)."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 resources:
   - cilium.yaml
   - ingress.yaml
+  - istio.yaml
   - vpn.yaml

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/operators.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/operators.yaml
@@ -36,3 +36,15 @@ spec:
             summary: "CloudNativePG operator down"
             description: "PostgreSQL cluster management blocked (failover/scaling/backup orchestration) — running DBs keep serving."
             action: "kubectl -n cnpg-system rollout restart deploy/cnpg-controller-manager; running DBs keep serving meanwhile."
+
+        - alert: KEDAScalerErrors
+          expr: sum(rate(keda_scaler_detail_errors_total[10m])) > 0
+          for: 15m
+          labels:
+            severity: warning
+            component: platform
+            priority: P2
+          annotations:
+            summary: "KEDA scaler errors — autoscaling frozen"
+            description: "Scaler cannot query its source (Kafka lag / Prometheus) — workloads stay at current replica count."
+            action: "kubectl -n keda logs deploy/keda-operator | grep -i error; check ScaledObject source reachability."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/kustomization.yaml
@@ -16,6 +16,9 @@ resources:
   - servicemonitors/coredns.yaml
   - servicemonitors/envoy-gateway.yaml
   - servicemonitors/envoy-ratelimit.yaml
+  - servicemonitors/istio.yaml
+  - servicemonitors/external-dns.yaml
+  - servicemonitors/keda.yaml
   # Storage
   # NOTE: rook-ceph + rook-ceph-exporter SMs are shipped by the rook-ceph Helm chart
   # itself (in rook-ceph ns). Don't duplicate them here.

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/servicemonitors/external-dns.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/servicemonitors/external-dns.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: external-dns
+  namespace: monitoring
+  labels:
+    app: external-dns
+    release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - external-dns
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: external-dns
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 60s
+      scrapeTimeout: 30s

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/servicemonitors/istio.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/servicemonitors/istio.yaml
@@ -1,0 +1,41 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: istiod
+  namespace: monitoring
+  labels:
+    app: istiod
+    release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - istio-system
+  selector:
+    matchLabels:
+      app: istiod
+  endpoints:
+    - port: http-monitoring
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 15s
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ztunnel
+  namespace: monitoring
+  labels:
+    app: ztunnel
+    release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - istio-system
+  selector:
+    matchLabels:
+      app: ztunnel
+  podMetricsEndpoints:
+    - port: ztunnel-stats
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 15s

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/servicemonitors/keda.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/servicemonitors/keda.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: keda-operator
+  namespace: monitoring
+  labels:
+    app: keda-operator
+    release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - keda
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: keda-operator
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 60s
+      scrapeTimeout: 30s

--- a/kubernetes/infrastructure/operators/keda/base/kustomization.yaml
+++ b/kubernetes/infrastructure/operators/keda/base/kustomization.yaml
@@ -13,3 +13,9 @@ helmCharts:
     releaseName: keda
     namespace: keda
     includeCRDs: true
+    valuesInline:
+      prometheus:
+        operator:
+          enabled: true
+        metricServer:
+          enabled: true


### PR DESCRIPTION
coverage audit: cert-manager/velero metrics alive, gaps were istio/keda/external-dns (0 series each). adds istiod servicemonitor + ztunnel podmonitor + 3 istio alerts (warning until phase 3, then critical), keda prometheus metrics via chart + servicemonitor + scaler-error alert, external-dns servicemonitor (symptom alert ExternalDNSResolutionFailed exists already).