### PR TITLE
istio alerts + dashboards

### DIFF
--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/network/istio-control-plane.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/network/istio-control-plane.yaml
@@ -1,0 +1,17 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: istio-control-plane
+  namespace: grafana
+spec:
+  uid: istio-control-plane
+  instanceSelector:
+    matchLabels:
+      app: grafana
+  allowCrossNamespaceImport: true
+  folder: "Network"
+  resyncPeriod: 5m
+  datasources:
+    - inputName: "DS_PROMETHEUS"
+      datasourceName: "prometheus"
+  url: "https://grafana.com/api/dashboards/7645/revisions/314/download"

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/network/istio-ztunnel.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/network/istio-ztunnel.yaml
@@ -1,0 +1,17 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: istio-ztunnel
+  namespace: grafana
+spec:
+  uid: istio-ztunnel
+  instanceSelector:
+    matchLabels:
+      app: grafana
+  allowCrossNamespaceImport: true
+  folder: "Network"
+  resyncPeriod: 5m
+  datasources:
+    - inputName: "DS_PROMETHEUS"
+      datasourceName: "prometheus"
+  url: "https://grafana.com/api/dashboards/21306/revisions/82/download"

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/kustomization.yaml
@@ -40,11 +40,13 @@ resources:
   # Hardware (1)
   - community-dashboards/hardware/smartctl.yaml
 
-  # Network (4)
+  # Network (6)
   - community-dashboards/network/cilium-agent.yaml
   - community-dashboards/network/cilium-operator.yaml
   - community-dashboards/network/hubble.yaml
   - community-dashboards/network/envoy-global.yaml
+  - community-dashboards/network/istio-control-plane.yaml
+  - community-dashboards/network/istio-ztunnel.yaml
 
   # Data / Databases (5)
   - community-dashboards/data/cnpg-postgres.yaml

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/istio.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/istio.yaml
@@ -44,3 +44,25 @@ spec:
             summary: "Istio Root-CA laeuft in <30d ab"
             description: "Alle Workload-Identitaeten haengen an dieser CA — Ablauf = Mesh-weiter mTLS-Ausfall."
             action: "Root-Cert-Rotation planen (istiod self-signed CA, 10y default — Alert = Anomalie)."
+        - alert: IstioCertIssuanceFailing
+          expr: rate(citadel_server_csr_count[10m]) - rate(citadel_server_success_cert_issuance_count[10m]) > 0
+          for: 10m
+          labels:
+            severity: warning
+            component: network
+            priority: P2
+          annotations:
+            summary: "istiod stellt Workload-Certs nicht aus"
+            description: "CSRs kommen an, aber Issuance schlaegt fehl — neue Pods kriegen keine mTLS-Identity, Rotation stockt."
+            action: "kubectl -n istio-system logs deploy/istiod | grep -i csr; ztunnel↔istiod-Verbindung pruefen."
+        - alert: IstioXdsConfigRejected
+          expr: rate(pilot_total_xds_rejects[10m]) > 0
+          for: 10m
+          labels:
+            severity: warning
+            component: network
+            priority: P2
+          annotations:
+            summary: "Proxies lehnen istiod-Config ab (xDS reject)"
+            description: "Ausgerollte Mesh-Config ist fuer ztunnel/waypoints ungueltig — Daten-Ebene laeuft auf alter Config weiter."
+            action: "kubectl -n istio-system logs deploy/istiod | grep -i reject; letzte Istio-/mesh-Config-Aenderung pruefen."


### PR DESCRIPTION
curated istio alert set: +IstioCertIssuanceFailing (csr vs issuance rate, lazy error counters avoided) +IstioXdsConfigRejected. official dashboards 7645 (control plane, rev 314) + 21306 (ztunnel, rev 82) into Network folder. metric names verified against live istiod.