### PR TITLE
drova ambient

### DIFF
--- a/kubernetes/tenants/drova/namespace.yaml
+++ b/kubernetes/tenants/drova/namespace.yaml
@@ -2,5 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: drova
+  labels:
+    istio.io/dataplane-mode: ambient
   annotations:
     argocd.argoproj.io/sync-wave: "-1"


### PR DESCRIPTION
phase 3: enroll drova namespace in ambient mesh. no cnp change needed - the portless drova-to-drova rules in default-deny already cover hbone 15008; spire auth rules match app ports only and simply stop matching meshed traffic. rollback = remove label.