### PR TITLE
kafka hbone netpol

### DIFF
--- a/kubernetes/tenants/drova/kafka/base/kafka-allow-hbone.yaml
+++ b/kubernetes/tenants/drova/kafka/base/kafka-allow-hbone.yaml
@@ -1,0 +1,18 @@
+# Strimzi generiert eigene NetworkPolicies (nur Kafka-Ports) — ambient HBONE braucht 15008 additiv.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: drova-kafka-allow-hbone
+  namespace: drova
+spec:
+  podSelector:
+    matchLabels:
+      strimzi.io/cluster: drova-kafka
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+      ports:
+        - port: 15008
+          protocol: TCP

--- a/kubernetes/tenants/drova/kafka/base/kustomization.yaml
+++ b/kubernetes/tenants/drova/kafka/base/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - drova-kafka-user.yaml
   - kafka-metrics-config.yaml         # JMX Prometheus Exporter rules
   - kafka-broker-podmonitor.yaml      # PodMonitor for broker JMX :9404
+  - kafka-allow-hbone.yaml            # ambient: 15008 zusaetzlich zu Strimzis eigenen NetPols
 
 labels:
   - pairs:


### PR DESCRIPTION
phase 3 fix: strimzi auto-generates its own networkpolicies for kafka pods (kafka ports only) - hbone 15008 was denied, broker-controller connections timed out after enrollment. additive netpol allows 15008 from drova pods. rollback of the label was clean (0 drops after, kafka ready, public 200).