### PR TITLE
kiali mesh ui

### DIFF
--- a/kubernetes/applicationsets/infrastructure/observability-stack.yaml
+++ b/kubernetes/applicationsets/infrastructure/observability-stack.yaml
@@ -31,6 +31,7 @@ spec:
                 - { component: blackbox-exporter,      appName: blackbox-exporter,                path: kubernetes/infrastructure/observability/blackbox-exporter/overlays/prod,      namespace: monitoring,   wave: "70" }
                 - { component: gatus,                  appName: gatus,                            path: kubernetes/infrastructure/observability/gatus/overlays/prod,                  namespace: monitoring,   wave: "70" }
                 - { component: pve-exporter,           appName: pve-exporter,                     path: kubernetes/infrastructure/observability/pve-exporter/overlays/prod,           namespace: monitoring,   wave: "70" }
+                - { component: kiali,                  appName: kiali,                            path: kubernetes/infrastructure/observability/dashboards/kiali,                     namespace: istio-system, wave: "70" }
                 # LOGS — Backends @ 40, shippers @ 70 (after apps exist)
                 - { component: elasticsearch,          appName: elasticsearch,                    path: kubernetes/infrastructure/observability/elasticsearch/overlays/prod,             namespace: elastic-system, wave: "40" }
                 - { component: loki,                   appName: loki,                             path: kubernetes/infrastructure/observability/loki/overlays/prod,                     namespace: monitoring,   wave: "40" }

--- a/kubernetes/infrastructure/observability/dashboards/kiali/basic-auth-sealed.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/kiali/basic-auth-sealed.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: kiali-basic-auth
+  namespace: istio-system
+spec:
+  encryptedData:
+    .htpasswd: AgCIPdoo5Hof0Yq4GQi5auvOwhIlK3zjZJGp+9rQYMtgnUyRpG8U84adzjjnajZ4hZKsdGZdyaRz1guC3GoytTMcXSjkunuF9ognkLXkPNPNR7LULv5YjFhJ/RFNrZRTMRscTyv0LH0ci7weXbqb25XnHiYrllBS0zL5Ao4eAPdpVmTaBA2HPiM2pil2yn5YsALKVom66kM2G72Dwqu8H5MRcox74/wPfRKVaTWpQhS6+zk9S45enwlqvXE/knkZPSDVK+g1S3DPNUp1j8ZwNt/l61fgvxx6PlKW/FQEjaIE1TtlVUdBKAvth8MctZQkWKq6GOoNEEGnmPQT3RQ+mcF/i+y0QkLLXQNv09mG845ZCb1cmbQKDMA6R7H6IE3A2Nzb4AHpbeRi9/2MXhxrkYmH8LSk4GTjkHiuqGfIDRkRxgYX8iyPT1qQTRf5gyzpBD3WvH4YYzqpWsOPAVy1OgCt4BC3/87xrjbqW2BF9yMJvRFt9t/Iu7Sb0uRtrUAOkFx+DTvu8r0G86f839/l271+zebM7a9gw8dfOzLCQT20vlJkdcO+P9ge5qB6ZQ/Z8wUOjubpbu7oC0lccD3WH7H7DAQTiFqqvQWXXexp8OtEWT9v/I4FsZV+feCTz5Zao+kdBdYwgkjWYavuEyEZvJluSmVj6mF/aEyMfZOB+OR7nk+njxzASdfnIdQ8fZ30fxfRycSqMwqmIdKt8ns05PWGbhudv3XRgtPd1p47ZUUBhE3JhGKwWW0=
+  template:
+    metadata:
+      name: kiali-basic-auth
+      namespace: istio-system

--- a/kubernetes/infrastructure/observability/dashboards/kiali/config.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/kiali/config.yaml
@@ -6,17 +6,17 @@ deployment:
 external_services:
   istio:
     root_namespace: istio-system
-    config_map_name: istio-default-v1-27-1
-    istiod_deployment_name: istiod-default-v1-27-1
+    config_map_name: istio
+    istiod_deployment_name: istiod
   prometheus:
-    url: http://prometheus-operator-kube-p-prometheus.monitoring.svc:9090
+    url: http://kube-prometheus-stack-prometheus.monitoring.svc:9090
   grafana:
     enabled: true
-    url: http://grafana.monitoring.svc
-    in_cluster_url: http://grafana.monitoring.svc
+    url: https://grafana.timourhomelab.org
+    in_cluster_url: http://grafana-service.grafana.svc:3000
   tracing:
     enabled: true
     namespace_selector: true
-    in_cluster_url: http://jaeger-query.jaeger.svc:16686
-    url: http://jaeger-query.jaeger.svc:16686
-    use_grpc: true
+    in_cluster_url: http://jaeger-collector.jaeger.svc:16686
+    url: https://jaeger.timourhomelab.org
+    use_grpc: false

--- a/kubernetes/infrastructure/observability/dashboards/kiali/httproute.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/kiali/httproute.yaml
@@ -1,0 +1,34 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kiali
+  namespace: istio-system
+spec:
+  parentRefs:
+    - name: envoy-gateway
+      namespace: gateway
+      sectionName: https
+  hostnames:
+    - "kiali.timourhomelab.org"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: kiali
+          port: 20001
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: kiali-basic-auth
+  namespace: istio-system
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: kiali
+  basicAuth:
+    users:
+      name: kiali-basic-auth

--- a/kubernetes/infrastructure/observability/dashboards/kiali/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/kiali/kustomization.yaml
@@ -11,6 +11,8 @@ resources:
   - clusterrolebinding.yaml
   - deployment.yaml
   - service.yaml
+  - httproute.yaml
+  - basic-auth-sealed.yaml
 
 configMapGenerator:
   - name: kiali


### PR DESCRIPTION
kiali 2.24 (staged files fixed: inplace istiod names, correct prometheus/grafana/jaeger urls) + httproute kiali.timourhomelab.org + envoy basicauth (sha htpasswd, sealed). anonymous kiali auth, edge auth via gateway - same pattern as jaeger.