### PR TITLE
gateway ambient

### DIFF
--- a/kubernetes/infrastructure/ingress/gateway/base/namespace.yaml
+++ b/kubernetes/infrastructure/ingress/gateway/base/namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: gateway
+  labels:
+    istio.io/dataplane-mode: ambient


### PR DESCRIPTION
phase 5 step 1: enroll gateway ns so envoy->drova goes hbone mtls (prereq for strict). external inbound stays passthrough. cnp checked: no 15008 inbound path to envoy pods needed.