### PR TITLE
envoy hbone ingress

### DIFF
--- a/kubernetes/security/foundation/network-policies/envoy-gateway.yaml
+++ b/kubernetes/security/foundation/network-policies/envoy-gateway.yaml
@@ -46,3 +46,9 @@ spec:
         - ports:
             - { port: "10443", protocol: TCP }
             - { port: "10080", protocol: TCP }
+    # istio ambient: HBONE (mTLS-Tunnel) von gemeshten Pods — gleicher Scope wie die
+    # cluster-Klartext-Regel oben, nur der Tunnel-Port (traegt 10443/10080 huckepack).
+    - fromEntities: [cluster]
+      toPorts:
+        - ports:
+            - { port: "15008", protocol: TCP }


### PR DESCRIPTION
gateway ns enrollment: ingress-lock cnp blocked hbone 15008 to proxy pods (controller->proxy timed out, grafana route 503). allow 15008 from cluster entities - same scope as the existing plaintext rule.