### PR TITLE
strict mtls + waypoint

### DIFF
--- a/kubernetes/security/foundation/network-policies/tenants/drova/istio-strict-mtls.yaml
+++ b/kubernetes/security/foundation/network-policies/tenants/drova/istio-strict-mtls.yaml
@@ -1,0 +1,98 @@
+# STRICT nur auf die App-Workloads — Kafka/PG/Redis bleiben PERMISSIVE
+# (deren Operatoren + Prometheus-Scrapes kommen von ausserhalb des Mesh).
+# Gateway-NS ist enrolled → North-South kommt als HBONE an, kein portLevelMtls noetig.
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: api-gateway-strict
+  namespace: drova
+spec:
+  selector:
+    matchLabels:
+      app: api-gateway
+  mtls:
+    mode: STRICT
+---
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: chat-service-strict
+  namespace: drova
+spec:
+  selector:
+    matchLabels:
+      app: chat-service
+  mtls:
+    mode: STRICT
+---
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: driver-service-strict
+  namespace: drova
+spec:
+  selector:
+    matchLabels:
+      app: driver-service
+  mtls:
+    mode: STRICT
+---
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: payment-service-strict
+  namespace: drova
+spec:
+  selector:
+    matchLabels:
+      app: payment-service
+  mtls:
+    mode: STRICT
+---
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: trip-service-strict
+  namespace: drova
+spec:
+  selector:
+    matchLabels:
+      app: trip-service
+  mtls:
+    mode: STRICT
+---
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: user-service-strict
+  namespace: drova
+spec:
+  selector:
+    matchLabels:
+      app: user-service
+  mtls:
+    mode: STRICT
+---
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: frontend-strict
+  namespace: drova
+spec:
+  selector:
+    matchLabels:
+      app: frontend
+  mtls:
+    mode: STRICT
+---
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: schema-registry-strict
+  namespace: drova
+spec:
+  selector:
+    matchLabels:
+      app: schema-registry
+  mtls:
+    mode: STRICT

--- a/kubernetes/security/foundation/network-policies/tenants/drova/kustomization.yaml
+++ b/kubernetes/security/foundation/network-policies/tenants/drova/kustomization.yaml
@@ -6,4 +6,5 @@ kind: Kustomization
 resources:
   # mtls.yaml — SPIRE-mTLS abgebaut 2026-07-10, ersetzt durch Istio ambient (ztunnel)
   - default-deny.yaml     # Drova Microservices Default-Deny (added 2026-05-08)
+  - istio-strict-mtls.yaml  # STRICT auf die 8 App-Workloads (Kafka/PG/Redis permissive)
   # egress.yaml — parked, will re-enable when stripe/mapbox FQDN-egress validated

--- a/kubernetes/tenants/drova/kustomization.yaml
+++ b/kubernetes/tenants/drova/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - limitrange.yaml
 - rbac.yaml
 - atlas-allowlist-sync.yaml
+- waypoint.yaml
 
 labels:
 - pairs:

--- a/kubernetes/tenants/drova/waypoint.yaml
+++ b/kubernetes/tenants/drova/waypoint.yaml
@@ -1,0 +1,16 @@
+# L7-Waypoint fuer die drova-Services (Kiali/AuthZ auf HTTP-Ebene).
+# Attachment per Service-Label istio.io/use-waypoint=waypoint (drova-gitops),
+# Kafka/PG/Redis bleiben bewusst L4-only (kein Extra-Hop auf dem Datenpfad).
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: waypoint
+  namespace: drova
+  labels:
+    istio.io/waypoint-for: service
+spec:
+  gatewayClassName: istio-waypoint
+  listeners:
+    - name: mesh
+      port: 15008
+      protocol: HBONE


### PR DESCRIPTION
phase 5: strict peerauth on the 8 app workloads (kafka/pg/redis stay permissive - operators + prometheus scrape from outside mesh). waypoint gateway for L7 (service attachment via drova-gitops labels, next pr). gateway ns meshed so north-south arrives as hbone.