### PR TITLE
park strict mtls

### DIFF
--- a/kubernetes/security/foundation/network-policies/tenants/drova/kustomization.yaml
+++ b/kubernetes/security/foundation/network-policies/tenants/drova/kustomization.yaml
@@ -6,5 +6,5 @@ kind: Kustomization
 resources:
   # mtls.yaml — SPIRE-mTLS abgebaut 2026-07-10, ersetzt durch Istio ambient (ztunnel)
   - default-deny.yaml     # Drova Microservices Default-Deny (added 2026-05-08)
-  - istio-strict-mtls.yaml
+  # - istio-strict-mtls.yaml  # STRICT killt kubelet-probes unter Cilium (cilium_host-SRC statt node-IP) — fix noetig
   # egress.yaml — parked, will re-enable when stripe/mapbox FQDN-egress validated


### PR DESCRIPTION
strict peerauth broke kubelet probes on all 8 apps: cilium sends probes from cilium_host ip (10.244.0.x) not node ip, istio ambient probe-bypass does not match -> plaintext probe rejected -> ready-flapping. ambient mtls itself keeps running (permissive). needs cilium probe-snat investigation before re-enable.