### PR TITLE
unenroll drova

### DIFF
--- a/kubernetes/tenants/drova/namespace.yaml
+++ b/kubernetes/tenants/drova/namespace.yaml
@@ -2,7 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: drova
-  labels:
-    istio.io/dataplane-mode: ambient
   annotations:
     argocd.argoproj.io/sync-wave: "-1"


### PR DESCRIPTION
kubelet probes get connection-reset for captured pods regardless of peerauth: cilium sends same-node probes from cilium_host pod-cidr ip, bypassing istio-cni host snat (169.254.7.127) via ebpf, ztunnel rejects. affects all drova apps -> ready-flapping -> 503. needs cilium/istio probe-compat fix before re-enroll. gateway ns enrollment unaffected (envoy probes fine).