### PR TITLE
cilium iptables masquerade

### DIFF
--- a/kubernetes/infrastructure/network/cilium/base/values.yaml
+++ b/kubernetes/infrastructure/network/cilium/base/values.yaml
@@ -14,7 +14,7 @@ identityChangeGracePeriod: "30s"
 # 2025 PERFORMANCE OPTIMIZATIONS
 
 # Bypass iptables conntrack for max performance
-installNoConntrackIptablesRules: true
+installNoConntrackIptablesRules: false
 
 # Native routing for best eBPF performance
 routingMode: native
@@ -52,7 +52,7 @@ cgroup:
 # https://docs.cilium.io/en/stable/operations/performance/tuning/#ebpf-host-routing
 bpf:
   hostLegacyRouting: false  # BPF host routing REQUIRED for BBR bandwidth manager
-  masquerade: true  # Required for installNoConntrackIptablesRules
+  masquerade: false  # istio ambient: bpf-masq SNATed kubelet-probes auf cilium_host → ztunnel reset; iptables-masq stattdessen
   # External-VPN-Clients (WARP, Tailscale) → ClusterIP-Services direkt erreichbar.
   # Pflicht für CF Zero Trust + Private Networks pattern (Mac via WARP zu 10.x).
   lbExternalClusterIP: true


### PR DESCRIPTION
root cause of the ambient probe failures: bpf.masquerade snats kubelet health probes to the cilium_host ip, bypassing istio-cni's probe snat (169.254.7.127) - ztunnel resets them, pods flap notready. documented istio+cilium prereq: use iptables masquerading. installNoConntrackIptablesRules requires bpf-masq so it goes too. bbr/host-routing unaffected.