### PR TITLE
drova ambient v2

### DIFF
--- a/kubernetes/tenants/drova/namespace.yaml
+++ b/kubernetes/tenants/drova/namespace.yaml
@@ -2,5 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: drova
+  labels:
+    istio.io/dataplane-mode: ambient
   annotations:
     argocd.argoproj.io/sync-wave: "-1"


### PR DESCRIPTION
re-enroll after the bpf.masquerade fix (#418). probe gate test passed: ambient pod with httpGet probes goes ready in 8s and stays ready.