### PR TITLE
unenroll drova again

### DIFF
--- a/kubernetes/tenants/drova/namespace.yaml
+++ b/kubernetes/tenants/drova/namespace.yaml
@@ -2,7 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: drova
-  labels:
-    istio.io/dataplane-mode: ambient
   annotations:
     argocd.argoproj.io/sync-wave: "-1"


### PR DESCRIPTION
fresh pods still fail probes even after bpf.masquerade fix (timeout instead of reset now - different layer). waypoint label removal did not help either. drova back to unmeshed until root cause is reproduced in a test namespace. gateway ns stays enrolled (envoy fine).