### PR TITLE
disable waf

### DIFF
--- a/kubernetes/infrastructure/ingress/gateway/base/kustomization.yaml
+++ b/kubernetes/infrastructure/ingress/gateway/base/kustomization.yaml
@@ -27,7 +27,7 @@ resources:
   - http-redirect-to-https.yaml
   - clienttraffic-policy.yaml
   - pdb.yaml  # PodDisruptionBudgets — Talos-upgrade-resilience
-  - waf  # Coraza WAF, gateway-wide, DetectionOnly. drova-safe via SecResponseBodyAccess Off (rig-verified 2026-06-11: drova frontend 200 through Coraza, SQLi 942100 detected, WS 101). failOpen. Rollback: re-comment + merge -> ArgoCD prunes.
+  # - waf  # DISABLED 2026-07-10: WASM remote-fetch bricht Envoy-Warmup nach controller-churn. Coraza WAF, gateway-wide, DetectionOnly. drova-safe via SecResponseBodyAccess Off (rig-verified 2026-06-11: drova frontend 200 through Coraza, SQLi 942100 detected, WS 101). failOpen. Rollback: re-comment + merge -> ArgoCD prunes.
   # rate-limit-policies.yaml moved to kubernetes/security/foundation/rate-limiting/
   # envoy-patch-ceph-tls.yaml: NOT NEEDED - Ceph Dashboard uses HTTP backend now
 labels:


### PR DESCRIPTION
wasm remote-fetch breaks envoy warmup after controller churn - all ingress down. removing coraza restores service; failopen means no hard security loss. re-enable once wasm fetch is stable.