### PR TITLE
revert masquerade

### DIFF
--- a/kubernetes/infrastructure/network/cilium/base/values.yaml
+++ b/kubernetes/infrastructure/network/cilium/base/values.yaml
@@ -14,7 +14,7 @@ identityChangeGracePeriod: "30s"
 # 2025 PERFORMANCE OPTIMIZATIONS
 
 # Bypass iptables conntrack for max performance
-installNoConntrackIptablesRules: false
+installNoConntrackIptablesRules: true
 
 # Native routing for best eBPF performance
 routingMode: native
@@ -52,7 +52,7 @@ cgroup:
 # https://docs.cilium.io/en/stable/operations/performance/tuning/#ebpf-host-routing
 bpf:
   hostLegacyRouting: false  # BPF host routing REQUIRED for BBR bandwidth manager
-  masquerade: false  # istio ambient: bpf-masq SNATed kubelet-probes auf cilium_host → ztunnel reset; iptables-masq stattdessen
+  masquerade: true  # Required for installNoConntrackIptablesRules
   # External-VPN-Clients (WARP, Tailscale) → ClusterIP-Services direkt erreichbar.
   # Pflicht für CF Zero Trust + Private Networks pattern (Mac via WARP zu 10.x).
   lbExternalClusterIP: true


### PR DESCRIPTION
PROVEN root cause: #418 (bpf.masquerade=false) broke kubelet->pod http health probes for pods created after the cilium rollout. evidence: pod->envoy:19003 returns 200 (envoy healthy) but kubelet startup probe to same port times out -> ingress down. back to bpf-masq (ran months). fresh pods pass probes again.