### PR TITLE
re-enable waf

### DIFF
--- a/kubernetes/infrastructure/ingress/gateway/base/kustomization.yaml
+++ b/kubernetes/infrastructure/ingress/gateway/base/kustomization.yaml
@@ -27,7 +27,7 @@ resources:
   - http-redirect-to-https.yaml
   - clienttraffic-policy.yaml
   - pdb.yaml  # PodDisruptionBudgets — Talos-upgrade-resilience
-  # - waf  # DISABLED 2026-07-10: WASM remote-fetch bricht Envoy-Warmup nach controller-churn. Coraza WAF, gateway-wide, DetectionOnly. drova-safe via SecResponseBodyAccess Off (rig-verified 2026-06-11: drova frontend 200 through Coraza, SQLi 942100 detected, WS 101). failOpen. Rollback: re-comment + merge -> ArgoCD prunes.
+  - waf  # Coraza WAF, gateway-wide, DetectionOnly. drova-safe via SecResponseBodyAccess Off (rig-verified 2026-06-11: drova frontend 200 through Coraza, SQLi 942100 detected, WS 101). failOpen. Rollback: re-comment + merge -> ArgoCD prunes.
   # rate-limit-policies.yaml moved to kubernetes/security/foundation/rate-limiting/
   # envoy-patch-ceph-tls.yaml: NOT NEEDED - Ceph Dashboard uses HTTP backend now
 labels:


### PR DESCRIPTION
controller stable now (no more churn). re-enable coraza; wasm fetch should complete cleanly. monitored rollback ready.