### PR TITLE
re-mesh drova permissive

### DIFF
--- a/kubernetes/tenants/drova/namespace.yaml
+++ b/kubernetes/tenants/drova/namespace.yaml
@@ -2,5 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: drova
+  labels:
+    istio.io/dataplane-mode: ambient
   annotations:
     argocd.argoproj.io/sync-wave: "-1"


### PR DESCRIPTION
re-enroll drova ambient PERMISSIVE (worked in phase 3 with masq=true - 36 hbone, mtls proven, no probe issue). strict stays parked. rolling restart follows.