### PR TITLE
revert hostlegacy routing

### DIFF
--- a/kubernetes/infrastructure/network/cilium/base/values.yaml
+++ b/kubernetes/infrastructure/network/cilium/base/values.yaml
@@ -51,7 +51,7 @@ cgroup:
 # https://www.talos.dev/latest/talos-guides/network/host-dns/#forwarding-kube-dns-to-host-dns
 # https://docs.cilium.io/en/stable/operations/performance/tuning/#ebpf-host-routing
 bpf:
-  hostLegacyRouting: true  # istio ambient STRICT: eBPF-host-routing zerstört sonst die kubelet-probe-SNAT (istio/istio#57911) → BBR faellt weg
+  hostLegacyRouting: false  # BPF host routing REQUIRED for BBR bandwidth manager
   masquerade: true  # Required for installNoConntrackIptablesRules
   # External-VPN-Clients (WARP, Tailscale) → ClusterIP-Services direkt erreichbar.
   # Pflicht für CF Zero Trust + Private Networks pattern (Mac via WARP zu 10.x).
@@ -143,8 +143,8 @@ gatewayAPI:
 #
 # https://docs.cilium.io/en/stable/network/kubernetes/bandwidth-manager/
 bandwidthManager:
-  enabled: false  # disabled 2026-07-10: inkompatibel mit hostLegacyRouting (fuer istio STRICT); BBR intern eh marginal
-  bbr: false
+  enabled: true
+  bbr: true  # ENABLED: BBR congestion control for improved throughput
 
 # PERFORMANCE - BIG TCP (DISABLED due to WireGuard)
 

--- a/tofu/talos/inline-manifests/cilium-values.yaml
+++ b/tofu/talos/inline-manifests/cilium-values.yaml
@@ -89,8 +89,8 @@ l7Proxy: true
 #  PHASE 1: PERFORMANCE - Bandwidth Manager + BBR (30-40% throughput boost)
 # NOTE: BBR requires BPF host routing (native routing mode), not tunneling
 bandwidthManager:
-  enabled: false  # disabled 2026-07-10: inkompatibel mit hostLegacyRouting (istio STRICT)
-  bbr: false
+  enabled: true
+  bbr: false  # DISABLED: BBR requires native routing, will enable in kubernetes/network/cilium
 
 #  PHASE 1: PERFORMANCE - BIG TCP (reduce CPU 20-40%, max throughput)
 # DISABLED: BIG TCP is not compatible with tunneling mode (VXLAN/Geneve)


### PR DESCRIPTION
hostLegacyRouting+bandwidthManager-off did NOT fix strict probes (tested in throwaway ns: strict still breaks kubelet probes even with the istio-maintainer fix). revert to known-good BBR. strict genuinely blocked on our cilium setup.