### PR TITLE
ipmasq link-local for strict

### DIFF
--- a/kubernetes/infrastructure/network/cilium/base/values.yaml
+++ b/kubernetes/infrastructure/network/cilium/base/values.yaml
@@ -77,6 +77,17 @@ ipam:
   mode: kubernetes
   multiPoolPreAllocation: ""
 
+# istio ambient STRICT: link-local (169.254.0.0/16) unmasqueriert lassen, sonst ersetzt Cilium
+# Istios kubelet-probe-SNAT (169.254.7.127) durch cilium_host → ztunnel erkennt Probe nicht → STRICT flappt.
+ipMasqAgent:
+  enabled: true
+  config:
+    nonMasqueradeCIDRs:
+      - 10.244.0.0/16
+      - 192.168.0.0/24
+      - 169.254.0.0/16
+    masqLinkLocal: false
+
 operator:
   # HIGH AVAILABILITY - 2 replicas for zero downtime
   replicas: 2

--- a/tofu/talos/inline-manifests/cilium-values.yaml
+++ b/tofu/talos/inline-manifests/cilium-values.yaml
@@ -26,6 +26,16 @@ bpf:
 ipam:
   mode: kubernetes
 
+# istio ambient STRICT: link-local unmasqueriert lassen (probe-SNAT 169.254.7.127 muss ztunnel erreichen)
+ipMasqAgent:
+  enabled: true
+  config:
+    nonMasqueradeCIDRs:
+      - 10.244.0.0/16
+      - 192.168.0.0/24
+      - 169.254.0.0/16
+    masqLinkLocal: false
+
 operator:
   rollOutPods: true
   resources:


### PR DESCRIPTION
root cause (ztunnel packet-trace): cilium masquerades istio kubelet-probe SNAT (169.254.7.127) to cilium_host because it's outside native-routing-cidr → ztunnel doesnt recognize probe → strict flaps. fix: ipMasqAgent exempts 169.254.0.0/16. EGRESS RISK: verify drova external (stripe/github) still works after roll before touching strict.