### PR TITLE
ipmasq gitops only

### DIFF
--- a/tofu/talos/inline-manifests/cilium-values.yaml
+++ b/tofu/talos/inline-manifests/cilium-values.yaml
@@ -26,16 +26,6 @@ bpf:
 ipam:
   mode: kubernetes
 
-# istio ambient STRICT: link-local unmasqueriert lassen (probe-SNAT 169.254.7.127 muss ztunnel erreichen)
-ipMasqAgent:
-  enabled: true
-  config:
-    nonMasqueradeCIDRs:
-      - 10.244.0.0/16
-      - 192.168.0.0/24
-      - 169.254.0.0/16
-    masqLinkLocal: false
-
 operator:
   rollOutPods: true
   resources:


### PR DESCRIPTION
ipMasqAgent belongs in gitops cilium values only, not tofu bootstrap (bootstrap is minimal, diverges from gitops by design). remove from bootstrap copy.