### PR TITLE
revert ipmasq

### DIFF
--- a/kubernetes/infrastructure/network/cilium/base/values.yaml
+++ b/kubernetes/infrastructure/network/cilium/base/values.yaml
@@ -77,17 +77,6 @@ ipam:
   mode: kubernetes
   multiPoolPreAllocation: ""
 
-# istio ambient STRICT: link-local (169.254.0.0/16) unmasqueriert lassen, sonst ersetzt Cilium
-# Istios kubelet-probe-SNAT (169.254.7.127) durch cilium_host → ztunnel erkennt Probe nicht → STRICT flappt.
-ipMasqAgent:
-  enabled: true
-  config:
-    nonMasqueradeCIDRs:
-      - 10.244.0.0/16
-      - 192.168.0.0/24
-      - 169.254.0.0/16
-    masqLinkLocal: false
-
 operator:
   # HIGH AVAILABILITY - 2 replicas for zero downtime
   replicas: 2


### PR DESCRIPTION
ipMasqAgent link-local exempt did NOT fix strict: probe source still rewritten to cilium_host (verified in ztunnel log). the link-local source rewrite happens at a fundamental cilium eBPF layer under kubeproxyreplacement that ipMasqAgent (destination-based) doesnt control. revert to known-good.