### PR TITLE
cilium 1.19 upgrade prep

### DIFF
--- a/kubernetes/infrastructure/network/cilium/base/ip-pool.yaml
+++ b/kubernetes/infrastructure/network/cilium/base/ip-pool.yaml
@@ -1,4 +1,4 @@
-apiVersion: cilium.io/v2alpha1
+apiVersion: cilium.io/v2
 kind: CiliumLoadBalancerIPPool
 metadata:
   name: ip-pool

--- a/kubernetes/infrastructure/network/cilium/base/values.yaml
+++ b/kubernetes/infrastructure/network/cilium/base/values.yaml
@@ -2,6 +2,9 @@ cluster:
   name: talos
   id: 1
 
+# 1.18 → 1.19 upgrade: haelt Datapath-Kompatibilitaet waehrend des Rollouts (Cilium-Upgrade-Prozedur)
+upgradeCompatibility: "1.18"
+
 kubeProxyReplacement: true
 
 hostFirewall:


### PR DESCRIPTION
prep for cilium 1.18.11 -> 1.19.5 (fixes istio ambient strict probe bug, cilium/cilium#36022). changes SAFE on 1.18: ip-pool CiliumLoadBalancerIPPool v2alpha1->v2 (v2alpha1 removed in 1.19, live obj already v2) + upgradeCompatibility 1.18. announce.yaml stays v2alpha1 (still served in 1.19, verified in source). NOT the version bump itself - that's PR #384 after this + preflight. DO NOT merge without focused session.