### PR TITLE
remove upgradecompat post-upgrade

### DIFF
--- a/kubernetes/infrastructure/network/cilium/base/values.yaml
+++ b/kubernetes/infrastructure/network/cilium/base/values.yaml
@@ -2,9 +2,6 @@ cluster:
   name: talos
   id: 1
 
-# 1.18 → 1.19 upgrade: haelt Datapath-Kompatibilitaet waehrend des Rollouts (Cilium-Upgrade-Prozedur)
-upgradeCompatibility: "1.18"
-
 kubeProxyReplacement: true
 
 hostFirewall:


### PR DESCRIPTION
post cilium 1.19.5 upgrade: remove upgradeCompatibility 1.18 so the full 1.19 datapath (incl the istio-ambient link-local probe fix, cilium#36022) activates.