### PR TITLE
hostlegacy on 1.19.5 for strict

### DIFF
--- a/kubernetes/infrastructure/network/cilium/base/values.yaml
+++ b/kubernetes/infrastructure/network/cilium/base/values.yaml
@@ -51,7 +51,7 @@ cgroup:
 # https://www.talos.dev/latest/talos-guides/network/host-dns/#forwarding-kube-dns-to-host-dns
 # https://docs.cilium.io/en/stable/operations/performance/tuning/#ebpf-host-routing
 bpf:
-  hostLegacyRouting: false  # BPF host routing REQUIRED for BBR bandwidth manager
+  hostLegacyRouting: true  # istio ambient STRICT auf 1.19.5: kein BPF-host-routing → istio-cni-probe-SNAT bleibt (BBR faellt weg)
   masquerade: true  # Required for installNoConntrackIptablesRules
   # External-VPN-Clients (WARP, Tailscale) → ClusterIP-Services direkt erreichbar.
   # Pflicht für CF Zero Trust + Private Networks pattern (Mac via WARP zu 10.x).
@@ -143,8 +143,8 @@ gatewayAPI:
 #
 # https://docs.cilium.io/en/stable/network/kubernetes/bandwidth-manager/
 bandwidthManager:
-  enabled: true
-  bbr: true  # ENABLED: BBR congestion control for improved throughput
+  enabled: false
+  bbr: false
 
 # PERFORMANCE - BIG TCP (DISABLED due to WireGuard)
 


### PR DESCRIPTION
last strict attempt: cilium 1.19.5 + hostLegacyRouting true. bpf-host-routing off means istio-cni probe SNAT (169.254.7.127) survives to ztunnel. bbr off (incompatible). revert if strict still breaks.