### PR TITLE
revert hostlegacy keep bbr

### DIFF
--- a/kubernetes/infrastructure/network/cilium/base/values.yaml
+++ b/kubernetes/infrastructure/network/cilium/base/values.yaml
@@ -51,7 +51,7 @@ cgroup:
 # https://www.talos.dev/latest/talos-guides/network/host-dns/#forwarding-kube-dns-to-host-dns
 # https://docs.cilium.io/en/stable/operations/performance/tuning/#ebpf-host-routing
 bpf:
-  hostLegacyRouting: true  # istio ambient STRICT auf 1.19.5: kein BPF-host-routing → istio-cni-probe-SNAT bleibt (BBR faellt weg)
+  hostLegacyRouting: false  # BPF host routing REQUIRED for BBR bandwidth manager
   masquerade: true  # Required for installNoConntrackIptablesRules
   # External-VPN-Clients (WARP, Tailscale) → ClusterIP-Services direkt erreichbar.
   # Pflicht für CF Zero Trust + Private Networks pattern (Mac via WARP zu 10.x).
@@ -143,8 +143,8 @@ gatewayAPI:
 #
 # https://docs.cilium.io/en/stable/network/kubernetes/bandwidth-manager/
 bandwidthManager:
-  enabled: false
-  bbr: false
+  enabled: true
+  bbr: true  # ENABLED: BBR congestion control for improved throughput
 
 # PERFORMANCE - BIG TCP (DISABLED due to WireGuard)
 


### PR DESCRIPTION
1.19.5 + hostLegacyRouting did NOT fix strict either (forward-path probe source still cilium_host). the 1.19.3 fix only addressed the return-path drop, not our forward-source-rewrite. revert to bbr, keep 1.19.5 (upgrade itself valuable). strict definitively not achievable on cilium+kubeproxyreplacement+ambient.