### PR TITLE
velero rgw-checksum + alert fixes

### DIFF
--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/host-sensors.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/host-sensors.yaml
@@ -13,9 +13,10 @@ spec:
       interval: 1m
       rules:
         - alert: HostCPUTemperatureCritical
-          expr: node_hwmon_temp_celsius > 95
+          expr: node_hwmon_temp_celsius{chip!~"nvme.*"} > 95
           # 2m war zu kurz: msa2 k10temp (CPU) spitzt unter Ceph-Last transient >95°C und
           # resolved selbst → Flap-Noise. 15m = nur SUSTAINED Hitze (echte Gefahr) alarmiert.
+          # nvme excluded → eigener HostNVMeTemperatureCritical (node_exporter labelt SSD-Hotspot sonst als "CPU")
           for: 15m
           labels:
             severity: warning
@@ -23,9 +24,21 @@ spec:
             priority: P2
           annotations:
             dashboard_url: "/d/k8s-node-overview"
-            summary: "CPU/sensor {{ $labels.chip }} on {{ $labels.instance }} at {{ $value }}°C"
+            summary: "CPU {{ $labels.chip }} on {{ $labels.instance }} at {{ $value }}°C"
             description: "Thermal shutdown imminent — host may power off. Check airflow / dust / fan."
             action: "PHYSICAL: clean dust + check fan/airflow on the host; reduce load until temp drops below throttle."
+        - alert: HostNVMeTemperatureCritical
+          expr: node_hwmon_temp_celsius{chip=~"nvme.*"} > 85
+          for: 15m
+          labels:
+            severity: warning
+            component: hardware
+            priority: P2
+          annotations:
+            dashboard_url: "/d/k8s-node-overview"
+            summary: "NVMe {{ $labels.chip }}/{{ $labels.sensor }} on {{ $labels.instance }} at {{ $value }}°C"
+            description: "NVMe running hot — thermal-throttles and degrades Ceph performance."
+            action: "PHYSICAL: add/reseat heatsink, improve airflow/dust; reduce write load."
 
         - alert: HostMemoryCritical
           expr: node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes < 0.05

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/velero.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/velero.yaml
@@ -14,7 +14,7 @@ spec:
       interval: 60s
       rules:
         - alert: VeleroNoRecentBackup
-          expr: time() - velero_backup_last_successful_timestamp{schedule!=""} > 86400
+          expr: time() - velero_backup_last_successful_timestamp{schedule!="",schedule!~"tier2-.*"} > 86400
           for: 10m
           labels:
             severity: critical
@@ -23,6 +23,17 @@ spec:
             dashboard_url: "/d/velero-overview"
             summary: "No successful Velero backup in 24h for {{ $labels.schedule }}"
             description: "RPO exceeded — covers failed/partial/not-running causes. DR-readiness compromised."
+            action: "velero backup get ; velero backup logs <name> ; check RGW bucket quota + creds"
+        - alert: VeleroNoRecentWeeklyBackup
+          expr: time() - velero_backup_last_successful_timestamp{schedule=~"tier2-.*"} > 691200
+          for: 10m
+          labels:
+            severity: critical
+            component: backup
+          annotations:
+            dashboard_url: "/d/velero-overview"
+            summary: "No successful weekly Velero backup in 8d for {{ $labels.schedule }}"
+            description: "Weekly-tier RPO exceeded (>8d). DR-readiness compromised."
             action: "velero backup get ; velero backup logs <name> ; check RGW bucket quota + creds"
 
     # ── TICKET ──

--- a/kubernetes/infrastructure/storage/velero-schedules/backup-schedules.yaml
+++ b/kubernetes/infrastructure/storage/velero-schedules/backup-schedules.yaml
@@ -49,27 +49,6 @@ spec:
 apiVersion: velero.io/v1
 kind: Schedule
 metadata:
-  name: tier0-infisical
-  namespace: velero
-  labels:
-    backup-tier: tier-0
-    app: infisical
-spec:
-  schedule: "0 */6 * * *"
-  template:
-    includedNamespaces:
-      - infisical
-    storageLocation: cluster-backups
-    ttl: 8760h  # 365 days retention (1 year)
-    defaultVolumesToFsBackup: true
-    metadata:
-      labels:
-        backup-tier: tier-0
-        namespace: infisical
----
-apiVersion: velero.io/v1
-kind: Schedule
-metadata:
   name: tier0-lldap
   namespace: velero
   labels:

--- a/kubernetes/infrastructure/storage/velero/base/kustomization.yaml
+++ b/kubernetes/infrastructure/storage/velero/base/kustomization.yaml
@@ -45,6 +45,7 @@ helmCharts:
               s3ForcePathStyle: "true"
               s3Url: http://rook-ceph-rgw-homelab-objectstore.rook-ceph.svc:80
               insecureSkipTLSVerify: "true"
+              checksumAlgorithm: ""  # Ceph RGW rejects SDK-v2 CRC32 checksums
           - name: pv-backups
             provider: aws
             bucket: velero-pv-backups
@@ -53,6 +54,7 @@ helmCharts:
               s3ForcePathStyle: "true"
               s3Url: http://rook-ceph-rgw-homelab-objectstore.rook-ceph.svc:80
               insecureSkipTLSVerify: "true"
+              checksumAlgorithm: ""  # Ceph RGW rejects SDK-v2 CRC32 checksums
           # OPTIONAL: AWS S3 Offsite Backup (Disaster Recovery)
           # ACTIVATION STEPS:
           # 1. Create AWS S3 bucket: timour-homelab-velero-dr


### PR DESCRIPTION
## Root causes (overnight alert flood)

- **Velero backups PartiallyFailed** (databases + infisical) — Ceph RGW returns `SignatureDoesNotMatch`: velero v1.15 (AWS SDK v2) sends default CRC32 checksums RGW rejects. Fix: `checksumAlgorithm: ""` on both BSLs.
- **restore-verify CronJob failing** — downstream of the above (requires a `Completed` databases backup; all were `PartiallyFailed`). Resolved by the checksum fix.
- **tier0-infisical schedule** targeted the deleted `infisical` namespace → removed.
- **VeleroNoRecentBackup false-positive** on `tier2-sealed-secrets` (weekly `0 4 * * 0`) vs 24h threshold → excluded weekly from the 24h rule + added `VeleroNoRecentWeeklyBackup` (8d).
- **HostCPUTemperatureCritical mislabeled** — caught the node_exporter NVMe hwmon sensor (nipogi Samsung 990 PRO, temp3 ~96°C). Excluded `nvme.*` + added `HostNVMeTemperatureCritical` (>85°C).

Physical follow-up (not this PR): heatsink / airflow on the nipogi Samsung 990 PRO — thermal-throttling ~12h.