### PR TITLE
chore(deps): update kyverno to v3.8 - abandoned

### DIFF
--- a/kubernetes/security/governance/kyverno/kustomization.yaml
+++ b/kubernetes/security/governance/kyverno/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 helmCharts:
   - name: kyverno
     repo: https://kyverno.github.io/kyverno
-    version: "3.8.1"
+    version: "3.8.2"
     releaseName: kyverno
     namespace: kyverno
     includeCRDs: true


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/kyverno-3.8.x`
Filter passed: <24h old, <5 commits ahead.