### PR TITLE
fix velero postgres-hook selector

### DIFF
--- a/kubernetes/infrastructure/storage/velero-schedules/tier0-databases-6h-schedule.yaml
+++ b/kubernetes/infrastructure/storage/velero-schedules/tier0-databases-6h-schedule.yaml
@@ -49,6 +49,7 @@ spec:
           labelSelector:
             matchLabels:
               cnpg.io/cluster: n8n-postgres  # CloudNativePG cluster selector
+              cnpg.io/instanceRole: primary  # skip replicas + pgbouncer poolers (no postgres container)
           pre:
             - exec:
                 container: postgres


### PR DESCRIPTION
## Root cause of the recurring `VeleroBackupPartialFailure` + restore-verify `KubeJobFailed`

The `tier0-databases-6h` backup runs a `postgres-backup-hook` (`CHECKPOINT;`) selected by `cnpg.io/cluster: n8n-postgres`. That label **also matches the 2 pgBouncer pooler pods**, which have no `postgres` container → velero logs `Error executing hook: no such container` **twice** → `PartiallyFailed`. Since restore-verify requires a `Completed` databases backup, it failed too.

Fix: add `cnpg.io/instanceRole: primary` to the hook's `matchLabels` → hook runs only on the primary instance (correct place for CHECKPOINT), skipping replicas and poolers.

Verified: read the actual backup log from RGW (`Error executing hook · no such container` ×2). Same CNPG pooler-selector class of bug as the scheduling-hardening fix. Only this schedule uses a `cnpg.io/cluster` hook selector.