### PR TITLE
renovate: disable platformCommit (v43 orphan-branch fix)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
 
   "configMigration": true,
   "forkProcessing": "disabled",
-  "platformCommit": "enabled",
+  "platformCommit": "disabled",
   "platformAutomerge": false,
   "automerge": false,
 


### PR DESCRIPTION
## Root cause of the orphan Renovate branches

`platformCommit: enabled` makes Renovate commit via the GitHub **API**. After that API commit, Renovate's local git layer re-checks the ref, sees it moved (by its own push), and aborts with *"Repository has changed during renovation - aborting"* — **before** opening the PR. The branch is left orphaned; the operator does not retry. This is what the `renovate-orphan-pr-opener` CronJob works around.

Fix: `platformCommit: disabled` → Renovate commits+pushes via local git, so its own push doesn't look like an external change → no abort → PRs are created normally.

Low-risk + revertible: the `RENOVATE_TOKEN` supports git push, so commits still work (just unsigned instead of API-verified). The orphan-pr-opener stays as a safety net.