### PR TITLE
fix ctrl-0 etcd datastore drift (local-zfs -> cephpool)

### DIFF
--- a/tofu/talos_nodes.auto.tfvars
+++ b/tofu/talos_nodes.auto.tfvars
@@ -7,7 +7,7 @@ talos_nodes = {
     vm_id          = 1000
     cpu            = 6
     ram_dedicated  = 14336
-    datastore_id   = "local-zfs"
+    datastore_id   = "cephpool"
     os_disk_size   = 50
     ceph_disk_size = 0
   }


### PR DESCRIPTION
## Config-vs-reality drift on the control-plane disk

`tofu/talos_nodes.auto.tfvars` declares `ctrl-0.datastore_id = "local-zfs"` (nipogi = the cheap HOGE SSD), but the **live disk is on `cephpool`** (Samsung 990 PRO):

```
scsi0: cephpool:vm-1000-disk-0,...size=50G
```

etcd on the slow HOGE was the documented **API-outage root cause**; it was moved to the Samsung live but the tfvars never followed. A naive `tofu apply` would try to **move etcd back to the HOGE** → outage returns. This aligns the config to reality.

## ⚠️ Before merge/apply — check the `tofu plan` output

- **plan shows no change** → state already `cephpool`, safe to merge.
- **plan shows a disk move/replace of ctrl-0** → do NOT apply naively (that recreates etcd = control-plane loss). Use a `moved` block / `tofu state` reconcile instead.

Apply as always: `-parallelism=1`, never `-refresh=false -replace`.