### PR TITLE
netbird exporter

### DIFF
--- a/kubernetes/applicationsets/infrastructure/observability-stack.yaml
+++ b/kubernetes/applicationsets/infrastructure/observability-stack.yaml
@@ -31,6 +31,7 @@ spec:
                 - { component: blackbox-exporter,      appName: blackbox-exporter,                path: kubernetes/infrastructure/observability/blackbox-exporter/overlays/prod,      namespace: monitoring,   wave: "70" }
                 - { component: gatus,                  appName: gatus,                            path: kubernetes/infrastructure/observability/gatus/overlays/prod,                  namespace: monitoring,   wave: "70" }
                 - { component: pve-exporter,           appName: pve-exporter,                     path: kubernetes/infrastructure/observability/pve-exporter/overlays/prod,           namespace: monitoring,   wave: "70" }
+                - { component: netbird-exporter,       appName: netbird-exporter,                 path: kubernetes/infrastructure/observability/netbird-exporter/overlays/prod,       namespace: monitoring,   wave: "70" }
                 - { component: kiali,                  appName: kiali,                            path: kubernetes/infrastructure/observability/dashboards/kiali,                     namespace: istio-system, wave: "70" }
                 # LOGS — Backends @ 40, shippers @ 70 (after apps exist)
                 - { component: elasticsearch,          appName: elasticsearch,                    path: kubernetes/infrastructure/observability/elasticsearch/overlays/prod,             namespace: elastic-system, wave: "40" }

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ingress.yaml
   - istio.yaml
   - vpn.yaml
+  - netbird.yaml

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/netbird.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/netbird.yaml
@@ -1,0 +1,46 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: network-netbird
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    # ── PAGE ── routing-peer down = VPN-only Infra (grafana/argo/…) unreachbar
+    - name: netbird-page
+      interval: 60s
+      rules:
+        - alert: NetBirdRoutingPeerDown
+          expr: min by (peer_name) (netbird_peer_connection_status_by_name{peer_name=~"msa2proxmox|nipogi"}) == 0
+          for: 5m
+          labels:
+            severity: critical
+            component: network
+          annotations:
+            summary: "NetBird routing-peer {{ $labels.peer_name }} offline"
+            description: "Host-Routing-Peer (msa2/nipogi) disconnected → LAN-Route 192.168.0.0/24 tot → alle VPN-only-Apps unerreichbar."
+            action: "NetBird-Agent am Proxmox-Host prüfen (`ssh <host> systemctl status netbird`); Setup-Key ist ephemeral=false → Peer sollte nicht gelöscht sein."
+    # ── TICKET ──
+    - name: netbird-ticket
+      interval: 60s
+      rules:
+        - alert: NetBirdExporterDown
+          expr: up{job="netbird-exporter"} == 0
+          for: 10m
+          labels:
+            severity: warning
+            component: network
+          annotations:
+            summary: "NetBird-API-Exporter down — VPN-Health blind"
+            description: "netbird-api-exporter nicht scrapebar → keine Peer/Route/Policy-Metriken. NetBird-Health ungemonitort."
+            action: "kubectl -n monitoring logs deploy/netbird-exporter; Token netbird-exporter-token / netbird-mgmt-api-key gültig?"
+        - alert: NetBirdManyPeersDisconnected
+          expr: (netbird_peers_connected{connected="false"} / clamp_min(netbird_peers, 1)) > 0.6
+          for: 15m
+          labels:
+            severity: warning
+            component: network
+          annotations:
+            summary: "Mehrheit der NetBird-Peers offline ({{ $value | humanizePercentage }})"
+            description: "> 60% der Peers disconnected — mögliches NetBird-Cloud/Signal-Problem oder breiter Client-Ausfall."
+            action: "NetBird-Dashboard-Status + api.netbird.io erreichbar? cilium host-firewall 51820/UDP offen?"

--- a/kubernetes/infrastructure/observability/netbird-exporter/base/dashboards/dashboard.yaml
+++ b/kubernetes/infrastructure/observability/netbird-exporter/base/dashboards/dashboard.yaml
@@ -1,0 +1,13 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: netbird
+  namespace: grafana
+spec:
+  allowCrossNamespaceImport: true
+  folder: NetBird
+  resyncPeriod: 30m
+  instanceSelector:
+    matchLabels:
+      app: grafana
+  url: "https://raw.githubusercontent.com/matanbaruch/netbird-api-exporter/main/grafana-dashboard.json"

--- a/kubernetes/infrastructure/observability/netbird-exporter/base/deployment.yaml
+++ b/kubernetes/infrastructure/observability/netbird-exporter/base/deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: netbird-exporter
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: netbird-exporter
+    app.kubernetes.io/component: exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: netbird-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: netbird-exporter
+    spec:
+      containers:
+        - name: exporter
+          image: ghcr.io/matanbaruch/netbird-api-exporter:v0.2.2
+          env:
+            - name: NETBIRD_API_URL
+              value: "https://api.netbird.io"
+            - name: LISTEN_ADDRESS
+              value: ":8080"
+            - name: LOG_LEVEL
+              value: "info"
+            - name: NETBIRD_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: netbird-exporter-token
+                  key: api-token
+          ports:
+            - name: metrics
+              containerPort: 8080
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: netbird-exporter
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: netbird-exporter
+spec:
+  selector:
+    app.kubernetes.io/name: netbird-exporter
+  ports:
+    - name: metrics
+      port: 8080
+      targetPort: metrics

--- a/kubernetes/infrastructure/observability/netbird-exporter/base/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/netbird-exporter/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - sealed-token.yaml
+  - deployment.yaml
+  - servicemonitor.yaml
+  - dashboards/dashboard.yaml

--- a/kubernetes/infrastructure/observability/netbird-exporter/base/sealed-token.yaml
+++ b/kubernetes/infrastructure/observability/netbird-exporter/base/sealed-token.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: netbird-exporter-token
+  namespace: monitoring
+spec:
+  encryptedData:
+    api-token: AgAKsP/iS6jo1DF9wEvzAtgGyFf7QF4ckO2Of+VS8SEjaizOlVSX3LpMwkOt74Fy9fTBVnH8EwclC1NolCPCsLkxU5NQqQ1gmT8lUj8u2LNO8lszenG1k6mA1FV2xXMIuPrp7THd2lkDa8XmxYItYZMnOgwka9T7nnnWVmS+m4P1p90ShSxYjxF4kBN5Godl+nw18xYf434Vs7V6gD/CQgjx5r+7AuBlEhoyYZXfPl3moSg/eQM/o3HFLh0+/3xC5KtVzggtodL7UEX5dLGc7+D2GKN5eTy5RiGmvNr6LJnw430qVU6uY49Y8BultvcXXaMHqaiiJYr1Yal/196HT4fPHiOddN4S9vN4Lx6OvS9JS+SFnxjb25ODv7l+3fu56FdWNZbWwXdGPDpsLtyJ4DcDQWM9bGFQmWw3JEcPKa0QBsxvbvwx1988KXnTpMm1gNEdyGDBmPOY6gLKvhEDIoM8gmyOtAp11tK6uRBBVzwKhC1hgN7oiSphVI3Q/R4TNzqxV7SImSCFj7YS2laOv6AAZMhQD+PWKB/I0pi92y2ifQ9lmDF8WAGvit+m9XcAgzWKYECKjySsWtKxhMpdd2GBO+wd19Bv2zS0bhgB2mMrWatjfJaVmXDXkpQJa1H5VgqDCJFhYV43T3AKndnOjJRbRIVENgntDs5df2XyXJCUims7wpVrUCeamNnZCz3vq85TCExlNsQ9fWla/OXqEL61q+5Utp+YFFSMMY1SbgDWUStI+kzowoF+
+  template:
+    metadata:
+      name: netbird-exporter-token
+      namespace: monitoring

--- a/kubernetes/infrastructure/observability/netbird-exporter/base/servicemonitor.yaml
+++ b/kubernetes/infrastructure/observability/netbird-exporter/base/servicemonitor.yaml
@@ -9,7 +9,7 @@ spec:
       app.kubernetes.io/name: netbird-exporter
   endpoints:
     - port: metrics
-      interval: 60s
+      interval: 120s
       scrapeTimeout: 30s
       path: /metrics
       relabelings:

--- a/kubernetes/infrastructure/observability/netbird-exporter/base/servicemonitor.yaml
+++ b/kubernetes/infrastructure/observability/netbird-exporter/base/servicemonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: netbird-exporter
+  namespace: monitoring
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: netbird-exporter
+  endpoints:
+    - port: metrics
+      interval: 60s
+      scrapeTimeout: 30s
+      path: /metrics
+      relabelings:
+        - targetLabel: job
+          replacement: netbird-exporter

--- a/kubernetes/infrastructure/observability/netbird-exporter/overlays/prod/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/netbird-exporter/overlays/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base


### PR DESCRIPTION
netbird-api-exporter → Prometheus (peer/route/policy/setup-key metrics) + Grafana dashboard + alerts. closes the netbird health-monitoring gap — routing-peer death (msa2/nipogi) was silent, now pages. reuses the existing mgmt-api-token (sealed into monitoring).