### PR TITLE
chore(deps): update cloudflare-cloudflared to v2026 - autoclosed

### DIFF
--- a/kubernetes/infrastructure/ingress/cloudflared/base/daemon-set.yaml
+++ b/kubernetes/infrastructure/ingress/cloudflared/base/daemon-set.yaml
@@ -21,7 +21,7 @@ spec:
         fsGroup: 65532
       containers:
         - name: cloudflared
-          image: cloudflare/cloudflared:2026.6.1@sha256:6d91c121b803126f7a5344005d17a9324788fc09d305b6e2560ec6040a7ae283
+          image: cloudflare/cloudflared:2026.7.0@sha256:5e49861633763e8933475477c20bae6039ed47f32c1d267a34babc347f28f0df
           securityContext:
             runAsNonRoot: true
             runAsUser: 65532


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/cloudflare-cloudflared-2026.x`
Filter passed: <24h old, <5 commits ahead.