### PR TITLE
alert hardening + unit tests

### DIFF
--- a/.github/scripts/test-alerts.py
+++ b/.github/scripts/test-alerts.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Run promtool unit tests against the PrometheusRule CRDs.
+
+Extracts every .spec.groups from PrometheusRule CRs into one raw rules file
+(.github/tests/alerts/.rules.generated.yaml), then runs `promtool test rules`
+on each *_test.yaml in that directory. The test files reference the generated
+rules via `rule_files: [.rules.generated.yaml]`.
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+TESTS_DIR = Path(".github/tests/alerts")
+GENERATED = TESTS_DIR / ".rules.generated.yaml"
+
+
+def extract_rules(root: Path) -> int:
+    groups = []
+    seen = set()
+    for path in root.rglob("*.yaml"):
+        if "/charts/" in str(path):
+            continue
+        try:
+            docs = list(yaml.safe_load_all(path.open()))
+        except yaml.YAMLError:
+            continue
+        for doc in docs:
+            if not isinstance(doc, dict) or doc.get("kind") != "PrometheusRule":
+                continue
+            for grp in doc.get("spec", {}).get("groups", []):
+                if grp.get("name") in seen:
+                    continue
+                seen.add(grp.get("name"))
+                groups.append(grp)
+    GENERATED.write_text(yaml.safe_dump({"groups": groups}))
+    return len(groups)
+
+
+def main(root: str = "kubernetes") -> int:
+    n = extract_rules(Path(root))
+    print(f"extracted {n} rule groups from {root}")
+    test_files = sorted(TESTS_DIR.glob("*_test.yaml"))
+    if not test_files:
+        print("no *_test.yaml files found")
+        return 1
+    failures = 0
+    for tf in test_files:
+        proc = subprocess.run(
+            ["promtool", "test", "rules", tf.name],
+            capture_output=True,
+            text=True,
+            cwd=TESTS_DIR,
+        )
+        print(f"--- {tf.name} ---")
+        print((proc.stdout + proc.stderr).strip())
+        if proc.returncode != 0:
+            failures += 1
+    GENERATED.unlink(missing_ok=True)
+    print(f"\nSummary: {len(test_files)} test file(s), {failures} failed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1] if len(sys.argv) > 1 else "kubernetes"))

--- a/.github/tests/alerts/resource_alerts_test.yaml
+++ b/.github/tests/alerts/resource_alerts_test.yaml
@@ -1,0 +1,112 @@
+# promtool unit tests — synthetic series prove the resource/edge/node alerts fire (and
+# don't false-fire), and assert the rendered summary/description templates. Run:
+#   python3 .github/scripts/test-alerts.py
+# (extracts every PrometheusRule .spec.groups → .rules.generated.yaml, then promtool test).
+rule_files:
+  - .rules.generated.yaml
+evaluation_interval: 1m
+tests:
+  # ── ContainerCPUThrottlingHigh: FIRES when a container is throttled >75% (83%) ──
+  - interval: 1m
+    input_series:
+      - series: 'container_cpu_cfs_throttled_periods_total{namespace="argocd",pod="argocd-redis-ha-server-1",container="sentinel"}'
+        values: '0+50x20'
+      - series: 'container_cpu_cfs_periods_total{namespace="argocd",pod="argocd-redis-ha-server-1",container="sentinel"}'
+        values: '0+60x20'
+    alert_rule_test:
+      - eval_time: 16m
+        alertname: ContainerCPUThrottlingHigh
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: application
+              priority: P2
+              namespace: argocd
+              pod: argocd-redis-ha-server-1
+              container: sentinel
+            exp_annotations:
+              dashboard_url: "/d/k8s-pod-overview"
+              summary: "argocd/argocd-redis-ha-server-1/sentinel throttled 83.33%"
+              description: "Container throttled >75% of CFS periods for 15min — busy-loop or under-sized CPU limit."
+              action: "kubectl top pod -n argocd argocd-redis-ha-server-1 --containers; busy-loop → fix root cause, else raise the cpu limit."
+
+  # ── ContainerCPUThrottlingHigh: does NOT fire below 75% (67%) ──
+  - interval: 1m
+    input_series:
+      - series: 'container_cpu_cfs_throttled_periods_total{namespace="drova",pod="api-gateway-1",container="app"}'
+        values: '0+40x20'
+      - series: 'container_cpu_cfs_periods_total{namespace="drova",pod="api-gateway-1",container="app"}'
+        values: '0+60x20'
+    alert_rule_test:
+      - eval_time: 16m
+        alertname: ContainerCPUThrottlingHigh
+        exp_alerts: []
+
+  # ── ContainerMemoryHigh: FIRES when working set >95% of limit (96%) ──
+  - interval: 1m
+    input_series:
+      - series: 'container_memory_working_set_bytes{namespace="keycloak",pod="keycloak-0",container="keycloak"}'
+        values: '960+0x40'
+      - series: 'kube_pod_container_resource_limits{namespace="keycloak",pod="keycloak-0",container="keycloak",resource="memory"}'
+        values: '1000+0x40'
+    alert_rule_test:
+      - eval_time: 31m
+        alertname: ContainerMemoryHigh
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: application
+              priority: P2
+              namespace: keycloak
+              pod: keycloak-0
+              container: keycloak
+            exp_annotations:
+              dashboard_url: "/d/k8s-pod-overview"
+              summary: "keycloak/keycloak-0/keycloak memory at 96% of limit"
+              description: "Container working set >95% of its memory limit for 30min — OOM-kill risk."
+              action: "kubectl top pod -n keycloak keycloak-0 --containers; raise the memory limit or fix the leak."
+
+  # ── TalosNodeDiskFillingUp: FIRES when /var <15% free (10%) ──
+  - interval: 1m
+    input_series:
+      - series: 'node_filesystem_avail_bytes{job="node-exporter",mountpoint="/var",instance="192.168.0.103:9100"}'
+        values: '10+0x20'
+      - series: 'node_filesystem_size_bytes{job="node-exporter",mountpoint="/var",instance="192.168.0.103:9100"}'
+        values: '100+0x20'
+    alert_rule_test:
+      - eval_time: 16m
+        alertname: TalosNodeDiskFillingUp
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: hardware
+              priority: P2
+              job: node-exporter
+              mountpoint: /var
+              instance: 192.168.0.103:9100
+            exp_annotations:
+              dashboard_url: "/d/k8s-node-overview"
+              summary: "192.168.0.103:9100 /var 10% free"
+              description: "Talos node writable partition (/var: etcd, containerd, logs) filling — evictions/CrashLoops loom before kubelet DiskPressure."
+              action: "talosctl -n 192.168.0.103:9100 df; prune unused images (crictl rmi --prune via debug); check log growth."
+
+  # ── EnvoyEdgeSLOFastBurn: FIRES at 10% 5xx sustained across both windows ──
+  - interval: 1m
+    input_series:
+      - series: 'envoy_cluster_upstream_rq_total'
+        values: '0+100x70'
+      - series: 'envoy_cluster_upstream_rq_xx{envoy_response_code_class="5"}'
+        values: '0+10x70'
+    alert_rule_test:
+      - eval_time: 65m
+        alertname: EnvoyEdgeSLOFastBurn
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              component: network
+              priority: P1
+            exp_annotations:
+              dashboard_url: "/d/envoy-global"
+              summary: "Edge SLO fast-burn: 10% 5xx (budget 0.5%)"
+              description: "The ingress edge is burning its availability error budget 14.4× — a month's budget in ~2 days. Every exposed app is affected."
+              action: "envoy-global dashboard → which upstream is 5xx'ing; check that backend + recent deploys. Pages because the whole front door is degraded."

--- a/.github/workflows/alert-lint.yml
+++ b/.github/workflows/alert-lint.yml
@@ -7,6 +7,8 @@ on:
       - "kubernetes/**/*.yaml"
       - ".github/workflows/alert-lint.yml"
       - ".github/scripts/lint-alerts.py"
+      - ".github/scripts/test-alerts.py"
+      - ".github/tests/alerts/**"
   push:
     branches: [main]
     paths:
@@ -35,6 +37,9 @@ jobs:
 
       - name: Lint PrometheusRules (syntax + required annotations/labels)
         run: python3 .github/scripts/lint-alerts.py kubernetes
+
+      - name: Unit-test PrometheusRules (promtool test rules)
+        run: python3 .github/scripts/test-alerts.py kubernetes
 
       - name: Lint GrafanaDashboards (panel structure + datasource UIDs + grid overlap)
         run: python3 .github/scripts/lint-dashboards.py kubernetes

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 !kubernetes/infrastructure/observability/logs/
 !kubernetes/infrastructure/observability/logs/**
 
+# CI: promtool test extracts all PrometheusRule CRs here transiently
+.github/tests/alerts/.rules.generated.yaml
+
 .env
 .env.*
 

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/disk-io.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/disk-io.yaml
@@ -7,7 +7,8 @@ metadata:
 spec:
   # Disk IO-saturation + read/write-latency → Grafana "Node Exporter / Disk" dashboard
   # (rates/latencies are debug signals, not pages — and they flap under Ceph load).
-  # Kept the node root-filesystem fill (covers Talos VM roots; proxmox.yaml covers hosts).
+  # Root-fs fill: node-exporter only reports mountpoint="/" on the Proxmox HOSTS (Talos
+  # roots aren't exposed) → this is the <5% PAGE tier; ProxmoxRootDiskFull is the <15% warn.
   groups:
     # ── PAGE ──
     - name: disk-io-page
@@ -26,22 +27,3 @@ spec:
             summary: "{{ $labels.instance }} root filesystem critically full ({{ $value | humanizePercentage }})"
             description: "Node out of disk space imminent — write failures, stuck services."
             action: "SSH host; 'journalctl --vacuum-size=200M'; 'du -sh /var/*' to find the offender; prune images/logs."
-
-    # ── TICKET ──
-    - name: disk-io-ticket
-      interval: 1m
-      rules:
-        - alert: HostRootFilesystemAlmostFull
-          expr: |
-            node_filesystem_avail_bytes{mountpoint="/",fstype!="rootfs"}
-            / node_filesystem_size_bytes{mountpoint="/",fstype!="rootfs"} < 0.10
-          for: 15m
-          labels:
-            severity: warning
-            component: hardware
-            priority: P2
-          annotations:
-            dashboard_url: "/d/k8s-node-overview"
-            summary: "{{ $labels.instance }} root filesystem {{ $value | humanizePercentage }} free"
-            description: "Node root nearly full — clean up or expand before it hits critical."
-            action: "SSH host; 'journalctl --vacuum-size=200M' + prune old images/logs before it hits critical."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/disk-io.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/disk-io.yaml
@@ -27,3 +27,25 @@ spec:
             summary: "{{ $labels.instance }} root filesystem critically full ({{ $value | humanizePercentage }})"
             description: "Node out of disk space imminent — write failures, stuck services."
             action: "SSH host; 'journalctl --vacuum-size=200M'; 'du -sh /var/*' to find the offender; prune images/logs."
+
+    # ── TICKET ──
+    - name: disk-io-ticket
+      interval: 1m
+      rules:
+        - alert: TalosNodeDiskFillingUp
+          # Talos node-exporter reports the writable partition as mountpoint="/var" (holds
+          # etcd, containerd images, logs). Nodes expose no "/" → this is the ONLY node
+          # disk-fill signal. Leading warn <15%; NodeDiskPressure (kubelet) is the lagging backstop.
+          expr: |
+            node_filesystem_avail_bytes{job="node-exporter",mountpoint="/var"}
+            / node_filesystem_size_bytes{job="node-exporter",mountpoint="/var"} < 0.15
+          for: 15m
+          labels:
+            severity: warning
+            component: hardware
+            priority: P2
+          annotations:
+            dashboard_url: "/d/k8s-node-overview"
+            summary: "{{ $labels.instance }} /var {{ $value | humanizePercentage }} free"
+            description: "Talos node writable partition (/var: etcd, containerd, logs) filling — evictions/CrashLoops loom before kubelet DiskPressure."
+            action: "talosctl -n {{ $labels.instance }} df; prune unused images (crictl rmi --prune via debug); check log growth."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/host-sensors.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/host-sensors.yaml
@@ -5,9 +5,10 @@ metadata:
   labels:
     release: kube-prometheus-stack
 spec:
-  # CPU-temp >85 (warn-tier) + load + memory-pressure(<10%, dup of proxmox.yaml) → Grafana
-  # "Node Exporter / Nodes" dashboard. Kept the early-warning tickets: thermal-shutdown
-  # imminent (>95), host OOM (<5%), heavy swap (nipogi runs RAM-overcommitted).
+  # CPU-temp (PAGE: thermal-shutdown imminent >95 → host power-off kills its Talos workers)
+  # + NVMe-temp + heavy swap (nipogi runs RAM-overcommitted) → Grafana "Node Exporter /
+  # Nodes" dashboard. Host-memory dropped 2026-07-14: duplicated ProxmoxHostMemoryPressure
+  # (hosts) + NodeMemoryPressure (Talos).
   groups:
     - name: host-sensors
       interval: 1m
@@ -19,9 +20,9 @@ spec:
           # nvme excluded → eigener HostNVMeTemperatureCritical (node_exporter labelt SSD-Hotspot sonst als "CPU")
           for: 15m
           labels:
-            severity: warning
+            severity: critical
             component: hardware
-            priority: P2
+            priority: P1
           annotations:
             dashboard_url: "/d/k8s-node-overview"
             summary: "CPU {{ $labels.chip }} on {{ $labels.instance }} at {{ $value }}°C"
@@ -39,19 +40,6 @@ spec:
             summary: "NVMe {{ $labels.chip }}/{{ $labels.sensor }} on {{ $labels.instance }} at {{ $value }}°C"
             description: "NVMe running hot — thermal-throttles and degrades Ceph performance."
             action: "PHYSICAL: add/reseat heatsink, improve airflow/dust; reduce write load."
-
-        - alert: HostMemoryCritical
-          expr: node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes < 0.05
-          for: 5m
-          labels:
-            severity: warning
-            component: hardware
-            priority: P2
-          annotations:
-            dashboard_url: "/d/k8s-node-overview"
-            summary: "{{ $labels.instance }} critically low RAM ({{ $value | humanizePercentage }})"
-            description: "OOM-killer likely active — VMs at risk of being killed (nipogi runs 84G allocated / 77G physical)."
-            action: "kubectl top nodes; reduce/rebalance VM RAM (nipogi overcommitted 84G/77G) before the OOM-killer hits."
 
         - alert: HostSwapUsageHigh
           # Feuert nur bei ECHTEM Thrashing: Swap voll UND wenig RAM frei.

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/ssd-health.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/ssd-health.yaml
@@ -36,6 +36,21 @@ spec:
             summary: "SSD {{ $labels.device }} media errors ({{ $value }} new in 1h)"
             description: "Uncorrectable NAND errors — the drive is failing. Back up + replace (Ceph replicas on the other node protect cluster data)."
 
+        - alert: SSDSmartHealthFailed
+          # Overall SMART self-assessment = FAILED (distinct from the NVMe critical-warning
+          # bitfield above — this is the drive's own pass/fail verdict). Moved here 2026-07-14
+          # from proxmox.yaml to co-locate all smartctl_exporter alerts; label fixed disk→device.
+          expr: smartctl_device_smart_status == 0
+          for: 5m
+          labels:
+            severity: critical
+            component: storage
+          annotations:
+            dashboard_url: "/d/smartctl-exporter"
+            summary: "SMART health FAILED: {{ $labels.device }} on {{ $labels.instance }}"
+            description: "Drive's overall SMART self-assessment = FAILED — replace soon (data-loss risk; Ceph replicas on the other node protect cluster data)."
+            action: "SSH the host; 'smartctl -a /dev/{{ $labels.device }}'; plan a disk replacement."
+
     # ── TICKET — wearing out / blind spot ──
     - name: ssd-ticket
       interval: 5m

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/infrastructure/proxmox.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/infrastructure/proxmox.yaml
@@ -40,18 +40,6 @@ spec:
             description: "Pool in a data-loss state ({{ $labels.state }}) — VMs/Ceph on it at risk."
             action: "SSH the host; 'zpool status {{ $labels.zpool }}'; check failed disks, replace + resilver."
 
-        - alert: ProxmoxDiskSmartFailure
-          expr: smartctl_device_smart_status == 0
-          for: 5m
-          labels:
-            severity: critical
-            component: hypervisor
-          annotations:
-            dashboard_url: "/d/proxmox-cluster"
-            summary: "SMART health failure: {{ $labels.disk }} on {{ $labels.instance }}"
-            description: "Disk reporting SMART failure — replace soon (data-loss risk)."
-            action: "SSH the host; 'smartctl -a {{ $labels.disk }}'; plan a disk replacement (data-loss risk)."
-
     # ── TICKET ──
     - name: proxmox-ticket
       interval: 60s

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/kubernetes/cluster.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/kubernetes/cluster.yaml
@@ -41,6 +41,24 @@ spec:
             description: "Single-node etcd on ctrl-0 reports down for >10m. This is the known single-CP SPOF — there is no Raft quorum to lose on one node. A clean etcd restart does NOT corrupt data; only act if it stays down or ctrl-0 rebooted dirty."
             action: "talosctl -n 192.168.0.101 etcd status / etcd members; if persistently down and corrupt, restore from snapshot ('talosctl etcd snapshot')."
 
+        - alert: EtcdRequestLatencyHigh
+          # apiserver→etcd call latency (p99) — scrapeable via the apiserver even though the
+          # kube-etcd target is disabled. Baseline ~25ms; >500ms sustained = etcd disk/fsync
+          # degrading, the leading signal for the API-latency cascade (ctrl-0 on a slow disk).
+          # Warn now → check the etcd VM disk BEFORE it becomes ClusterAPIServerDown.
+          expr: |
+            histogram_quantile(0.99, sum by (le) (rate(etcd_request_duration_seconds_bucket[5m]))) > 0.5
+          for: 10m
+          labels:
+            severity: warning
+            component: kubernetes
+            priority: P2
+          annotations:
+            dashboard_url: "/d/k8s-cluster-overview"
+            summary: "etcd request p99 {{ $value | humanizeDuration }} (baseline ~25ms)"
+            description: "apiserver→etcd p99 >500ms for 10min — etcd disk/fsync is degrading. Unchecked this cascades to API-server slowness + outage (ctrl-0 on a slow disk)."
+            action: "'talosctl -n ctrl-0 etcd status'; ensure ctrl-0's etcd VM disk is on the fast SSD (Samsung, not HOGE); check I/O contention on that host."
+
         - alert: ControlPlaneNodeDown
           expr: kube_node_status_condition{condition="Ready",status="true",node="ctrl-0"} == 0
           for: 1m

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/kubernetes/workloads.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/kubernetes/workloads.yaml
@@ -71,3 +71,54 @@ spec:
             summary: "{{ $labels.namespace }}/{{ $labels.pod }}/{{ $labels.container }} throttled {{ $value | humanizePercentage }}"
             description: "Container throttled >75% of CFS periods for 15min — busy-loop or under-sized CPU limit."
             action: "kubectl top pod -n {{ $labels.namespace }} {{ $labels.pod }} --containers; busy-loop → fix root cause, else raise the cpu limit."
+
+        - alert: ContainerMemoryHigh
+          # working set / memory limit — the pre-OOM warning (ContainerOOMKilled only fires
+          # AFTER the kill). 95%: cilium + cert-manager-webhook measured ~0.91 near their
+          # (tight) limits by design → 90% would chronically fire on them; 95%/30m is the
+          # clean floor (0 chronic occupants). JVM/cache apps carry their own alerts too.
+          expr: |
+            sum by (namespace, pod, container) (container_memory_working_set_bytes{container!=""})
+              /
+            sum by (namespace, pod, container) (kube_pod_container_resource_limits{resource="memory"})
+              > 0.95
+          for: 30m
+          labels:
+            severity: warning
+            component: application
+            priority: P2
+          annotations:
+            dashboard_url: "/d/k8s-pod-overview"
+            summary: "{{ $labels.namespace }}/{{ $labels.pod }}/{{ $labels.container }} memory at {{ $value | humanizePercentage }} of limit"
+            description: "Container working set >95% of its memory limit for 30min — OOM-kill risk."
+            action: "kubectl top pod -n {{ $labels.namespace }} {{ $labels.pod }} --containers; raise the memory limit or fix the leak."
+
+        - alert: ContainerMemoryLeakSuspected
+          # predict_linear over the 6h trend: will the working set cross the memory limit
+          # within 6h — AND is it already >60% of that limit? JVM-immune (healthy GC = flat/
+          # sawtooth slope → no fire); the >60% floor drops benign slow-growers far from
+          # danger (cut 3 false candidates → 0). for:1h kills startup/cache-fill ramps.
+          expr: |
+            (
+              sum by (namespace, pod, container) (
+                predict_linear(container_memory_working_set_bytes{container!=""}[6h], 6 * 3600)
+              )
+                >
+              sum by (namespace, pod, container) (
+                kube_pod_container_resource_limits{resource="memory"}
+              )
+            )
+            and
+            sum by (namespace, pod, container) (container_memory_working_set_bytes{container!=""})
+              / sum by (namespace, pod, container) (kube_pod_container_resource_limits{resource="memory"})
+              > 0.60
+          for: 1h
+          labels:
+            severity: warning
+            component: application
+            priority: P2
+          annotations:
+            dashboard_url: "/d/k8s-pod-overview"
+            summary: "{{ $labels.namespace }}/{{ $labels.pod }}/{{ $labels.container }} memory trending to OOM"
+            description: "Working set is climbing; at the current 6h trend it exceeds the memory limit within ~24h — likely a leak."
+            action: "Check the pod's 24h memory graph; steady ramp (not sawtooth) = leak → restart to mitigate, then fix the root cause."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/kubernetes/workloads.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/kubernetes/workloads.yaml
@@ -50,3 +50,24 @@ spec:
             summary: "Pod {{ $labels.namespace }}/{{ $labels.pod }} not ready"
             description: "Pod stuck in {{ $labels.phase }} for 15+ min — scheduling failure or PVC unbound."
             action: "kubectl describe pod -n {{ $labels.namespace }} {{ $labels.pod }}; check events — scheduling, PVC-unbound, or failing readiness."
+
+        - alert: ContainerCPUThrottlingHigh
+          # A container pinned against its CPU limit >75% of CFS periods = busy-loop or under-
+          # sized limit. Blind spot before: the argocd redis-ha sentinel busy-looped at ~1 core
+          # UNCAPPED (no limit → no throttling → no signal) and cooked msa2 to 95°C. Now that
+          # runaways carry a limit, a recurrence surfaces here with the pod name before it heats.
+          expr: |
+            sum by (namespace, pod, container) (rate(container_cpu_cfs_throttled_periods_total{container!=""}[5m]))
+              /
+            sum by (namespace, pod, container) (rate(container_cpu_cfs_periods_total{container!=""}[5m]))
+              > 0.75
+          for: 15m
+          labels:
+            severity: warning
+            component: application
+            priority: P2
+          annotations:
+            dashboard_url: "/d/k8s-pod-overview"
+            summary: "{{ $labels.namespace }}/{{ $labels.pod }}/{{ $labels.container }} throttled {{ $value | humanizePercentage }}"
+            description: "Container throttled >75% of CFS periods for 15min — busy-loop or under-sized CPU limit."
+            action: "kubectl top pod -n {{ $labels.namespace }} {{ $labels.pod }} --containers; busy-loop → fix root cause, else raise the cpu limit."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/ingress.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/ingress.yaml
@@ -58,6 +58,61 @@ spec:
             description: "Edge proxy seeing high upstream errors — backend services degraded, users see failures."
             action: "Find the failing upstream in the envoy-global dashboard; check that backend's pods/health + any recent deploy."
 
+        - alert: EnvoyEdgeSLOFastBurn
+          # Edge availability SLO 99.5% (error budget 0.5%). Multi-window burn: 5m AND 1h
+          # 5xx-ratio both >14.4× budget (7.2%) = a month's budget gone in ~2 days → PAGE.
+          # Front-door SLO for EVERY exposed app (n8n, grafana, drova, …) — n8n has no internal
+          # error-SLI, so its user-facing availability is captured here. Traffic-floor kills
+          # low-traffic night false-pages.
+          expr: |
+            (
+              sum(rate(envoy_cluster_upstream_rq_xx{envoy_response_code_class="5"}[1h]))
+              / clamp_min(sum(rate(envoy_cluster_upstream_rq_total[1h])), 0.001) > 0.072
+            )
+            and
+            (
+              sum(rate(envoy_cluster_upstream_rq_xx{envoy_response_code_class="5"}[5m]))
+              / clamp_min(sum(rate(envoy_cluster_upstream_rq_total[5m])), 0.001) > 0.072
+            )
+            and
+            sum(rate(envoy_cluster_upstream_rq_total[5m])) > 0.05
+          for: 2m
+          labels:
+            severity: critical
+            component: network
+            priority: P1
+          annotations:
+            dashboard_url: "/d/envoy-global"
+            summary: "Edge SLO fast-burn: {{ $value | humanizePercentage }} 5xx (budget 0.5%)"
+            description: "The ingress edge is burning its availability error budget 14.4× — a month's budget in ~2 days. Every exposed app is affected."
+            action: "envoy-global dashboard → which upstream is 5xx'ing; check that backend + recent deploys. Pages because the whole front door is degraded."
+
+        - alert: EnvoyEdgeSLOSlowBurn
+          # Slow window: 30m AND 6h 5xx-ratio both >6× budget (3%) → catches a grinding
+          # degradation the fast-burn misses. Ticket.
+          expr: |
+            (
+              sum(rate(envoy_cluster_upstream_rq_xx{envoy_response_code_class="5"}[6h]))
+              / clamp_min(sum(rate(envoy_cluster_upstream_rq_total[6h])), 0.001) > 0.03
+            )
+            and
+            (
+              sum(rate(envoy_cluster_upstream_rq_xx{envoy_response_code_class="5"}[30m]))
+              / clamp_min(sum(rate(envoy_cluster_upstream_rq_total[30m])), 0.001) > 0.03
+            )
+            and
+            sum(rate(envoy_cluster_upstream_rq_total[30m])) > 0.05
+          for: 15m
+          labels:
+            severity: warning
+            component: network
+            priority: P2
+          annotations:
+            dashboard_url: "/d/envoy-global"
+            summary: "Edge SLO slow-burn: {{ $value | humanizePercentage }} 5xx (budget 0.5%)"
+            description: "The ingress edge has burned availability budget at 6× for hours — a persistent low-grade failure across the front door."
+            action: "envoy-global dashboard → the chronically-failing upstream; likely one backend flapping. Fix before it erodes the month's budget."
+
         - alert: EnvoyGatewayNoEndpoints
           expr: |
             sum by (envoy_cluster_name, namespace) (

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/observability/health.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/observability/health.yaml
@@ -60,6 +60,22 @@ spec:
             description: "Prometheus cannot scrape {{ $labels.instance }} for >15min."
             action: "Check {{ $labels.instance }} ({{ $labels.job }}): is the exporter/pod up? ServiceMonitor selector + network policy?"
 
+        - alert: PrometheusRuleFailures
+          # A recording/alerting rule erroring at eval time = silent blind spot: the alert it
+          # would raise never fires. We add rules often → catch a broken PromQL/template.
+          # (Does NOT catch a missing `release` label — that rule never loads, no failure metric.)
+          expr: increase(prometheus_rule_evaluation_failures_total[10m]) > 0
+          for: 15m
+          labels:
+            severity: warning
+            component: observability
+            priority: P2
+          annotations:
+            dashboard_url: "/d/prometheus-stats"
+            summary: "Prometheus rule group {{ $labels.rule_group }} failing evaluation"
+            description: "A Prometheus rule has been erroring at evaluation for >15min — the alert/recording rule it defines is silently not working."
+            action: "Prometheus UI → Status → Rules for the red group; fix the PromQL/template error in the offending PrometheusRule."
+
         - alert: GrafanaDown
           expr: up{job="grafana"} == 0
           for: 5m

--- a/kubernetes/security/compliance/kyverno-policies.yaml
+++ b/kubernetes/security/compliance/kyverno-policies.yaml
@@ -54,6 +54,38 @@ spec:
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
+  name: audit-require-limits
+spec:
+  failurePolicy: Ignore
+  background: true
+  rules:
+    - name: require-memory-limits
+      # Memory is incompressible → a container without a memory limit can OOM the whole node,
+      # and it is invisible to ContainerMemoryHigh/ContainerMemoryLeakSuspected (both divide
+      # by the limit). Audit-only: reports via PolicyReport, blocks nothing. CPU limits are
+      # deliberately NOT required — CPU is compressible; a blanket cpu-limit causes harmful
+      # throttling. Runaway CPU is caught by ContainerCPUThrottlingHigh on capped workloads.
+      match:
+        any:
+          - resources:
+              kinds: ["Pod"]
+      exclude:
+        any:
+          - resources:
+              namespaces: ["kube-system", "kyverno", "argocd"]
+      validate:
+        failureAction: Audit
+        message: "A memory limit should be set (prevents node OOM + enables the memory alerts)."
+        pattern:
+          spec:
+            containers:
+              - resources:
+                  limits:
+                    memory: "?*"
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
   name: audit-verify-drova-signatures
 spec:
   failurePolicy: Ignore


### PR DESCRIPTION
## What

Alerting hardening pass — closes the Google-SRE Golden-Signals saturation gap, adds leading indicators, an edge SLO, and promtool unit-testing. Motivated by the redis-ha sentinel busy-loop (uncapped container burned ~1 core → msa2 hit 95°C) that no alert caught.

### New alerts
- **ContainerCPUThrottlingHigh** — container pinned >75% of CFS periods. The sentinel class: uncapped containers can't throttle, so there was no signal.
- **ContainerMemoryHigh** (>95% of limit, 30m) + **ContainerMemoryLeakSuspected** (`predict_linear` 6h→6h, floor >60%) — JVM-immune leak detector (healthy GC = flat slope → no fire).
- **EtcdRequestLatencyHigh** — apiserver→etcd p99 >500ms. Leading signal for the ctrl-0-on-slow-disk API cascade; scrapeable via apiserver (kube-etcd target is disabled), baseline ~25ms.
- **TalosNodeDiskFillingUp** — `/var` <15%. node-exporter exposes no `/` on Talos → node disk-fill was fully unmonitored.
- **EnvoyEdgeSLOFastBurn** (page) + **EnvoyEdgeSLOSlowBurn** (ticket) — multi-window burn on edge availability (99.5% SLO). Front-door SLO for every exposed app; n8n has no internal error-SLI so this covers its user-facing availability.
- **PrometheusRuleFailures** — silent rule-eval breakage watchdog.

### Removed (redundant — verified via live job-label check)
- **HostMemoryCritical** — duplicated ProxmoxHostMemoryPressure (hosts) + NodeMemoryPressure (Talos).
- **HostRootFilesystemAlmostFull** — duplicated ProxmoxRootDiskFull; both only match the Proxmox hosts (the `disk-io.yaml` comment claiming Talos coverage was false — corrected).

### Changed
- **HostCPUTemperatureCritical** `warning` → `critical` — a host thermal-shutdown kills its Talos workers, page-worthy.
- **ProxmoxDiskSmartFailure** → **SSDSmartHealthFailed**, co-located into `ssd-health.yaml`; label fixed `disk` → `device` (the message rendered empty).

### Policy
- Kyverno **audit-require-limits** (memory limits, Audit mode — reports, blocks nothing). CPU limits deliberately not required: CPU is compressible, blanket cpu-limits cause harmful throttling; runaway CPU is caught by ContainerCPUThrottlingHigh.

### Testing
- promtool unit-test harness (`.github/scripts/test-alerts.py` + `.github/tests/alerts/`) wired into the `alert-lint` CI job. 5 cases green: firing + rendered summary/description assertions + a negative (below-threshold) case.

## Validation
- All rule changes pass server-side dry-run (prometheus-operator webhook validates PromQL).
- promtool unit tests green locally (0 failed).
- All exprs sanity-checked live against Prometheus (thresholds vs. current baselines).

Net **154** alert rules (+6: 8 added, 2 redundant removed, 1 renamed/relocated).
