### PR TITLE
n8n barman sidecar resources

### DIFF
--- a/kubernetes/tenants/n8n-prod/postgres/base/barman-object-store.yaml
+++ b/kubernetes/tenants/n8n-prod/postgres/base/barman-object-store.yaml
@@ -22,3 +22,13 @@ spec:
       compression: gzip
       jobs: 2
   retentionPolicy: "30d"
+  # was missing entirely (drova/keycloak have it) → plugin default limit throttled the
+  # sidecar 91% of CFS periods (caught by ContainerCPUThrottlingHigh on day one) → slow WAL-archiving
+  instanceSidecarConfiguration:
+    resources:
+      requests:
+        cpu: 200m
+        memory: 128Mi
+      limits:
+        cpu: 1000m           # 1.0 CPU for WAL-archive bursts (compression intensive)
+        memory: 256Mi


### PR DESCRIPTION
## What
Add the missing `instanceSidecarConfiguration` to n8n-prod's barman ObjectStore — drova (1500m) and keycloak (1000m, with the same throttling history in its comment) have it; n8n was left on the plugin default.

## Why
Caught by the new **ContainerCPUThrottlingHigh** alert on its first day live: `n8n-prod/n8n-postgres-1/plugin-barman-cloud` throttled **91.5%** of CFS periods (all other clusters' sidecars: 0). A near-zero-usage container throttling that hard = tiny default quota → every WAL-archive burst gets choked → slow archiving.

Mirrors keycloak's values: requests 200m/128Mi, limits 1000m/256Mi.

## Validation
- server-side dry-run OK, prod overlay builds.
- n8n-prod-cnpg app is Synced/Healthy and owns this path (tenants are manual-sync → sync after merge, then verify throttle-ratio drops to ~0).