### PR TITLE
edge slo + waf dashboards

### DIFF
--- a/kubernetes/infrastructure/observability/dashboards/configs/base/cert-manager-dashboard.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/configs/base/cert-manager-dashboard.yaml
@@ -1,0 +1,16 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: cert-manager-working
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/part-of: monitoring-stack
+    team: platform
+spec:
+  instanceSelector:
+    matchLabels:
+      app: grafana
+  allowCrossNamespaceImport: true
+  folder: "Infrastructure"
+  resyncPeriod: "10m"
+  url: "https://raw.githubusercontent.com/monitoring-mixins/website/master/assets/cert-manager/dashboards/cert-manager.json"

--- a/kubernetes/infrastructure/observability/dashboards/configs/base/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/configs/base/kustomization.yaml
@@ -9,6 +9,8 @@ resources:
   - ../drova
   - ../observability
   - ../infrastructure
+  - ../network
+  - ../security
   - velero-backup-status.yaml
   - n8n-health.yaml
   - n8n-overview.yaml

--- a/kubernetes/infrastructure/observability/dashboards/configs/drova/drova-slo-burnrate.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/configs/drova/drova-slo-burnrate.yaml
@@ -58,6 +58,36 @@ spec:
         {"id":21,"type":"timeseries","title":"5xx rate per service","gridPos":{"x":0,"y":21,"w":24,"h":8},
          "datasource":{"type":"prometheus","uid":"prometheus"},
          "targets":[{"expr":"sum by (service_name) (rate(http_server_request_duration_seconds_count{service_name=~\"api-gateway|user-service|chat-service|trip-service|driver-service|payment-service\",http_response_status_code=~\"5..\"}[5m]))","legendFormat":"{{service_name}}"}],
-         "fieldConfig":{"defaults":{"unit":"reqps"}}}
+         "fieldConfig":{"defaults":{"unit":"reqps"}}},
+        {"id":30,"type":"row","title":"Error budget per service (30d — availability 99.5% / latency 99%)","gridPos":{"x":0,"y":29,"w":24,"h":1}},
+        {"id":31,"type":"bargauge","title":"Budget remaining — availability (30d)","gridPos":{"x":0,"y":30,"w":8,"h":8},
+         "datasource":{"type":"prometheus","uid":"prometheus"},
+         "targets":[
+           {"expr":"100 * clamp_min(1 - ((1 - avg_over_time(slo:drova_chat_service_availability:ratio_rate1h[30d])) / 0.005), 0)","legendFormat":"chat","instant":true},
+           {"expr":"100 * clamp_min(1 - ((1 - avg_over_time(slo:drova_api_gateway_availability:ratio_rate1h[30d])) / 0.005), 0)","legendFormat":"api-gateway","instant":true},
+           {"expr":"100 * clamp_min(1 - ((1 - avg_over_time(slo:drova_user_service_availability:ratio_rate1h[30d])) / 0.005), 0)","legendFormat":"user","instant":true},
+           {"expr":"100 * clamp_min(1 - ((1 - avg_over_time(slo:drova_trip_service_availability:ratio_rate1h[30d])) / 0.005), 0)","legendFormat":"trip","instant":true},
+           {"expr":"100 * clamp_min(1 - ((1 - avg_over_time(slo:drova_driver_service_availability:ratio_rate1h[30d])) / 0.005), 0)","legendFormat":"driver","instant":true}],
+         "options":{"displayMode":"gradient","orientation":"horizontal"},
+         "fieldConfig":{"defaults":{"unit":"percent","min":0,"max":100,"decimals":1,"thresholds":{"mode":"absolute","steps":[{"color":"red","value":null},{"color":"yellow","value":50},{"color":"green","value":80}]}}}},
+        {"id":32,"type":"bargauge","title":"Budget remaining — latency (30d)","gridPos":{"x":8,"y":30,"w":8,"h":8},
+         "datasource":{"type":"prometheus","uid":"prometheus"},
+         "targets":[
+           {"expr":"100 * clamp_min(1 - ((1 - avg_over_time(slo:drova_chat_service_latency:ratio_rate1h[30d])) / 0.01), 0)","legendFormat":"chat","instant":true},
+           {"expr":"100 * clamp_min(1 - ((1 - avg_over_time(slo:drova_api_gateway_latency:ratio_rate1h[30d])) / 0.01), 0)","legendFormat":"api-gateway","instant":true},
+           {"expr":"100 * clamp_min(1 - ((1 - avg_over_time(slo:drova_user_service_latency:ratio_rate1h[30d])) / 0.01), 0)","legendFormat":"user","instant":true},
+           {"expr":"100 * clamp_min(1 - ((1 - avg_over_time(slo:drova_trip_service_latency:ratio_rate1h[30d])) / 0.01), 0)","legendFormat":"trip","instant":true},
+           {"expr":"100 * clamp_min(1 - ((1 - avg_over_time(slo:drova_driver_service_latency:ratio_rate1h[30d])) / 0.01), 0)","legendFormat":"driver","instant":true}],
+         "options":{"displayMode":"gradient","orientation":"horizontal"},
+         "fieldConfig":{"defaults":{"unit":"percent","min":0,"max":100,"decimals":1,"thresholds":{"mode":"absolute","steps":[{"color":"red","value":null},{"color":"yellow","value":50},{"color":"green","value":80}]}}}},
+        {"id":33,"type":"timeseries","title":"Budget burndown per service — availability (rolling 30d)","gridPos":{"x":16,"y":30,"w":8,"h":8},
+         "datasource":{"type":"prometheus","uid":"prometheus"},
+         "targets":[
+           {"expr":"100 * clamp_min(1 - ((1 - avg_over_time(slo:drova_chat_service_availability:ratio_rate1h[30d])) / 0.005), 0)","legendFormat":"chat"},
+           {"expr":"100 * clamp_min(1 - ((1 - avg_over_time(slo:drova_api_gateway_availability:ratio_rate1h[30d])) / 0.005), 0)","legendFormat":"api-gateway"},
+           {"expr":"100 * clamp_min(1 - ((1 - avg_over_time(slo:drova_user_service_availability:ratio_rate1h[30d])) / 0.005), 0)","legendFormat":"user"},
+           {"expr":"100 * clamp_min(1 - ((1 - avg_over_time(slo:drova_trip_service_availability:ratio_rate1h[30d])) / 0.005), 0)","legendFormat":"trip"},
+           {"expr":"100 * clamp_min(1 - ((1 - avg_over_time(slo:drova_driver_service_availability:ratio_rate1h[30d])) / 0.005), 0)","legendFormat":"driver"}],
+         "fieldConfig":{"defaults":{"unit":"percent","min":0,"max":100,"thresholds":{"mode":"absolute","steps":[{"color":"red","value":null},{"color":"yellow","value":50},{"color":"green","value":80}]}}}}
       ]
     }

--- a/kubernetes/infrastructure/observability/dashboards/configs/network/edge-slo.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/configs/network/edge-slo.yaml
@@ -1,0 +1,70 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: edge-slo
+  namespace: grafana
+spec:
+  uid: edge-slo
+  instanceSelector:
+    matchLabels:
+      app: grafana
+  allowCrossNamespaceImport: true
+  folder: Network
+  json: |
+    {
+      "title": "Edge SLO — Availability 99.5% (Envoy front door)",
+      "uid": "edge-slo",
+      "tags": ["sre","slo","edge","envoy"],
+      "timezone": "browser",
+      "schemaVersion": 39,
+      "refresh": "30s",
+      "time": {"from": "now-24h", "to": "now"},
+      "templating": {"list":[]},
+      "panels": [
+        {"id":1,"type":"stat","title":"SLO compliance (30d)","gridPos":{"x":0,"y":0,"w":5,"h":5},
+         "datasource":{"type":"prometheus","uid":"prometheus"},
+         "targets":[{"expr":"100 * avg_over_time(slo:edge_availability:ratio_rate1h[30d])"}],
+         "fieldConfig":{"defaults":{"unit":"percent","decimals":3,"thresholds":{"mode":"absolute","steps":[{"color":"red","value":null},{"color":"yellow","value":99},{"color":"green","value":99.5}]}}}},
+        {"id":2,"type":"stat","title":"Error budget remaining (30d)","gridPos":{"x":5,"y":0,"w":5,"h":5},
+         "datasource":{"type":"prometheus","uid":"prometheus"},
+         "targets":[{"expr":"100 * clamp_min(1 - ((1 - avg_over_time(slo:edge_availability:ratio_rate1h[30d])) / 0.005), 0)"}],
+         "fieldConfig":{"defaults":{"unit":"percent","decimals":1,"thresholds":{"mode":"absolute","steps":[{"color":"red","value":null},{"color":"yellow","value":50},{"color":"green","value":80}]}}}},
+        {"id":3,"type":"stat","title":"Fast burn (1h, page ≥14.4)","gridPos":{"x":10,"y":0,"w":5,"h":5},
+         "datasource":{"type":"prometheus","uid":"prometheus"},
+         "targets":[{"expr":"(1 - slo:edge_availability:ratio_rate1h) / 0.005"}],
+         "fieldConfig":{"defaults":{"decimals":2,"thresholds":{"mode":"absolute","steps":[{"color":"green","value":null},{"color":"yellow","value":6},{"color":"red","value":14.4}]}}}},
+        {"id":4,"type":"stat","title":"Slow burn (6h, ticket ≥6)","gridPos":{"x":15,"y":0,"w":5,"h":5},
+         "datasource":{"type":"prometheus","uid":"prometheus"},
+         "targets":[{"expr":"(1 - slo:edge_availability:ratio_rate6h) / 0.005"}],
+         "fieldConfig":{"defaults":{"decimals":2,"thresholds":{"mode":"absolute","steps":[{"color":"green","value":null},{"color":"yellow","value":1},{"color":"red","value":6}]}}}},
+        {"id":5,"type":"stat","title":"Traffic (req/s)","gridPos":{"x":20,"y":0,"w":4,"h":5},
+         "datasource":{"type":"prometheus","uid":"prometheus"},
+         "targets":[{"expr":"slo:edge_requests:rate5m"}],
+         "fieldConfig":{"defaults":{"unit":"reqps","decimals":2,"thresholds":{"mode":"absolute","steps":[{"color":"text","value":null}]}}}},
+        {"id":10,"type":"row","title":"Multi-Window Burn-Rate (alert pair: 14.4× fast / 6× slow)","gridPos":{"x":0,"y":5,"w":24,"h":1}},
+        {"id":11,"type":"timeseries","title":"Fast windows: 5m + 1h burn (EnvoyEdgeSLOFastBurn pages at 14.4)","gridPos":{"x":0,"y":6,"w":12,"h":7},
+         "datasource":{"type":"prometheus","uid":"prometheus"},
+         "targets":[
+           {"expr":"(1 - slo:edge_availability:ratio_rate5m) / 0.005","legendFormat":"burn 5m"},
+           {"expr":"(1 - slo:edge_availability:ratio_rate1h) / 0.005","legendFormat":"burn 1h"}],
+         "fieldConfig":{"defaults":{"custom":{"axisLabel":"× budget"},"thresholds":{"mode":"absolute","steps":[{"color":"green","value":null},{"color":"red","value":14.4}]}}}},
+        {"id":12,"type":"timeseries","title":"Slow windows: 30m + 6h burn (EnvoyEdgeSLOSlowBurn tickets at 6)","gridPos":{"x":12,"y":6,"w":12,"h":7},
+         "datasource":{"type":"prometheus","uid":"prometheus"},
+         "targets":[
+           {"expr":"(1 - slo:edge_availability:ratio_rate30m) / 0.005","legendFormat":"burn 30m"},
+           {"expr":"(1 - slo:edge_availability:ratio_rate6h) / 0.005","legendFormat":"burn 6h"}],
+         "fieldConfig":{"defaults":{"custom":{"axisLabel":"× budget"},"thresholds":{"mode":"absolute","steps":[{"color":"green","value":null},{"color":"red","value":6}]}}}},
+        {"id":20,"type":"row","title":"Error budget","gridPos":{"x":0,"y":13,"w":24,"h":1}},
+        {"id":21,"type":"timeseries","title":"Budget burndown (rolling 30d window)","gridPos":{"x":0,"y":14,"w":12,"h":7},
+         "datasource":{"type":"prometheus","uid":"prometheus"},
+         "targets":[{"expr":"100 * clamp_min(1 - ((1 - avg_over_time(slo:edge_availability:ratio_rate1h[30d])) / 0.005), 0)","legendFormat":"budget remaining"}],
+         "fieldConfig":{"defaults":{"unit":"percent","min":0,"max":100,"thresholds":{"mode":"absolute","steps":[{"color":"red","value":null},{"color":"yellow","value":50},{"color":"green","value":80}]}}}},
+        {"id":22,"type":"timeseries","title":"5xx ratio (5m / 1h / 6h)","gridPos":{"x":12,"y":14,"w":12,"h":7},
+         "datasource":{"type":"prometheus","uid":"prometheus"},
+         "targets":[
+           {"expr":"1 - slo:edge_availability:ratio_rate5m","legendFormat":"5m"},
+           {"expr":"1 - slo:edge_availability:ratio_rate1h","legendFormat":"1h"},
+           {"expr":"1 - slo:edge_availability:ratio_rate6h","legendFormat":"6h"}],
+         "fieldConfig":{"defaults":{"unit":"percentunit","thresholds":{"mode":"absolute","steps":[{"color":"green","value":null},{"color":"red","value":0.005}]}}}}
+      ]
+    }

--- a/kubernetes/infrastructure/observability/dashboards/configs/network/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/configs/network/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - edge-slo.yaml

--- a/kubernetes/infrastructure/observability/dashboards/configs/security/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/configs/security/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - waf-coraza.yaml

--- a/kubernetes/infrastructure/observability/dashboards/configs/security/waf-coraza.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/configs/security/waf-coraza.yaml
@@ -1,0 +1,50 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: waf-coraza
+  namespace: grafana
+spec:
+  uid: waf-coraza
+  instanceSelector:
+    matchLabels:
+      app: grafana
+  allowCrossNamespaceImport: true
+  folder: Security
+  json: |
+    {
+      "title": "Coraza WAF — Detections & Blocks",
+      "uid": "waf-coraza",
+      "tags": ["security","waf","coraza","owasp-crs"],
+      "timezone": "browser",
+      "schemaVersion": 39,
+      "refresh": "1m",
+      "time": {"from": "now-7d", "to": "now"},
+      "templating": {"list":[]},
+      "panels": [
+        {"id":1,"type":"text","title":"","gridPos":{"x":0,"y":0,"w":24,"h":2},
+         "options":{"mode":"markdown","content":"**Event-getriebene Metrik** (`waf_coraza_detections_total`, erzeugt von Vector `log_to_metric` aus Envoy/Coraza-Logs): *No data = keine Angriffe erkannt* — die Serie wird stale, wenn nichts detektiert wird. Pipeline-Test: Request mit SQLi-Pattern gegen eine öffentliche Route schicken → Panel muss zucken. Alerts: CorazaWAFDetectionSpike / CorazaWAFBlockingSpike."}},
+        {"id":2,"type":"stat","title":"Detections (24h)","gridPos":{"x":0,"y":2,"w":6,"h":5},
+         "datasource":{"type":"prometheus","uid":"prometheus"},
+         "targets":[{"expr":"sum(increase(waf_coraza_detections_total[24h])) or vector(0)"}],
+         "fieldConfig":{"defaults":{"decimals":0,"thresholds":{"mode":"absolute","steps":[{"color":"green","value":null},{"color":"yellow","value":10},{"color":"red","value":100}]}}}},
+        {"id":3,"type":"stat","title":"Detections (7d)","gridPos":{"x":6,"y":2,"w":6,"h":5},
+         "datasource":{"type":"prometheus","uid":"prometheus"},
+         "targets":[{"expr":"sum(increase(waf_coraza_detections_total[7d])) or vector(0)"}],
+         "fieldConfig":{"defaults":{"decimals":0,"thresholds":{"mode":"absolute","steps":[{"color":"green","value":null},{"color":"yellow","value":50},{"color":"red","value":500}]}}}},
+        {"id":4,"type":"stat","title":"Actions (24h)","gridPos":{"x":12,"y":2,"w":12,"h":5},
+         "datasource":{"type":"prometheus","uid":"prometheus"},
+         "targets":[{"expr":"sum by (action) (increase(waf_coraza_detections_total[24h]))","legendFormat":"{{action}}","instant":true}],
+         "options":{"textMode":"value_and_name"},
+         "fieldConfig":{"defaults":{"decimals":0,"thresholds":{"mode":"absolute","steps":[{"color":"text","value":null}]}}}},
+        {"id":10,"type":"row","title":"Timeline","gridPos":{"x":0,"y":7,"w":24,"h":1}},
+        {"id":11,"type":"timeseries","title":"Detections by action (1h rate)","gridPos":{"x":0,"y":8,"w":12,"h":8},
+         "datasource":{"type":"prometheus","uid":"prometheus"},
+         "targets":[{"expr":"sum by (action) (increase(waf_coraza_detections_total[1h]))","legendFormat":"{{action}}"}],
+         "fieldConfig":{"defaults":{"decimals":0,"custom":{"drawStyle":"bars","fillOpacity":60}}}},
+        {"id":12,"type":"bargauge","title":"Top rule IDs (7d) — CRS-Regel-Treffer","gridPos":{"x":12,"y":8,"w":12,"h":8},
+         "datasource":{"type":"prometheus","uid":"prometheus"},
+         "targets":[{"expr":"topk(10, sum by (rule_id) (increase(waf_coraza_detections_total[7d])))","legendFormat":"{{rule_id}}","instant":true}],
+         "options":{"displayMode":"gradient","orientation":"horizontal"},
+         "fieldConfig":{"defaults":{"decimals":0,"thresholds":{"mode":"absolute","steps":[{"color":"blue","value":null}]}}}}
+      ]
+    }

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/ingress.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/ingress.yaml
@@ -8,6 +8,40 @@ spec:
   # Two 5xx alerts deduped to one (the %-based EnvoyGateway5xxRateHigh). Down+Info merged.
   # Upstream-connection-failure → dashboard. CloudflaredAllDown = the external-access page.
   groups:
+    # ── RECORDING — edge SLO ratios (single source for the burn alerts below AND the
+    # edge-slo Grafana dashboard; availability = 1 - 5xx-ratio at the Envoy front door) ──
+    - name: edge-slo-recording
+      interval: 30s
+      rules:
+        - record: slo:edge_availability:ratio_rate5m
+          expr: |
+            1 - (
+              sum(rate(envoy_cluster_upstream_rq_xx{envoy_response_code_class="5"}[5m]))
+              / clamp_min(sum(rate(envoy_cluster_upstream_rq_total[5m])), 0.001)
+            )
+        - record: slo:edge_availability:ratio_rate30m
+          expr: |
+            1 - (
+              sum(rate(envoy_cluster_upstream_rq_xx{envoy_response_code_class="5"}[30m]))
+              / clamp_min(sum(rate(envoy_cluster_upstream_rq_total[30m])), 0.001)
+            )
+        - record: slo:edge_availability:ratio_rate1h
+          expr: |
+            1 - (
+              sum(rate(envoy_cluster_upstream_rq_xx{envoy_response_code_class="5"}[1h]))
+              / clamp_min(sum(rate(envoy_cluster_upstream_rq_total[1h])), 0.001)
+            )
+        - record: slo:edge_availability:ratio_rate6h
+          expr: |
+            1 - (
+              sum(rate(envoy_cluster_upstream_rq_xx{envoy_response_code_class="5"}[6h]))
+              / clamp_min(sum(rate(envoy_cluster_upstream_rq_total[6h])), 0.001)
+            )
+        - record: slo:edge_requests:rate5m
+          expr: sum(rate(envoy_cluster_upstream_rq_total[5m]))
+        - record: slo:edge_requests:rate30m
+          expr: sum(rate(envoy_cluster_upstream_rq_total[30m]))
+
     # ── PAGE ──
     - name: ingress-page
       interval: 60s
@@ -65,17 +99,11 @@ spec:
           # error-SLI, so its user-facing availability is captured here. Traffic-floor kills
           # low-traffic night false-pages.
           expr: |
-            (
-              sum(rate(envoy_cluster_upstream_rq_xx{envoy_response_code_class="5"}[1h]))
-              / clamp_min(sum(rate(envoy_cluster_upstream_rq_total[1h])), 0.001) > 0.072
-            )
+            ((1 - slo:edge_availability:ratio_rate1h) > 0.072)
             and
-            (
-              sum(rate(envoy_cluster_upstream_rq_xx{envoy_response_code_class="5"}[5m]))
-              / clamp_min(sum(rate(envoy_cluster_upstream_rq_total[5m])), 0.001) > 0.072
-            )
+            ((1 - slo:edge_availability:ratio_rate5m) > 0.072)
             and
-            sum(rate(envoy_cluster_upstream_rq_total[5m])) > 0.05
+            slo:edge_requests:rate5m > 0.05
           for: 2m
           labels:
             severity: critical
@@ -91,17 +119,11 @@ spec:
           # Slow window: 30m AND 6h 5xx-ratio both >6× budget (3%) → catches a grinding
           # degradation the fast-burn misses. Ticket.
           expr: |
-            (
-              sum(rate(envoy_cluster_upstream_rq_xx{envoy_response_code_class="5"}[6h]))
-              / clamp_min(sum(rate(envoy_cluster_upstream_rq_total[6h])), 0.001) > 0.03
-            )
+            ((1 - slo:edge_availability:ratio_rate6h) > 0.03)
             and
-            (
-              sum(rate(envoy_cluster_upstream_rq_xx{envoy_response_code_class="5"}[30m]))
-              / clamp_min(sum(rate(envoy_cluster_upstream_rq_total[30m])), 0.001) > 0.03
-            )
+            ((1 - slo:edge_availability:ratio_rate30m) > 0.03)
             and
-            sum(rate(envoy_cluster_upstream_rq_total[30m])) > 0.05
+            slo:edge_requests:rate30m > 0.05
           for: 15m
           labels:
             severity: warning


### PR DESCRIPTION
## What
Closes the 3 dashboard gaps from the audit (all live-verified beforehand):

1. **Recording rules** `slo:edge_availability:ratio_rate{5m,30m,1h,6h}` + `slo:edge_requests:rate{5m,30m}` — the EnvoyEdgeSLO burn alerts now consume them instead of inlining the math, so **alerts and dashboard compute from one source**. promtool unit tests still green after the refactor (proves the indirection).
2. **New `edge-slo` dashboard** (Network folder): SLO compliance 30d · error-budget remaining gauge · fast/slow burn stats · multi-window burn timelines with the 14.4×/6× alert thresholds drawn in · budget burndown · 5xx-ratio windows.
3. **New `waf-coraza` dashboard** (Security folder): first consumer of `waf_coraza_detections_total` (metric is alive — 7 series in 30d — but no dashboard used it). Detections 24h/7d · actions · timeline by action · top CRS rule-ids. Header text documents the event-driven/stale-when-quiet semantics.
4. **drova-slo-burnrate extended**: per-service error-budget row — remaining-budget bargauges (availability 99.5% + latency 99%) + 30d burndown per service. (The aggregate budget stat already existed; per-service view was the gap.)

## Validation
- promtool unit tests: SUCCESS (alert refactor covered by existing EnvoyEdgeSLOFastBurn cases)
- lint-alerts: 0 failures · lint-dashboards: 53 CRs, 0 failures
- kustomize build green, server-side dry-run green on all changed/new CRs