### PR TITLE
slack prod prefix + memcached exclusion

### DIFF
--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/kubernetes/workloads.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/kubernetes/workloads.yaml
@@ -76,9 +76,10 @@ spec:
           # working set / memory limit — the pre-OOM warning (ContainerOOMKilled only fires
           # AFTER the kill). 95%: cilium + cert-manager-webhook measured ~0.91 near their
           # (tight) limits by design → 90% would chronically fire on them; 95%/30m is the
-          # clean floor (0 chronic occupants). JVM/cache apps carry their own alerts too.
+          # clean floor (0 chronic occupants). memcached excluded: caches fill to their
+          # limit BY DESIGN (evict, don't OOM) — loki-chunks-cache false-fired 2026-07-14.
           expr: |
-            sum by (namespace, pod, container) (container_memory_working_set_bytes{container!=""})
+            sum by (namespace, pod, container) (container_memory_working_set_bytes{container!="",container!="memcached"})
               /
             sum by (namespace, pod, container) (kube_pod_container_resource_limits{resource="memory"})
               > 0.95
@@ -98,10 +99,13 @@ spec:
           # within 6h — AND is it already >60% of that limit? JVM-immune (healthy GC = flat/
           # sawtooth slope → no fire); the >60% floor drops benign slow-growers far from
           # danger (cut 3 false candidates → 0). for:1h kills startup/cache-fill ramps.
+          # memcached excluded: a cache filling toward its limit is its JOB (evicts at the
+          # top, never OOMs) — the predict sees the fill-ramp and cries wolf
+          # (loki-chunks-cache, 2026-07-14).
           expr: |
             (
               sum by (namespace, pod, container) (
-                predict_linear(container_memory_working_set_bytes{container!=""}[6h], 6 * 3600)
+                predict_linear(container_memory_working_set_bytes{container!="",container!="memcached"}[6h], 6 * 3600)
               )
                 >
               sum by (namespace, pod, container) (
@@ -109,7 +113,7 @@ spec:
               )
             )
             and
-            sum by (namespace, pod, container) (container_memory_working_set_bytes{container!=""})
+            sum by (namespace, pod, container) (container_memory_working_set_bytes{container!="",container!="memcached"})
               / sum by (namespace, pod, container) (kube_pod_container_resource_limits{resource="memory"})
               > 0.60
           for: 1h

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
@@ -625,7 +625,7 @@ alertmanager:
       {{ end }}
 
       {{ define "slack.title" -}}
-      [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ template "slack.icon" . }} {{ .CommonLabels.alertname }}
+      [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] [{{ .CommonLabels.cluster | toUpper | reReplaceAll "-TALOS" "" }}] {{ template "slack.icon" . }} {{ .CommonLabels.alertname }}
       {{- end }}
 
       {{ define "slack.color" -}}


### PR DESCRIPTION
## What
1. **Slack title gets a cluster prefix:** `[FIRING:1] [PROD] ⚠️ CephSlowOps …` — rendered from the `cluster` externalLabel (prod-talos → PROD) that every alert already carries but nothing displayed. Channel rename isn't possible, so the message now self-identifies; when staging/test exist, their alerts automatically render [STAGING]/[TEST] with zero further changes.
2. **memcached excluded from both memory alerts** (ContainerMemoryHigh + ContainerMemoryLeakSuspected): a cache filling toward its limit is its job — it evicts at the top and never OOMs. The predict_linear saw loki-chunks-cache's fill-ramp tonight (22:37) and cried wolf. Same reasoning as the cilium/cert-manager 95%-floor: known by-design occupants get excluded, not alarmed.

## Validation
values YAML parses · lint-alerts 0/0/0 · promtool unit tests green (memory-alert cases use keycloak/argocd containers — unaffected) · server dry-run green.