### PR TITLE
argocd repo-server exec timeout 3m

### DIFF
--- a/kubernetes/infrastructure/argocd/base/values.yaml
+++ b/kubernetes/infrastructure/argocd/base/values.yaml
@@ -769,6 +769,13 @@ repoServer:
   # 2 replicas → parallel manifest-generation für 65+ apps.
   replicas: 2
 
+  # kustomize --enable-helm on the kube-prometheus-stack overlay renders >90s under
+  # evening Ceph-IO load → default 90s exec timeout produced ComparisonError/Unknown
+  # (2026-07-14, also hit blackbox-exporter). 3m gives the biggest chart headroom.
+  env:
+    - name: ARGOCD_EXEC_TIMEOUT
+      value: "3m"
+
   pdb:
     enabled: true
     minAvailable: 1


### PR DESCRIPTION
kustomize --enable-helm on the kube-prometheus-stack overlay renders >90s under evening Ceph-IO load → the default 90s exec timeout produced `ComparisonError: … failed timeout after 1m30s` and stuck the app on Unknown (blackbox-exporter hit it too; recovered after repo-server restart, kps did not — its render is genuinely the biggest). `ARGOCD_EXEC_TIMEOUT=3m` gives headroom. Render verified locally; env lands on both repo-server replicas via rollout.