### PR TITLE
kyverno tuf + velero version align

### DIFF
--- a/kubernetes/infrastructure/storage/velero/base/kustomization.yaml
+++ b/kubernetes/infrastructure/storage/velero/base/kustomization.yaml
@@ -21,11 +21,11 @@ helmCharts:
     includeCRDs: true
     valuesInline:
       # DISABLED 2026-05-15: bitnamilegacy/kubectl:1.36 returns 404 (Bitnami deprecation Oct 2025)
-      # CRDs already installed manually — no upgrade-job needed.
+      # CRD-Upgrades laufen via includeCRDs + ArgoCD-SSA — kein upgrade-Job nötig.
       upgradeCRDs: false
-      image:
-        repository: velero/velero
-        tag: v1.15.0
+      # Image-Pin entfernt 2026-07-15: tag folgt der Chart-appVersion (11.4.0 = v1.17.1).
+      # Vorher divergierte v1.15.0-Pin vom Chart → EINE Versions-Quelle, Renovate
+      # managt nur noch die Chart-Version.
       replicas: 2
       credentials:
         useSecret: true

--- a/kubernetes/security/governance/kyverno/kustomization.yaml
+++ b/kubernetes/security/governance/kyverno/kustomization.yaml
@@ -26,9 +26,9 @@ helmCharts:
           limits:
             memory: 512Mi
       # Kyverno TUF — Sigstore-Trust-Root (Fulcio/Rekor) für keyless cosign-Verify.
-      # DAS ist die Ursache, warum audit-verify-drova-signatures alle Images
-      # "unverified" meldet: ohne TUF fehlt Kyverno der Trust-Root (Egress ist OK).
-      # AKTIVIEREN (platform-weit! betrifft ALLE verifyImages) → einkommentieren:
-      # features:
-      #   tuf:
-      #     enabled: true
+      # Ohne TUF meldete audit-verify-drova-signatures alle Images "unverified"
+      # (fehlender Trust-Root, Egress war OK). Aktiviert 2026-07-15 — platform-weit,
+      # betrifft alle verifyImages; Policies sind Audit-only, kein Blocking-Risiko.
+      features:
+        tuf:
+          enabled: true


### PR DESCRIPTION
## Was

**Kyverno TUF aktiviert** (`features.tuf.enabled: true`): Sigstore-Trust-Root für keyless cosign-Verify — ohne ihn meldete `audit-verify-drova-signatures` alle Images pauschal *unverified*. Policies sind Audit-only → kein Blocking-Risiko. Egress im kyverno-NS ist frei (kein default-deny CNP). Render-verifiziert: `--enableTuf=true` in admission- + reports-controller.

**Velero Versions-Alignment**: Image-Pin `v1.15.0` entfernt → tag folgt der Chart-appVersion (**11.4.0 = v1.17.1**). Vorher zwei divergierende Versions-Knöpfe (Chart via Renovate gebumpt, Image-Pin blieb stehen). CRD-Upgrade läuft via `includeCRDs` + ArgoCD-SSA (13 CRDs im Render) — der alte upgrade-Job bleibt disabled (bitnamilegacy-404). Plugin `velero-plugin-for-aws v1.14.2` ist mit 1.17 kompatibel.

## Verify-Plan nach Merge
- kyverno-Controller rollen → `--enableTuf=true` live, keine CrashLoops
- velero rollt auf v1.17.1 → BSL `Available`, manueller Test-Backup, restore-verify beobachten