### PR TITLE
harden appproject cluster whitelists

### DIFF
--- a/kubernetes/infrastructure/storage/velero/base/kustomization.yaml
+++ b/kubernetes/infrastructure/storage/velero/base/kustomization.yaml
@@ -25,8 +25,8 @@ helmCharts:
       upgradeCRDs: false
       # Image-Pin entfernt 2026-07-15: tag folgt der Chart-appVersion (11.4.0 = v1.17.1).
       # Vorher divergierte v1.15.0-Pin vom Chart → EINE Versions-Quelle, Renovate
-      # managt nur noch die Chart-Version.
-      replicas: 2
+      # managt nur noch die Chart-Version. Kein replicas-Value: Chart 11.x hardcodet
+      # replicas=1 — Velero-Server ist Singleton by design (kein active-active).
       credentials:
         useSecret: true
         existingSecret: velero-s3-credentials

--- a/kubernetes/projects/default.yaml
+++ b/kubernetes/projects/default.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: default
+  namespace: argocd
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    app.kubernetes.io/part-of: timour-homelab
+    team: timour
+spec:
+  description: "Fail-secure default — nur die projects-App (AppProjects nach argocd), sonst nichts"
+
+  # ArgoCDs built-in default war */* auf alles — jede App OHNE explizites
+  # project: landete im God-Mode. Jetzt: neue App ohne project failt sichtbar.
+  destinations:
+    - namespace: argocd
+      server: https://kubernetes.default.svc
+
+  sourceRepos:
+    - 'https://github.com/Tim275/talos-homelab'
+
+  clusterResourceWhitelist: []
+
+  namespaceResourceWhitelist:
+    - group: argoproj.io
+      kind: AppProject

--- a/kubernetes/projects/kustomization.yaml
+++ b/kubernetes/projects/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - default.yaml
   - apps.yaml
   - infrastructure.yaml
   - platform.yaml

--- a/kubernetes/projects/platform.yaml
+++ b/kubernetes/projects/platform.yaml
@@ -36,9 +36,18 @@ spec:
     - 'https://charts.konghq.com'
 
   # Platform resource permissions
+  # Cluster-scoped: nur was die Apps LIVE nutzen (Evidenz 2026-07-15 aus
+  # app.status.resources; war */* = God-Mode). Neues Kind -> Sync-Fehler
+  # "not permitted in project" -> hier nachtragen.
   clusterResourceWhitelist:
-    - group: '*'
-      kind: '*'
+    - group: ''
+      kind: Namespace
+    - group: rbac.authorization.k8s.io
+      kind: ClusterRole
+    - group: rbac.authorization.k8s.io
+      kind: ClusterRoleBinding
+    - group: scheduling.k8s.io
+      kind: PriorityClass
 
   namespaceResourceWhitelist:
     - group: '*'

--- a/kubernetes/projects/security.yaml
+++ b/kubernetes/projects/security.yaml
@@ -46,8 +46,19 @@ spec:
     - 'https://github.com/Tim275/talos-homelab'
 
   # Security resource permissions
+  # Cluster-scoped: nur was die Apps LIVE nutzen (Evidenz 2026-07-15 aus
+  # app.status.resources; war */* = God-Mode). Neues Kind -> Sync-Fehler
+  # "not permitted in project" -> hier nachtragen.
   clusterResourceWhitelist:
-    - group: '*'
+    - group: ''
+      kind: Namespace
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+    - group: rbac.authorization.k8s.io
+      kind: ClusterRole
+    - group: rbac.authorization.k8s.io
+      kind: ClusterRoleBinding
+    - group: kyverno.io
       kind: '*'
 
   namespaceResourceWhitelist:

--- a/kubernetes/projects/storage.yaml
+++ b/kubernetes/projects/storage.yaml
@@ -9,6 +9,17 @@ spec:
   destinations:
     - namespace: 'kube-system'
       server: 'https://kubernetes.default.svc'
+  # Cluster-scoped: nur was die Apps LIVE nutzen (Evidenz 2026-07-15 aus
+  # app.status.resources; war */* = God-Mode). Neues Kind -> Sync-Fehler
+  # "not permitted in project" -> hier nachtragen.
   clusterResourceWhitelist:
-    - group: '*'
+    - group: ''
+      kind: Namespace
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+    - group: rbac.authorization.k8s.io
+      kind: ClusterRole
+    - group: rbac.authorization.k8s.io
+      kind: ClusterRoleBinding
+    - group: snapshot.storage.k8s.io
       kind: '*'


### PR DESCRIPTION
## Was

**P1-Gap:** `default`/`platform`/`security`/`storage` AppProjects hatten `clusterResourceWhitelist: */*` (God-Mode) — ein böser PR in diesen Layern hätte cluster-weite Ressourcen (ClusterRoles, CRDs, Webhooks…) anlegen können. `apps` + `infrastructure` waren bereits gehärtet.

**Methode (Evidenz-basiert):** pro Project alle LIVE cluster-scoped Ressourcen aus `app.status.resources` aggregiert → Whitelist = exakt das Beobachtete (+ `Namespace` als Sicherheitsmarge für CreateNamespace):
- **platform**: Namespace · ClusterRole/Binding · PriorityClass
- **security**: Namespace · CRD · ClusterRole/Binding · kyverno.io/*
- **storage**: Namespace · CRD · ClusterRole/Binding · snapshot.storage.k8s.io/*
- **default (NEU als Datei, fail-secure)**: built-in default war `*/*` für JEDE App ohne explizites `project:` → jetzt nur noch AppProjects→argocd (einziger Nutzer: die projects-App). Neue App ohne project failt sichtbar statt God-Mode.

**Bewusst NICHT angefasst:** destinations + namespaceResourceWhitelist der Layer-Projects (PR-#305-Lesson: destination-Härtung brach cross-namespace-Apps). Nur die Cluster-Whitelists.

Nebenbei (P3): toter `replicas: 2`-Value aus velero values (Chart 11.x hardcodet Singleton).

## Verify-Plan nach Merge
Hard-Refresh aller Apps in den 4 Projects → Conditions auf "not permitted in project" prüfen (false-Synced-Falle aus #305). Fehlt ein Kind → Whitelist nachtragen, kein Rollback nötig.