### PR TITLE
appset hardening + blindspot alerts

### DIFF
--- a/.github/tests/alerts/argocd_appset_test.yaml
+++ b/.github/tests/alerts/argocd_appset_test.yaml
@@ -1,0 +1,89 @@
+# promtool unit tests — ArgoCD ApplicationSet-Blindspot-Alerts (Fire + Negativ).
+# Run: python3 .github/scripts/test-alerts.py
+rule_files:
+  - .rules.generated.yaml
+evaluation_interval: 1m
+tests:
+  # ── ArgoCDApplicationSetControllerDown: FIRES wenn BEIDE Replicas weg ──
+  - interval: 1m
+    input_series:
+      - series: 'up{job="argocd-applicationset-controller-metrics",pod="appset-a"}'
+        values: '1 1 1 0 0 0 0 0 0 0 0 0'
+      - series: 'up{job="argocd-applicationset-controller-metrics",pod="appset-b"}'
+        values: '1 1 1 0 0 0 0 0 0 0 0 0'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: ArgoCDApplicationSetControllerDown
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: platform
+              priority: P2
+            exp_annotations:
+              dashboard_url: "/d/argocd-overview"
+              summary: "ArgoCD applicationset-controller down (beide Replicas)"
+              description: "AppSet-Generierung steht >5min — neue/geänderte List-Einträge erzeugen keine Applications, Fehler nur im Controller-Log sichtbar."
+              action: "kubectl -n argocd rollout restart deployment/argocd-applicationset-controller; kubectl -n argocd logs deploy/argocd-applicationset-controller | tail."
+
+  # ── ArgoCDApplicationSetControllerDown: NICHT bei nur 1 toter Replica ──
+  - interval: 1m
+    input_series:
+      - series: 'up{job="argocd-applicationset-controller-metrics",pod="appset-a"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'up{job="argocd-applicationset-controller-metrics",pod="appset-b"}'
+        values: '1 1 1 0 0 0 0 0 0 0 0 0'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: ArgoCDApplicationSetControllerDown
+        exp_alerts: []
+
+  # ── ArgoCDAppsMassDeletion: FIRES — 10 Apps → 5 Apps (50% übrig < 80%) ──
+  - interval: 1m
+    input_series:
+      - series: 'argocd_app_info{name="app-1"}'
+        values: '1x45'
+      - series: 'argocd_app_info{name="app-2"}'
+        values: '1x45'
+      - series: 'argocd_app_info{name="app-3"}'
+        values: '1x45'
+      - series: 'argocd_app_info{name="app-4"}'
+        values: '1x45'
+      - series: 'argocd_app_info{name="app-5"}'
+        values: '1x45'
+      - series: 'argocd_app_info{name="del-1"}'
+        values: '1x10 stale'
+      - series: 'argocd_app_info{name="del-2"}'
+        values: '1x10 stale'
+      - series: 'argocd_app_info{name="del-3"}'
+        values: '1x10 stale'
+      - series: 'argocd_app_info{name="del-4"}'
+        values: '1x10 stale'
+      - series: 'argocd_app_info{name="del-5"}'
+        values: '1x10 stale'
+    alert_rule_test:
+      - eval_time: 40m
+        alertname: ArgoCDAppsMassDeletion
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: platform
+              priority: P1
+            exp_annotations:
+              dashboard_url: "/d/argocd-overview"
+              summary: "ArgoCD Apps massenhaft verschwunden (50% der Vor-30min-Zahl übrig)"
+              description: "App-Anzahl fiel in 30min um >20% — AppSet gelöscht / Generator leer / Kaskaden-Prune läuft. Sofort prüfen."
+              action: "kubectl get applicationsets -n argocd; kubectl -n argocd logs deploy/argocd-applicationset-controller | tail -50; letzter Merge auf kubernetes/applicationsets/?"
+
+  # ── ArgoCDAppsMassDeletion: NICHT bei stabiler App-Zahl ──
+  - interval: 1m
+    input_series:
+      - series: 'argocd_app_info{name="app-1"}'
+        values: '1x45'
+      - series: 'argocd_app_info{name="app-2"}'
+        values: '1x45'
+      - series: 'argocd_app_info{name="app-3"}'
+        values: '1x45'
+    alert_rule_test:
+      - eval_time: 40m
+        alertname: ArgoCDAppsMassDeletion
+        exp_alerts: []

--- a/kubernetes/applicationsets/apps/apps-stack.yaml
+++ b/kubernetes/applicationsets/apps/apps-stack.yaml
@@ -12,6 +12,10 @@ metadata:
 spec:
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
+  # AppSet weg (z.B. PR-Zeile verloren) => Apps ueberleben als Orphans
+  # statt Kaskaden-Delete+prune aller Layer-Workloads.
+  syncPolicy:
+    preserveResourcesOnDeletion: true
   generators:
     - matrix:
         generators:
@@ -38,7 +42,7 @@ spec:
       project: apps
       source:
         repoURL: https://github.com/Tim275/talos-homelab
-        targetRevision: HEAD
+        targetRevision: main
         path: '{{.path}}'
       destination:
         server: '{{.server}}'

--- a/kubernetes/applicationsets/infrastructure/controllers-stack.yaml
+++ b/kubernetes/applicationsets/infrastructure/controllers-stack.yaml
@@ -13,6 +13,10 @@ metadata:
 spec:
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
+  # AppSet weg (z.B. PR-Zeile verloren) => Apps ueberleben als Orphans
+  # statt Kaskaden-Delete+prune aller Layer-Workloads.
+  syncPolicy:
+    preserveResourcesOnDeletion: true
   generators:
     - matrix:
         generators:
@@ -55,7 +59,7 @@ spec:
       project: infrastructure
       source:
         repoURL: https://github.com/Tim275/talos-homelab
-        targetRevision: HEAD
+        targetRevision: main
         path: '{{.path}}'
       destination:
         server: '{{.server}}'

--- a/kubernetes/applicationsets/infrastructure/network-stack.yaml
+++ b/kubernetes/applicationsets/infrastructure/network-stack.yaml
@@ -12,6 +12,10 @@ metadata:
 spec:
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
+  # AppSet weg (z.B. PR-Zeile verloren) => Apps ueberleben als Orphans
+  # statt Kaskaden-Delete+prune aller Layer-Workloads.
+  syncPolicy:
+    preserveResourcesOnDeletion: true
   generators:
     - matrix:
         generators:
@@ -43,7 +47,7 @@ spec:
       project: infrastructure
       source:
         repoURL: https://github.com/Tim275/talos-homelab
-        targetRevision: HEAD
+        targetRevision: main
         path: '{{.path}}'
       destination:
         server: '{{.server}}'

--- a/kubernetes/applicationsets/infrastructure/observability-stack.yaml
+++ b/kubernetes/applicationsets/infrastructure/observability-stack.yaml
@@ -15,6 +15,10 @@ metadata:
 spec:
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
+  # AppSet weg (z.B. PR-Zeile verloren) => Apps ueberleben als Orphans
+  # statt Kaskaden-Delete+prune aller Layer-Workloads.
+  syncPolicy:
+    preserveResourcesOnDeletion: true
   generators:
     - matrix:
         generators:
@@ -63,7 +67,7 @@ spec:
       project: infrastructure
       source:
         repoURL: https://github.com/Tim275/talos-homelab
-        targetRevision: HEAD
+        targetRevision: main
         path: '{{.path}}'
       destination:
         server: '{{.server}}'

--- a/kubernetes/applicationsets/infrastructure/storage-stack.yaml
+++ b/kubernetes/applicationsets/infrastructure/storage-stack.yaml
@@ -12,6 +12,10 @@ metadata:
 spec:
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
+  # AppSet weg (z.B. PR-Zeile verloren) => Apps ueberleben als Orphans
+  # statt Kaskaden-Delete+prune aller Layer-Workloads.
+  syncPolicy:
+    preserveResourcesOnDeletion: true
   generators:
     - matrix:
         generators:
@@ -42,7 +46,7 @@ spec:
       project: '{{.appProject}}'
       source:
         repoURL: '{{.repoURL}}'
-        targetRevision: HEAD
+        targetRevision: main
         path: '{{.path}}'
       destination:
         server: '{{.server}}'

--- a/kubernetes/applicationsets/platform/identity-stack.yaml
+++ b/kubernetes/applicationsets/platform/identity-stack.yaml
@@ -12,6 +12,10 @@ metadata:
 spec:
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
+  # AppSet weg (z.B. PR-Zeile verloren) => Apps ueberleben als Orphans
+  # statt Kaskaden-Delete+prune aller Layer-Workloads.
+  syncPolicy:
+    preserveResourcesOnDeletion: true
   generators:
     - matrix:
         generators:
@@ -39,7 +43,7 @@ spec:
       project: platform
       source:
         repoURL: '{{.repoURL}}'
-        targetRevision: HEAD
+        targetRevision: main
         path: '{{.path}}'
       destination:
         server: '{{.server}}'

--- a/kubernetes/applicationsets/security/security-stack.yaml
+++ b/kubernetes/applicationsets/security/security-stack.yaml
@@ -15,6 +15,10 @@ metadata:
 spec:
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
+  # AppSet weg (z.B. PR-Zeile verloren) => Apps ueberleben als Orphans
+  # statt Kaskaden-Delete+prune aller Layer-Workloads.
+  syncPolicy:
+    preserveResourcesOnDeletion: true
   generators:
     - matrix:
         generators:
@@ -42,7 +46,7 @@ spec:
       project: security
       source:
         repoURL: https://github.com/Tim275/talos-homelab
-        targetRevision: HEAD
+        targetRevision: main
         path: '{{.path}}'
       destination:
         server: '{{.server}}'

--- a/kubernetes/applicationsets/tenants/drova-tenant.yaml
+++ b/kubernetes/applicationsets/tenants/drova-tenant.yaml
@@ -33,6 +33,10 @@ spec:
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
 
+  # AppSet weg (z.B. PR-Zeile verloren) => Apps ueberleben als Orphans
+  # statt Kaskaden-Delete+prune aller Layer-Workloads.
+  syncPolicy:
+    preserveResourcesOnDeletion: true
   generators:
     - matrix:
         generators:
@@ -86,7 +90,7 @@ spec:
       project: '{{.appProject}}'
       source:
         repoURL: '{{.repoURL}}'
-        targetRevision: HEAD
+        targetRevision: main
         path: '{{.path}}'
       destination:
         server: '{{.server}}'
@@ -121,9 +125,9 @@ spec:
           jsonPointers:
             - /spec/selector
       syncPolicy:
-        automated:
-          prune: true
-          selfHeal: true
+        # automated: { prune: true, selfHeal: true }  # manual by design (DAX-Gate),
+        # 2026-07-15 an n8n-tenant/tenants-config/apps-stack angeglichen — war der
+        # einzige auto-sync-Tenant (Doku sagte immer manual).
         syncOptions:
           - CreateNamespace=false
           - PrunePropagationPolicy=foreground

--- a/kubernetes/applicationsets/tenants/n8n-tenant.yaml
+++ b/kubernetes/applicationsets/tenants/n8n-tenant.yaml
@@ -15,6 +15,10 @@ metadata:
 spec:
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
+  # AppSet weg (z.B. PR-Zeile verloren) => Apps ueberleben als Orphans
+  # statt Kaskaden-Delete+prune aller Layer-Workloads.
+  syncPolicy:
+    preserveResourcesOnDeletion: true
   generators:
     - matrix:
         generators:
@@ -60,7 +64,7 @@ spec:
       project: '{{.appProject}}'
       source:
         repoURL: '{{.repoURL}}'
-        targetRevision: HEAD
+        targetRevision: main
         path: '{{.path}}'
       destination:
         server: '{{.server}}'

--- a/kubernetes/applicationsets/tenants/tenants-config.yaml
+++ b/kubernetes/applicationsets/tenants/tenants-config.yaml
@@ -10,6 +10,10 @@ metadata:
 spec:
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
+  # AppSet weg (z.B. PR-Zeile verloren) => Apps ueberleben als Orphans
+  # statt Kaskaden-Delete+prune aller Layer-Workloads.
+  syncPolicy:
+    preserveResourcesOnDeletion: true
   generators:
     - matrix:
         generators:
@@ -38,7 +42,7 @@ spec:
       project: platform
       source:
         repoURL: https://github.com/Tim275/talos-homelab
-        targetRevision: HEAD
+        targetRevision: main
         path: 'kubernetes/tenants/{{.component}}'
       destination:
         server: '{{.server}}'

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/argocd.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/argocd.yaml
@@ -26,6 +26,42 @@ spec:
             description: "GitOps reconciliation halted >5min — no auto-deploy/self-heal until restored."
             action: "kubectl -n argocd rollout restart statefulset/argocd-application-controller; check its logs + resource limits."
 
+        # 2 Replicas leader-elected → erst BEIDE weg = Ausfall. Quellen-Warnung
+        # (appset-Docs): Generator-Fehler landen NUR im Controller-Log, nicht in
+        # der UI — ohne Controller fehlen neue Apps still.
+        - alert: ArgoCDApplicationSetControllerDown
+          expr: sum(up{job="argocd-applicationset-controller-metrics"}) == 0
+          for: 5m
+          labels:
+            severity: warning
+            component: platform
+            priority: P2
+          annotations:
+            dashboard_url: "/d/argocd-overview"
+            summary: "ArgoCD applicationset-controller down (beide Replicas)"
+            description: "AppSet-Generierung steht >5min — neue/geänderte List-Einträge erzeugen keine Applications, Fehler nur im Controller-Log sichtbar."
+            action: "kubectl -n argocd rollout restart deployment/argocd-applicationset-controller; kubectl -n argocd logs deploy/argocd-applicationset-controller | tail."
+
+        # Massen-Verschwinden von Apps (>20% in 30min, Baseline ~68) = AppSet-GAU
+        # (AppSet geloescht/Generator leer -> Kaskaden-Delete). preserve-
+        # ResourcesOnDeletion schuetzt die Workloads, DAS hier macht es sichtbar.
+        - alert: ArgoCDAppsMassDeletion
+          expr: |
+            count(argocd_app_info)
+              /
+            (count(argocd_app_info offset 30m) > 0)
+              < 0.8
+          for: 5m
+          labels:
+            severity: warning
+            component: platform
+            priority: P1
+          annotations:
+            dashboard_url: "/d/argocd-overview"
+            summary: "ArgoCD Apps massenhaft verschwunden ({{ $value | humanizePercentage }} der Vor-30min-Zahl übrig)"
+            description: "App-Anzahl fiel in 30min um >20% — AppSet gelöscht / Generator leer / Kaskaden-Prune läuft. Sofort prüfen."
+            action: "kubectl get applicationsets -n argocd; kubectl -n argocd logs deploy/argocd-applicationset-controller | tail -50; letzter Merge auf kubernetes/applicationsets/?"
+
         # lldap excluded: its hourly bootstrap CronJob churns app-health (job exits 1 on
         # ≥3 dual-store-bug users → app Degraded across hours) — already covered by the
         # dedicated LLDAPBootstrapCronJobFailing below, and an lldap-service outage surfaces


### PR DESCRIPTION
## Was (Research-Ergebnis aus dem AppSet-Enterprise-Vergleich)

**1. `preserveResourcesOnDeletion: true` in allen 10 AppSets (P1):** faellt ein AppSet-File aus der kustomization (1 PR-Zeile), loeschte der Controller bisher ALLE Apps des Layers und prune reisst die Workloads mit. Jetzt ueberleben die Apps als Orphans.

**2. AppSet-Blindspot-Alerts (P2):** Generator-Fehler erscheinen NUR im Controller-Log, nicht in der UI (dokumentierte Quellen-Warnung).
- `ArgoCDApplicationSetControllerDown`: `sum(up{job="argocd-applicationset-controller-metrics"}) == 0` — Label live verifiziert (promtool query; 2 Replicas leader-elected, erst beide weg = Ausfall)
- `ArgoCDAppsMassDeletion`: App-Anzahl faellt >20% in 30min (Baseline 68) = AppSet-GAU sichtbar machen
- promtool-Unit-Tests (Fire + Negativ je Alert)

**3. `targetRevision: HEAD` zu `main` x10 (P3):** explizit statt implizit (Literatur: named branch).

**4. drova-tenant zu manual-sync:** war der EINZIGE auto-sync-Tenant (automated+prune+selfHeal) — Doku/Design sagt seit jeher "tenants = manual (DAX-Gate)"; n8n-tenant/tenants-config/apps-stack sind manual. Der Drift war der auto-sync, nicht das Design.

## Verify-Plan nach Merge
AppSets updaten in-place (kein App-Recreate, nur spec-Update). Check: App-Zahl bleibt 68, drova-Apps zeigen kuenftig OutOfSync statt auto-sync.
