### PR TITLE
drop dead n8n-dev backup schedule

### DIFF
--- a/kubernetes/infrastructure/storage/velero-schedules/backup-schedules.yaml
+++ b/kubernetes/infrastructure/storage/velero-schedules/backup-schedules.yaml
@@ -67,31 +67,9 @@ spec:
         backup-tier: tier-0
         namespace: lldap
 ---
-# TIER-1 BACKUPS (Daily - IMPORTANT)
-# Namespaces: n8n-development, monitoring (Grafana)
-# RPO: 24h | RTO: 4h
-apiVersion: velero.io/v1
-kind: Schedule
-metadata:
-  name: tier1-n8n-development
-  namespace: velero
-  labels:
-    backup-tier: tier-1
-    app: n8n-development
-    environment: development
-spec:
-  schedule: "0 2 * * *"  # Daily at 2 AM
-  template:
-    includedNamespaces:
-      - n8n-dev
-    storageLocation: cluster-backups
-    ttl: 8760h  # 365 days retention (1 year)
-    defaultVolumesToFsBackup: true
-    metadata:
-      labels:
-        backup-tier: tier-1
-        namespace: n8n-dev
-        environment: development
+# tier1-n8n-development ENTFERNT 2026-07-15: NS n8n-dev existiert nicht mehr ->
+# Schedule lief 5 Naechte in PartiallyFailed und hielt velero-schedules Degraded.
+# Kommt n8n-dev zurueck, Schedule bewusst neu anlegen.
 ---
 apiVersion: velero.io/v1
 kind: Schedule


### PR DESCRIPTION
Schedule tier1-n8n-development sichert NS n8n-dev — der existiert nicht mehr → PartiallyFailed jede Nacht (02:00) seit mind. 5 Tagen → hielt die velero-schedules-App dauerhaft Degraded (ArgoCD built-in Backup-Health-Lua). Raus; die 8 wertlosen PartiallyFailed-Backup-CRs (5× n8n-dev + 3× infisical-Altlasten) werden live via DeleteBackupRequest entsorgt. Kommt n8n-dev je zurück → Schedule bewusst neu.