### PR TITLE
redpanda console for drova kafka

### DIFF
--- a/kubernetes/applicationsets/tenants/drova-tenant.yaml
+++ b/kubernetes/applicationsets/tenants/drova-tenant.yaml
@@ -62,6 +62,12 @@ spec:
                   repoURL: https://github.com/Tim275/talos-homelab
                   path: kubernetes/tenants/drova/kafka/overlays/prod
                   wave: "30"
+                - component: console
+                  appName: drova-console
+                  appProject: platform
+                  repoURL: https://github.com/Tim275/talos-homelab
+                  path: kubernetes/tenants/drova/console
+                  wave: "60"
                 - component: redis
                   appName: redis-drova
                   appProject: platform

--- a/kubernetes/tenants/drova/console/configmap.yaml
+++ b/kubernetes/tenants/drova/console/configmap.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console-config
+  namespace: drova
+data:
+  # sasl.password kommt NICHT hierher — env KAFKA_SASL_PASSWORD (aus dem
+  # Strimzi-KafkaUser-Secret) überschreibt den config-Pfad zur Laufzeit.
+  console-config.yaml: |
+    kafka:
+      brokers:
+        - drova-kafka-kafka-bootstrap.drova.svc.cluster.local:9095
+      clientId: redpanda-console
+      sasl:
+        enabled: true
+        mechanism: SCRAM-SHA-512
+        username: redpanda-console
+      tls:
+        enabled: true
+        caFilepath: /etc/kafka-ca/ca.crt
+      schemaRegistry:
+        enabled: true
+        urls:
+          - http://schema-registry.drova.svc.cluster.local:8080

--- a/kubernetes/tenants/drova/console/deployment.yaml
+++ b/kubernetes/tenants/drova/console/deployment.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  namespace: drova
+  labels:
+    app: redpanda-console
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redpanda-console
+  template:
+    metadata:
+      labels:
+        app: redpanda-console
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: console
+          image: docker.redpanda.com/redpandadata/console:v2.8.5
+          args: ["--config.filepath=/etc/console/console-config.yaml"]
+          env:
+            - name: KAFKA_SASL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: redpanda-console
+                  key: password
+          ports:
+            - name: http
+              containerPort: 8080
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /admin/health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /admin/health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          volumeMounts:
+            - name: config
+              mountPath: /etc/console
+              readOnly: true
+            - name: kafka-ca
+              mountPath: /etc/kafka-ca
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: config
+          configMap:
+            name: redpanda-console-config
+        - name: kafka-ca
+          secret:
+            secretName: drova-kafka-cluster-ca-cert
+            items:
+              - key: ca.crt
+                path: ca.crt
+        - name: tmp
+          emptyDir:
+            sizeLimit: 32Mi

--- a/kubernetes/tenants/drova/console/httproute.yaml
+++ b/kubernetes/tenants/drova/console/httproute.yaml
@@ -1,0 +1,20 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: redpanda-console
+  namespace: drova
+spec:
+  parentRefs:
+    - name: envoy-gateway
+      namespace: gateway
+      sectionName: https
+  hostnames:
+    - "redpanda.timourhomelab.org"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: redpanda-console
+          port: 8080

--- a/kubernetes/tenants/drova/console/kafka-user.yaml
+++ b/kubernetes/tenants/drova/console/kafka-user.yaml
@@ -1,0 +1,27 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: redpanda-console
+  namespace: drova
+  labels:
+    strimzi.io/cluster: drova-kafka
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    # Read-only UI-User: sehen ja, anfassen nein (kein Write/Create/Delete).
+    acls:
+      - resource:
+          type: topic
+          name: "*"
+          patternType: literal
+        operations: [Read, Describe, DescribeConfigs]
+      - resource:
+          type: group
+          name: "*"
+          patternType: literal
+        operations: [Read, Describe]
+      - resource:
+          type: cluster
+        operations: [Describe, DescribeConfigs]

--- a/kubernetes/tenants/drova/console/kustomization.yaml
+++ b/kubernetes/tenants/drova/console/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: drova
+
+resources:
+  - kafka-user.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml

--- a/kubernetes/tenants/drova/console/service.yaml
+++ b/kubernetes/tenants/drova/console/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  namespace: drova
+  labels:
+    app: redpanda-console
+spec:
+  selector:
+    app: redpanda-console
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http


### PR DESCRIPTION
Kafka-UI (Redpanda Console v2.8.5) für den drova-Kafka unter **redpanda.timourhomelab.org** (VPN-only wie alles Interne).

- `tenants/drova/console/` — bewusst TENANT-scoped, nicht platform: die UI gehört zum drova-Kafka (gleicher Lifecycle, gleiche Quota/RBAC-Grenze, gleiches AppProject wie die anderen drova-Data-Komponenten). Platform wäre richtig, wenn der Kafka mandantenübergreifend wäre.
- **Least-Privilege KafkaUser** `redpanda-console` (SCRAM-SHA-512): Read/Describe auf Topics+Groups, Describe Cluster — kein Write/Create/Delete. TLS gegen die Strimzi-Cluster-CA.
- Schema-Registry integriert (http://schema-registry:8080).
- Kyverno-konform: non-root, drop-ALL, ro-rootfs, requests + mem-Limit.
- AppSet: 1 List-Eintrag in drova-tenant (wave 60) → App `drova-console` (manual-sync wie alle Tenants).