### PR TITLE
fix console schema registry path

### DIFF
--- a/kubernetes/tenants/drova/console/configmap.yaml
+++ b/kubernetes/tenants/drova/console/configmap.yaml
@@ -20,5 +20,7 @@ data:
         caFilepath: /etc/kafka-ca/ca.crt
       schemaRegistry:
         enabled: true
+        # Apicurio Registry (nicht Confluent) — Confluent-kompatible API liegt
+        # unter /apis/ccompat/v7, Root liefert 404 (RESTEASY).
         urls:
-          - http://schema-registry.drova.svc.cluster.local:8080
+          - http://schema-registry.drova.svc.cluster.local:8080/apis/ccompat/v7


### PR DESCRIPTION
Redpanda Console crashte am Registry-Healthcheck: drova nutzt **Apicurio** (RESTEASY-404 auf /subjects) — die Confluent-kompatible API liegt unter `/apis/ccompat/v7` (live verifiziert: Subjects kommen). Kafka-Seite lief schon (33 Topics, SASL+TLS ok).