### PR TITLE
kafka round: console auth + partitions + mm2

### DIFF
--- a/kubernetes/tenants/drova/console/basic-auth-sealed.yaml
+++ b/kubernetes/tenants/drova/console/basic-auth-sealed.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: redpanda-basic-auth
+  namespace: drova
+spec:
+  encryptedData:
+    .htpasswd: AgB9+4RarqGRI+IMKbB/dvEIG0k2+wgfXtvuhLDNKodXPcAZHC7VEABGOHl4MVj8FRArwmmO8wYFv2lcPSVQpYh03oPR86ree0A9Ip9ggCbkGvWqdr96rE42yzavmHHSefUY2eZ2kV++go4i4qLbcN7zjBShKXJuqGy7xdKmlKwjI/P17BM6MXGtjllqoVSnV71urr8+2xyKG/QAQ52Cv8My+Xdip1sDHEtGpYYXB68v9meKVMV8UsB9itiL9W6s9sajnur/abTpAYxCCWlSkPqZBcveteFXaAhuoN5EtVuSY9hs/ktlVgWMAzeTWXZWZ0gtB/g2G9HDnlK2NQH5xzXORSFRxpxBMC75mzf9o1AriDb51PEXI59i4/w0A7CWAGbKoPi0MrQFrbHe1urDf18HLBFfCITg82zzd2v5m65TQ5QIKd1WU9/ecr4Gol33RF6VL+YVOTDPYchSLHJzBkGcVXB7Wc1xXMnySlodW8Dz/8uWfQwcDuX18na73sfiLk+L1HvpMFu/QSddpRV5xgmlCBGl2SfUMKyAfVdA6qpfr3enPBKbd99HC5AO02CczJcyO15bf24/Z3HtUPKESeU2ux9Kzu0JFJODyfjD7atmG72wSx25E3S/ll3PNz0vuXT9lezX/ONpybtQTYX5X6gUR4UyE5ZnQBUSgW/FOFzCQ5squyseU7jtfAnL4pcQzY0GM3esQ1tTZb7Lnlmp2BpskGwvHhr3xYUbH2oNG3/AVDs/NwnBA2M212M=
+  template:
+    metadata:
+      name: redpanda-basic-auth
+      namespace: drova

--- a/kubernetes/tenants/drova/console/httproute.yaml
+++ b/kubernetes/tenants/drova/console/httproute.yaml
@@ -18,3 +18,17 @@ spec:
       backendRefs:
         - name: redpanda-console
           port: 8080
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: redpanda-basic-auth
+  namespace: drova
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: redpanda-console
+  basicAuth:
+    users:
+      name: redpanda-basic-auth

--- a/kubernetes/tenants/drova/console/kustomization.yaml
+++ b/kubernetes/tenants/drova/console/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: drova
 
 resources:
   - kafka-user.yaml
+  - basic-auth-sealed.yaml
   - configmap.yaml
   - deployment.yaml
   - service.yaml

--- a/kubernetes/tenants/drova/kafka/base/kafka-topics.yaml
+++ b/kubernetes/tenants/drova/kafka/base/kafka-topics.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     strimzi.io/cluster: drova-kafka
 spec:
-  partitions: 3
+  partitions: 6
   replicas: 3
   config:
     retention.ms: "2592000000"
@@ -19,7 +19,7 @@ metadata:
   labels:
     strimzi.io/cluster: drova-kafka
 spec:
-  partitions: 3
+  partitions: 6
   replicas: 3
   config:
     retention.ms: "2592000000"
@@ -32,7 +32,7 @@ metadata:
   labels:
     strimzi.io/cluster: drova-kafka
 spec:
-  partitions: 3
+  partitions: 6
   replicas: 3
   config:
     retention.ms: "2592000000"
@@ -45,7 +45,7 @@ metadata:
   labels:
     strimzi.io/cluster: drova-kafka
 spec:
-  partitions: 3
+  partitions: 6
   replicas: 3
   config:
     retention.ms: "2592000000"
@@ -162,7 +162,7 @@ metadata:
   labels:
     strimzi.io/cluster: drova-kafka
 spec:
-  partitions: 3
+  partitions: 6
   replicas: 3
   config:
     retention.ms: "2592000000"
@@ -175,7 +175,7 @@ metadata:
   labels:
     strimzi.io/cluster: drova-kafka
 spec:
-  partitions: 3
+  partitions: 6
   replicas: 3
   config:
     retention.ms: "2592000000"

--- a/kubernetes/tenants/drova/kafka/base/kustomization.yaml
+++ b/kubernetes/tenants/drova/kafka/base/kustomization.yaml
@@ -10,6 +10,8 @@ resources:
   - kafka-cluster.yaml
   - kafka-topics.yaml
   - drova-kafka-user.yaml
+  - mm2-user.yaml
+  - mirrormaker2.yaml          # same-cluster MM2-Demo (primary.-Praefix, kein NodePort)
   - kafka-metrics-config.yaml         # JMX Prometheus Exporter rules
   - kafka-broker-podmonitor.yaml      # PodMonitor for broker JMX :9404
   - kafka-allow-hbone.yaml            # ambient: 15008 zusaetzlich zu Strimzis eigenen NetPols

--- a/kubernetes/tenants/drova/kafka/base/mirrormaker2.yaml
+++ b/kubernetes/tenants/drova/kafka/base/mirrormaker2.yaml
@@ -1,0 +1,74 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaMirrorMaker2
+metadata:
+  name: drova-mm2
+  namespace: drova
+spec:
+  # Same-Cluster-Demo (active-passive-Mechanik lernen, kein NodePort/2. Cluster):
+  # primary + mirror zeigen auf DENSELBEN Broker — Topics werden mit
+  # "primary."-Praefix gespiegelt (DefaultReplicationPolicy), Offset-Translation
+  # via checkpoints. Bei echtem DR: mirror-bootstrap auf den 2. Cluster drehen.
+  version: 4.1.1
+  replicas: 1
+  connectCluster: mirror
+  clusters:
+    - alias: primary
+      bootstrapServers: drova-kafka-kafka-bootstrap.drova.svc.cluster.local:9095
+      tls:
+        trustedCertificates:
+          - secretName: drova-kafka-cluster-ca-cert
+            certificate: ca.crt
+      authentication:
+        type: scram-sha-512
+        username: mm2
+        passwordSecret:
+          secretName: mm2
+          password: password
+    - alias: mirror
+      bootstrapServers: drova-kafka-kafka-bootstrap.drova.svc.cluster.local:9095
+      tls:
+        trustedCertificates:
+          - secretName: drova-kafka-cluster-ca-cert
+            certificate: ca.crt
+      authentication:
+        type: scram-sha-512
+        username: mm2
+        passwordSecret:
+          secretName: mm2
+          password: password
+      config:
+        # Connect-interne Topics: Cluster hat 3 Broker → RF 3 wie ueberall
+        config.storage.replication.factor: 3
+        offset.storage.replication.factor: 3
+        status.storage.replication.factor: 3
+  mirrors:
+    - sourceCluster: primary
+      targetCluster: mirror
+      topicsPattern: "trip-event-completed"
+      groupsPattern: ".*"
+      sourceConnector:
+        tasksMax: 1
+        config:
+          replication.factor: 3
+          offset-syncs.topic.replication.factor: 3
+          sync.topic.acls.enabled: "false"
+      checkpointConnector:
+        tasksMax: 1
+        config:
+          checkpoints.topic.replication.factor: 3
+          sync.group.offsets.enabled: "true"
+      heartbeatConnector:
+        config:
+          heartbeats.topic.replication.factor: 3
+  resources:
+    requests:
+      cpu: 100m
+      memory: 384Mi
+    limits:
+      memory: 768Mi
+  template:
+    pod:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault

--- a/kubernetes/tenants/drova/kafka/base/mm2-user.yaml
+++ b/kubernetes/tenants/drova/kafka/base/mm2-user.yaml
@@ -1,0 +1,30 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: mm2
+  namespace: drova
+  labels:
+    strimzi.io/cluster: drova-kafka
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    # MM2 = System-Replikationsdienst: braucht Create/Read/Write auf gespiegelte
+    # + Connect-interne Topics (offsets/configs/status, heartbeats, checkpoints,
+    # offset-syncs) und Group-/Cluster-Rechte fuer Offset-Translation. Bewusst
+    # breit — im Gegensatz zum read-only Console-User.
+    acls:
+      - resource:
+          type: topic
+          name: "*"
+          patternType: literal
+        operations: [All]
+      - resource:
+          type: group
+          name: "*"
+          patternType: literal
+        operations: [All]
+      - resource:
+          type: cluster
+        operations: [All]


### PR DESCRIPTION
Drei Punkte aus dem Kafka-Backlog:

**1. Redpanda-Console-Auth (Security-Gap):** SecurityPolicy `redpanda-basic-auth` auf der HTTPRoute (Muster jaeger) + SealedSecret (`{SHA}`-htpasswd — Envoy lehnt bcrypt ab). Console war VPN-only ohne Auth erreichbar.

**2. Partition-Sizing:** die 3 Hot-Path-Topics `trip-event-created`, `driver-cmd-trip-request`, `driver-cmd-trip-response` von 3 auf 6 Partitionen (Consumer-Parallelitaet 2 Replicas × Headroom; increase ist safe, Strimzi Topic-Operator macht das online; Key-Rehash transient bei idle egal). Rest bleibt 3, DLQ bleibt 3.

**3. MirrorMaker2 same-cluster-Demo (kein NodePort!):** `drova-mm2` — primary+mirror-Alias auf denselben Broker, spiegelt `trip-event-completed` als `primary.trip-event-completed`, checkpoints mit `sync.group.offsets` (Offset-Translation lernen). Eigener KafkaUser `mm2` (System-Replikationsdienst, bewusst breite ACLs — dokumentiert, im Gegensatz zum read-only Console-User). 1 Replica, 384Mi/768Mi. Fuer echtes DR: mirror-bootstrap auf 2. Cluster drehen — Mechanik identisch.
