### PR TITLE
mm2 boot probe fix

### DIFF
--- a/kubernetes/tenants/drova/kafka/base/mirrormaker2.yaml
+++ b/kubernetes/tenants/drova/kafka/base/mirrormaker2.yaml
@@ -62,10 +62,22 @@ spec:
           heartbeats.topic.replication.factor: 3
   resources:
     requests:
-      cpu: 100m
-      memory: 384Mi
+      cpu: 250m
+      memory: 512Mi
     limits:
-      memory: 768Mi
+      memory: 1Gi
+  # Connect-Boot (Plugin-Scan + JVM) braucht hier >60s — Default-Liveness killte
+  # den Start im Loop ("failed liveness probe, will be restarted", exit 0).
+  livenessProbe:
+    initialDelaySeconds: 180
+    timeoutSeconds: 10
+    periodSeconds: 15
+    failureThreshold: 6
+  readinessProbe:
+    initialDelaySeconds: 60
+    timeoutSeconds: 10
+    periodSeconds: 10
+    failureThreshold: 12
   template:
     pod:
       securityContext:


### PR DESCRIPTION
MM2-Pod crash-loopte am Start: Kafka-Connect-Boot (Plugin-Scan + JVM auf 100m-Request) dauert >60s → Default-Liveness killte den Container mitten im Startup (Events: *failed liveness probe, will be restarted*, exit 0, kein Fehler im Log). Fix: initialDelay 180s + tolerantere Thresholds, CPU-Request 250m, mem-Limit 1Gi (Connect-JVM-Luft). Lehrbuch-Fall aus der eigenen Probes-Doku: langsame Apps brauchen Boot-Schutz.