### PR TITLE
mm2 explicit cpu limit

### DIFF
--- a/kubernetes/tenants/drova/kafka/base/mirrormaker2.yaml
+++ b/kubernetes/tenants/drova/kafka/base/mirrormaker2.yaml
@@ -65,6 +65,8 @@ spec:
       cpu: 250m
       memory: 512Mi
     limits:
+      # drova-LimitRange injiziert sonst default cpu-limit 200m < request → Pod invalid
+      cpu: "1"
       memory: 1Gi
   # Connect-Boot (Plugin-Scan + JVM) braucht hier >60s — Default-Liveness killte
   # den Start im Loop ("failed liveness probe, will be restarted", exit 0).


### PR DESCRIPTION
Pod-Create wurde von der API abgelehnt: `requests.cpu 250m > limit 200m` — der drova-**LimitRange** injiziert ein Default-CPU-Limit von 200m in Container ohne explizites Limit. Explizites `limits.cpu: 1` im MM2-CR überstimmt den Default (Connect-Boot braucht die Burst-Luft, genau deshalb schlug auch die Liveness-Probe an).