### PR TITLE
n8n waf exclusion

### DIFF
--- a/kubernetes/infrastructure/ingress/gateway/base/waf/coraza-waf.yaml
+++ b/kubernetes/infrastructure/ingress/gateway/base/waf/coraza-waf.yaml
@@ -41,5 +41,10 @@ spec:
             # Blockt kubectl-OIDC + SSO. Verifiziert via Envoy-Coraza-Log 2026-06-17. login-actions = Login-Form-POST.
             - 'SecRule REQUEST_URI "@beginsWith /realms/kubernetes/protocol/openid-connect" "id:1100013,phase:1,pass,nolog,ctl:ruleEngine=Off"'
             - 'SecRule REQUEST_URI "@beginsWith /realms/kubernetes/login-actions" "id:1100014,phase:1,pass,nolog,ctl:ruleEngine=Off"'
+            # n8n false-positive: REST-API nutzt PATCH/PUT/DELETE + text/plain-Telemetrie.
+            # CRS 911100 (Method-Enforcement) blockt PATCH /rest/me/password -> 403 beim Passwort-
+            # Aendern; 920420 blockt /rest/ph/ (text/plain). Verifiziert Envoy-Coraza-Log 2026-07-15.
+            # n8n = public, haengt hinter Cloudflare-Edge-WAF + App-Login -> Engine fuer den Host aus.
+            - 'SecRule REQUEST_HEADERS:Host "@streq n8n.timourhomelab.org" "id:1100015,phase:1,pass,nolog,ctl:ruleEngine=Off"'
             - "Include @owasp_crs/*.conf"
         default_directives: "default"


### PR DESCRIPTION
Coraza CRS 911100 (method-enforcement) allows only GET/POST -> blocks PATCH /rest/me/password -> 403 on n8n password change (plus 920420 on /rest/ph/ text/plain telemetry). Disable WAF engine for host n8n.timourhomelab.org (public app behind Cloudflare edge WAF + app login). Same pattern as the existing Kibana/Grafana/Keycloak exclusions.