### PR TITLE
disable mm2 demo

### DIFF
--- a/kubernetes/tenants/drova/kafka/base/kustomization.yaml
+++ b/kubernetes/tenants/drova/kafka/base/kustomization.yaml
@@ -10,8 +10,9 @@ resources:
   - kafka-cluster.yaml
   - kafka-topics.yaml
   - drova-kafka-user.yaml
-  - mm2-user.yaml
-  - mirrormaker2.yaml          # same-cluster MM2-Demo (primary.-Praefix, kein NodePort)
+  # MM2-Demo deaktiviert: leakte Memory (OOM-Trend) + trieb Ceph-Slow-Ops. Files bleiben zum Re-Enable.
+  # - mm2-user.yaml
+  # - mirrormaker2.yaml          # same-cluster MM2-Demo (primary.-Praefix, kein NodePort)
   - kafka-metrics-config.yaml         # JMX Prometheus Exporter rules
   - kafka-broker-podmonitor.yaml      # PodMonitor for broker JMX :9404
   - kafka-allow-hbone.yaml            # ambient: 15008 zusaetzlich zu Strimzis eigenen NetPols


### PR DESCRIPTION
MM2 same-cluster demo leaks memory (OOM trend) + drives Ceph slow-ops on the Kafka PVCs. Disable it in the kafka kustomization (files kept for re-enable). Live pod already deleted once but a sync recreated it from main; this removes it from git durably.