### PR TITLE
ctrl-0 datastore cephpool

### DIFF
--- a/tofu/talos_nodes.auto.tfvars
+++ b/tofu/talos_nodes.auto.tfvars
@@ -7,7 +7,8 @@ talos_nodes = {
     vm_id          = 1000
     cpu            = 6
     ram_dedicated  = 14336
-    datastore_id   = "local-zfs"
+    # etcd-fsync: ctrl-0 OS-Disk auf Samsung (cephpool), nicht HOGE (local-zfs)
+    datastore_id   = "cephpool"
     os_disk_size   = 50
     ceph_disk_size = 0
   }


### PR DESCRIPTION
ctrl-0 OS disk (etcd fsync) is live on cephpool/Samsung (qm config 1000: scsi0 cephpool:vm-1000-disk-0), moved via qm move-disk on 2026-06-30. tfvars still declared local-zfs = drift → a tofu apply would migrate etcd back to the slow HOGE. Align declared with reality. Verify CI tofu plan is a no-op before merge.