### PR TITLE
postfix smtp relay

### DIFF
--- a/kubernetes/applicationsets/infrastructure/controllers-stack.yaml
+++ b/kubernetes/applicationsets/infrastructure/controllers-stack.yaml
@@ -44,6 +44,8 @@ spec:
                 - { component: sail-operator,   appName: sail-operator,   path: kubernetes/infrastructure/operators/sail-operator/overlays/prod,   namespace: sail-operator,   wave: "-50" }
                 - { component: descheduler,     appName: descheduler,     path: kubernetes/infrastructure/operators/descheduler/overlays/prod,     namespace: kube-system,     wave: "0" }
                 - { component: keda,            appName: keda,            path: kubernetes/infrastructure/operators/keda/overlays/prod,            namespace: keda,            wave: "-50" }
+                # Postfix Send-Relay — zentraler SMTP-Smarthost fuer n8n/Keycloak/Grafana
+                - { component: postfix,         appName: postfix-relay,   path: kubernetes/infrastructure/mail/postfix/overlays/prod,              namespace: mail,            wave: "0" }
                 - { component: argocd,          appName: argocd,          path: kubernetes/infrastructure/argocd/overlays/prod,          namespace: argocd,          wave: "90" }
   template:
     metadata:

--- a/kubernetes/infrastructure/mail/postfix/base/deployment.yaml
+++ b/kubernetes/infrastructure/mail/postfix/base/deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postfix-relay
+  namespace: mail
+  labels:
+    app: postfix-relay
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postfix-relay
+  template:
+    metadata:
+      labels:
+        app: postfix-relay
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: postfix
+          image: boky/postfix:v5.1.0-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: submission
+              containerPort: 587
+          env:
+            # In-built Postfix-Spamschutz: nur Mails VON diesen Domains werden relayed
+            - name: ALLOWED_SENDER_DOMAINS
+              value: "timourhomelab.org"
+            - name: POSTFIX_myhostname
+              value: "mail.timourhomelab.org"
+            # Cluster-Pods duerfen ohne Auth relayen (interner Relay, NICHT exponiert)
+            - name: POSTFIX_mynetworks
+              value: "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+            # ---- DELIVERABILITY-UPGRADE (spaeter, swappable - Apps merken NICHTS) ----
+            # Direct-Send (jetzt): Homelab-IP hat keine Reputation -> Gmail/Outlook
+            # rejecten evtl. Fuer zuverlaessige Zustellung Free-Upstream setzen;
+            # n8n/Keycloak/Grafana bleiben unveraendert (kennen nur diesen Relay):
+            # - name: RELAYHOST
+            #   value: "smtp-relay.brevo.com:587"
+            # - name: RELAYHOST_USERNAME
+            #   valueFrom: { secretKeyRef: { name: postfix-upstream, key: username } }
+            # - name: RELAYHOST_PASSWORD
+            #   valueFrom: { secretKeyRef: { name: postfix-upstream, key: password } }
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+          livenessProbe:
+            tcpSocket:
+              port: 587
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            tcpSocket:
+              port: 587
+            initialDelaySeconds: 10
+            periodSeconds: 15

--- a/kubernetes/infrastructure/mail/postfix/base/kustomization.yaml
+++ b/kubernetes/infrastructure/mail/postfix/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml

--- a/kubernetes/infrastructure/mail/postfix/base/namespace.yaml
+++ b/kubernetes/infrastructure/mail/postfix/base/namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mail
+  labels:
+    # Postfix laeuft als root (MTA-Standard) -> baseline erlaubt das, restricted nicht
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/kubernetes/infrastructure/mail/postfix/base/service.yaml
+++ b/kubernetes/infrastructure/mail/postfix/base/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: smtp-relay
+  namespace: mail
+  labels:
+    app: postfix-relay
+spec:
+  selector:
+    app: postfix-relay
+  ports:
+    - name: submission
+      port: 587
+      targetPort: 587
+  # Apps nutzen: smtp-relay.mail.svc.cluster.local:587

--- a/kubernetes/infrastructure/mail/postfix/overlays/prod/kustomization.yaml
+++ b/kubernetes/infrastructure/mail/postfix/overlays/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base

--- a/kubernetes/tenants/n8n-prod/app/configmap.yaml
+++ b/kubernetes/tenants/n8n-prod/app/configmap.yaml
@@ -77,6 +77,17 @@ data:
   # TASK RUNNERS
   #N8N_RUNNERS_ENABLED: "false"
 
+  # EMAIL / SMTP (zentraler Postfix-Relay in ns mail, unauth. via mynetworks)
+
+  N8N_EMAIL_MODE: "smtp"
+  N8N_SMTP_HOST: "smtp-relay.mail.svc.cluster.local"
+  N8N_SMTP_PORT: "587"
+  N8N_SMTP_SSL: "false"
+  N8N_SMTP_STARTTLS: "false"
+  N8N_SMTP_SENDER: "n8n <no-reply@timourhomelab.org>"
+  # kein N8N_SMTP_USER/PASS: Relay erlaubt Cluster-Pods ohne Auth (mynetworks).
+  # Falls n8n "must issue STARTTLS first" wirft -> STARTTLS "true" ODER Relay-TLS auf "may".
+
   # TEMPLATES & FEATURES
 
   N8N_TEMPLATES_ENABLED: "true"


### PR DESCRIPTION
Central Postfix send-relay in ns mail (infrastructure/mail/postfix) so n8n/keycloak/grafana can send mail (n8n password reset needs SMTP). Wired into controllers-stack (wave 0). n8n configmap points N8N_EMAIL_MODE=smtp at smtp-relay.mail.svc:587. Direct-send for now; upstream relayhost is a commented, swappable follow-up for deliverability.