### PR TITLE
allow mail ns

### DIFF
--- a/kubernetes/projects/infrastructure.yaml
+++ b/kubernetes/projects/infrastructure.yaml
@@ -136,6 +136,8 @@ spec:
       server: 'https://kubernetes.default.svc'
     - namespace: 'keda'
       server: 'https://kubernetes.default.svc'
+    - namespace: 'mail'
+      server: 'https://kubernetes.default.svc'
 
   clusterResourceWhitelist:
     # Core Kubernetes Resources


### PR DESCRIPTION
postfix-relay (infrastructure/mail, controllers-stack) was rejected with InvalidSpecError: namespace 'mail' not in the infrastructure AppProject destinations. Add it (clusterResourceWhitelist already permits Namespace via group '' kind '*').