### PR TITLE
exclude drova-postgres alert

### DIFF
--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/argocd.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/argocd.yaml
@@ -66,8 +66,11 @@ spec:
         # ≥3 dual-store-bug users → app Degraded across hours) — already covered by the
         # dedicated LLDAPBootstrapCronJobFailing below, and an lldap-service outage surfaces
         # via the Keycloak SSO alerts. Generic app-health flapping on it = pure noise.
+        # drova-postgres excluded too: confirmed stale ArgoCD-health false-positive — the CNPG
+        # Cluster reports "healthy state" 3/3, no resource is actually Degraded (survives refresh/
+        # sync/controller-restart/recreate). Real DB issues surface via CnpgPrimaryDown / CNPGBackupStale.
         - alert: ArgoCDAppUnhealthy
-          expr: argocd_app_info{health_status=~"Degraded|Missing", name!="lldap"} == 1
+          expr: argocd_app_info{health_status=~"Degraded|Missing", name!~"lldap|drova-postgres"} == 1
           for: 30m
           labels:
             severity: warning


### PR DESCRIPTION
drova-postgres ArgoCDAppUnhealthy is a confirmed stale-health false-positive (CNPG Cluster healthy 3/3, no resource actually Degraded, survives refresh/sync/recreate). Add it to the existing lldap exclusion. Real DB issues are covered by CnpgPrimaryDown / CNPGBackupStale.