### PR TITLE
wire coredns app

### DIFF
--- a/kubernetes/applicationsets/infrastructure/network-stack.yaml
+++ b/kubernetes/applicationsets/infrastructure/network-stack.yaml
@@ -27,6 +27,7 @@ spec:
           - list:
               elements:
                 - { component: cilium,        appName: cilium,        path: kubernetes/infrastructure/network/cilium/overlays/prod,        namespace: kube-system,  wave: "0" }
+                - { component: coredns,       appName: coredns,       path: kubernetes/infrastructure/network/coredns/base,                namespace: kube-system,  wave: "0" }
                 - { component: istio,         appName: istio-control-plane, path: kubernetes/infrastructure/network/istio-control-plane,   namespace: istio-system, wave: "5" }
                 - { component: gateway,       appName: gateway,       path: kubernetes/infrastructure/ingress/gateway/overlays/prod,       namespace: gateway,      wave: "70" }
                 - { component: cloudflared,   appName: cloudflared,   path: kubernetes/infrastructure/ingress/cloudflared/overlays/prod,   namespace: cloudflared,  wave: "70" }


### PR DESCRIPTION
network-stack kommentar versprach coredns, eintrag fehlte — coredns/base (Corefile + neues PDB) hing im leeren. Repo-Corefile == live-Corefile (gediffte) → wiring ändert null config, bringt aber: PDB deployed + selfHeal re-applied die CoreDNS-config automatisch nach talosctl upgrade-k8s (bisher manueller Schritt).