### PR TITLE
node pool prep

### DIFF
--- a/kubernetes/infrastructure/observability/elasticsearch/base/cluster/elasticsearch-cluster.yaml
+++ b/kubernetes/infrastructure/observability/elasticsearch/base/cluster/elasticsearch-cluster.yaml
@@ -112,6 +112,8 @@ spec:
                   # Heap 1g (50% of 2Gi limit) — homelab right-size, Loki carries most logs.
                   value: "-Xms1g -Xmx1g"
           # Affinity - schedule on large memory nodes (worker-1, worker-2 have 28GB)
+          # node-pool prep: bei Pool-Aktivierung hostname-Pinning ersetzen durch
+          #   - { key: node-pool, operator: In, values: [stateful] }
           affinity:
             nodeAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:

--- a/kubernetes/tenants/drova/kafka/base/kafka-cluster.yaml
+++ b/kubernetes/tenants/drova/kafka/base/kafka-cluster.yaml
@@ -47,6 +47,14 @@ spec:
   template:
     pod:
       priorityClassName: platform-critical
+      # node-pool prep (inaktiv bis neue Hardware, Design: tofu/talos_nodes.auto.tfvars):
+      # affinity:
+      #   nodeAffinity:
+      #     preferredDuringSchedulingIgnoredDuringExecution:
+      #       - weight: 100
+      #         preference:
+      #           matchExpressions:
+      #             - { key: node-pool, operator: In, values: [stateful] }
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -100,6 +108,14 @@ spec:
   template:
     pod:
       priorityClassName: platform-critical
+      # node-pool prep (inaktiv bis neue Hardware, Design: tofu/talos_nodes.auto.tfvars):
+      # affinity:
+      #   nodeAffinity:
+      #     preferredDuringSchedulingIgnoredDuringExecution:
+      #       - weight: 100
+      #         preference:
+      #           matchExpressions:
+      #             - { key: node-pool, operator: In, values: [stateful] }
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/tenants/drova/postgres/base/postgres-cluster 2.yaml
+++ b/kubernetes/tenants/drova/postgres/base/postgres-cluster 2.yaml
@@ -11,6 +11,9 @@ metadata:
 spec:
   instances: 3
   imageName: ghcr.io/cloudnative-pg/postgresql:16.1
+  # Preemption + Eviction-Reihenfolge: DB wird zuletzt verdraengt
+  # (Klasse aus tenants/drova/kafka/base — Requests bewusst schlank gelassen)
+  priorityClassName: platform-critical
   resources:
     requests:
       memory: 256Mi
@@ -22,9 +25,13 @@ spec:
     size: 10Gi
     storageClass: rook-ceph-block-enterprise-retain
   postgresql:
+    shared_preload_libraries:
+      - pgaudit
     parameters:
       max_connections: '100'
       shared_buffers: 128MB
+      pgaudit.log: "ddl,write,role"
+      pgaudit.log_parameter: "on"
   plugins:
   - name: barman-cloud.cloudnative-pg.io
     parameters:
@@ -48,6 +55,19 @@ spec:
     # 8 worker nodes — plenty of capacity. preferred was a homelab-shortcut.
     podAntiAffinityType: required
     topologyKey: kubernetes.io/hostname
+    # node-pool prep (inaktiv): nodeSelector: {node-pool: stateful}
+  # Zone-Spread HART: nie alle 3 Instanzen auf einem Proxmox-Host.
+  # ScheduleAnyway verlor gegen das RAM-Scoring (alle 3 landeten auf msa2 = Totalausfall-Risiko).
+  # Trade-off: bei echtem Zonen-Ausfall kann die 3. Instanz Pending bleiben — akzeptiert,
+  # dafür überlebt garantiert eine Instanz in der anderen Zone.
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          cnpg.io/cluster: drova-postgres
+          cnpg.io/podRole: instance
   # Rook-Ceph disk I/O is slow — replicas need more time for WAL replay on startup
   probes:
     startup:

--- a/kubernetes/tenants/n8n-prod/postgres/base/cluster.yaml
+++ b/kubernetes/tenants/n8n-prod/postgres/base/cluster.yaml
@@ -42,6 +42,7 @@ spec:
   affinity:
     podAntiAffinityType: required
     topologyKey: kubernetes.io/hostname
+    # node-pool prep (inaktiv): nodeSelector: {node-pool: stateful}
   topologySpreadConstraints:
     - maxSkew: 1
       topologyKey: topology.kubernetes.io/zone

--- a/tofu/talos/machine-config/common.yaml.tftpl
+++ b/tofu/talos/machine-config/common.yaml.tftpl
@@ -58,6 +58,8 @@ machine:
   nodeLabels:
     topology.kubernetes.io/region: ${cluster_name}
     topology.kubernetes.io/zone: ${node_name}
+    # node-pool prep (inaktiv): Label kommt bei Aktivierung via talosctl patch, Design in talos_nodes.auto.tfvars
+    # node-pool: stateful|stateless
   network:
     hostname: ${hostname}
     # upstream DNS = gateway directly. DHCP hands out 8.8.8.8 which times out from

--- a/tofu/talos_nodes.auto.tfvars
+++ b/tofu/talos_nodes.auto.tfvars
@@ -84,24 +84,21 @@ talos_nodes = {
   }
 
   # ─── FUTURE NODES (vorbereitet, einkommentieren sobald neue Hardware da) ───
-  # IP/MAC/vm_id sind Platzhalter (frei: .102/.106/.109+, vm 1006+) — vor Aktivierung setzen.
-  # Reihenfolge: erst host3 in Proxmox, dann ctrl-1+ctrl-2 (etcd 1→3 = SPOF weg),
-  # dann worker-6 als ai-Pool (Taint hält Alltagslast fern, MLOps-Roadmap).
 
   # "ctrl-1" = {
-  #   host_node      = "msa2proxmox"   # CP-Spread: nipogi + msa2 + host3
+  #   host_node      = "msa2proxmox"
   #   machine_type   = "controlplane"
   #   ip             = "192.168.0.102"
   #   mac_address    = "BC:24:11:2E:C8:B1"
   #   vm_id          = 1006
   #   cpu            = 4
   #   ram_dedicated  = 12288
-  #   datastore_id   = "local-zfs"     # etcd-fsync: beste Disk des Hosts nehmen!
+  #   datastore_id   = "local-zfs"
   #   os_disk_size   = 50
   #   ceph_disk_size = 0
   # }
   # "ctrl-2" = {
-  #   host_node      = "host3"         # erst mit 3. Host ueberlebt etcd einen HOST-Ausfall
+  #   host_node      = "host3"
   #   machine_type   = "controlplane"
   #   ip             = "192.168.0.106"
   #   mac_address    = "BC:24:11:2E:C8:B2"
@@ -122,7 +119,7 @@ talos_nodes = {
   #   ram_dedicated  = 32768
   #   datastore_id   = "local-zfs"
   #   os_disk_size   = 50
-  #   ceph_disk_size = 250             # host3-OSDs => Ceph 3. Zone => size-3-Pools moeglich
-  #   # pool         = "ai"            # + Taint dedicated=ai:NoSchedule (GPU/ML exklusiv)
+  #   ceph_disk_size = 250
+  #   # pool         = "ai"
   # }
 }

--- a/tofu/talos_nodes.auto.tfvars
+++ b/tofu/talos_nodes.auto.tfvars
@@ -1,12 +1,12 @@
 talos_nodes = {
   "ctrl-0" = {
-    host_node      = "nipogi"
-    machine_type   = "controlplane"
-    ip             = "192.168.0.101"
-    mac_address    = "BC:24:11:2E:C8:A0"
-    vm_id          = 1000
-    cpu            = 6
-    ram_dedicated  = 14336
+    host_node     = "nipogi"
+    machine_type  = "controlplane"
+    ip            = "192.168.0.101"
+    mac_address   = "BC:24:11:2E:C8:A0"
+    vm_id         = 1000
+    cpu           = 6
+    ram_dedicated = 14336
     # etcd-fsync: ctrl-0 OS-Disk auf Samsung (cephpool), nicht HOGE (local-zfs)
     datastore_id   = "cephpool"
     os_disk_size   = 50
@@ -24,6 +24,9 @@ talos_nodes = {
     os_disk_size        = 50
     ceph_disk_size      = 170
     ceph_disk_datastore = "cephpool"
+    # node-pool prep (inaktiv bis neue Hardware): stateful=w1/w4/w5, stateless=w2/w3.
+    # Beide Pools spannen BEIDE Zonen — zone-Spread von drova-pg/kafka bricht sonst.
+    # Aktivierung OHNE tofu apply (Drift!): talosctl patch machineconfig nodeLabels + hier einkommentieren.
     # pool              = "stateful"
   }
   "worker-2" = {
@@ -38,7 +41,7 @@ talos_nodes = {
     os_disk_size        = 50
     ceph_disk_size      = 170
     ceph_disk_datastore = "cephpool"
-    # pool              = "stateful"
+    # pool              = "stateless"
   }
   "worker-3" = {
     host_node      = "msa2proxmox"
@@ -64,7 +67,7 @@ talos_nodes = {
     datastore_id   = "local-zfs"
     os_disk_size   = 50
     ceph_disk_size = 250
-    # pool         = "stateless"
+    # pool         = "stateful"
   }
   "worker-5" = {
     host_node      = "msa2proxmox"
@@ -77,6 +80,49 @@ talos_nodes = {
     datastore_id   = "local-zfs"
     os_disk_size   = 50
     ceph_disk_size = 250
-    # pool         = "stateless"
+    # pool         = "stateful"
   }
+
+  # ─── FUTURE NODES (vorbereitet, einkommentieren sobald neue Hardware da) ───
+  # IP/MAC/vm_id sind Platzhalter (frei: .102/.106/.109+, vm 1006+) — vor Aktivierung setzen.
+  # Reihenfolge: erst host3 in Proxmox, dann ctrl-1+ctrl-2 (etcd 1→3 = SPOF weg),
+  # dann worker-6 als ai-Pool (Taint hält Alltagslast fern, MLOps-Roadmap).
+
+  # "ctrl-1" = {
+  #   host_node      = "msa2proxmox"   # CP-Spread: nipogi + msa2 + host3
+  #   machine_type   = "controlplane"
+  #   ip             = "192.168.0.102"
+  #   mac_address    = "BC:24:11:2E:C8:B1"
+  #   vm_id          = 1006
+  #   cpu            = 4
+  #   ram_dedicated  = 12288
+  #   datastore_id   = "local-zfs"     # etcd-fsync: beste Disk des Hosts nehmen!
+  #   os_disk_size   = 50
+  #   ceph_disk_size = 0
+  # }
+  # "ctrl-2" = {
+  #   host_node      = "host3"         # erst mit 3. Host ueberlebt etcd einen HOST-Ausfall
+  #   machine_type   = "controlplane"
+  #   ip             = "192.168.0.106"
+  #   mac_address    = "BC:24:11:2E:C8:B2"
+  #   vm_id          = 1007
+  #   cpu            = 4
+  #   ram_dedicated  = 12288
+  #   datastore_id   = "local-zfs"
+  #   os_disk_size   = 50
+  #   ceph_disk_size = 0
+  # }
+  # "worker-6" = {
+  #   host_node      = "host3"
+  #   machine_type   = "worker"
+  #   ip             = "192.168.0.109"
+  #   mac_address    = "BC:24:11:2E:C8:B3"
+  #   vm_id          = 1008
+  #   cpu            = 12
+  #   ram_dedicated  = 32768
+  #   datastore_id   = "local-zfs"
+  #   os_disk_size   = 50
+  #   ceph_disk_size = 250             # host3-OSDs => Ceph 3. Zone => size-3-Pools moeglich
+  #   # pool         = "ai"            # + Taint dedicated=ai:NoSchedule (GPU/ML exklusiv)
+  # }
 }


### PR DESCRIPTION
node-pools vorbereitet, alles auskommentiert = null live-effekt:

- tfvars: pool-kommentare zonen-korrekt gedreht (stateful=w1/w4/w5, stateless=w2/w3 — beide pools spannen beide zonen, sonst bricht der zone-spread von drova-pg/kafka) + future nodes voll auskommentiert (ctrl-1/ctrl-2 fuer etcd-quorum 3, worker-6 als ai-pool auf host3)
- machine-config template: node-pool label als kommentar-prep
- kafka/es/drova-pg/n8n-pg: affinity/nodeSelector-bloecke auskommentiert bereit

aktivierung spaeter OHNE tofu apply: talosctl patch machineconfig (nodeLabels) + bloecke einkommentieren. kustomize builds verifiziert (render unveraendert).