### PR TITLE
chore(deps): update kiali-server to v2 - autoclosed

### DIFF
--- a/kubernetes/infrastructure/observability/dashboards/kiali/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/kiali/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 helmCharts:
   - name: kiali-server
     repo: https://kiali.org/helm-charts
-    version: 2.28.0
+    version: 2.29.0
     releaseName: kiali
     namespace: istio-system
     valuesInline:


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/kiali-server-2.x`
Filter passed: <24h old, <5 commits ahead.