### PR TITLE
fix: stagger DR-verify schedules + fail-fast

### DIFF
--- a/kubernetes/infrastructure/storage/velero-schedules/restore-verify-cronjob.yaml
+++ b/kubernetes/infrastructure/storage/velero-schedules/restore-verify-cronjob.yaml
@@ -46,7 +46,11 @@ metadata:
     app.kubernetes.io/name: velero-restore-verify
     app.kubernetes.io/part-of: backup-validation
 spec:
-  schedule: "0 4 * * *"          # täglich 04:00 UTC (nach 03:00 Daily-Backup)
+  # 07:30 UTC — war 04:00 und lief damit exakt zeitgleich mit cnpg-dr-verify (jetzt 04:30).
+  # Beide zusammen mit dem 03:00-Backup-Nachlauf = I/O-Sturm auf cephpool/Samsung, wo auch
+  # etcd liegt → fsync-Spikes → leader-election-Verluste clusterweit (2026-07-20).
+  # 07:30 liegt frei zwischen der 06:00- und 12:00-tier0-Welle.
+  schedule: "30 7 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 7      # 7 days history für DR-Drill-Tracking
@@ -125,8 +129,8 @@ spec:
                   EOF
 
                   ERROR_REASON=""
-                  # 4. Wait for restore to complete (max 10min)
-                  for i in $(seq 1 60); do
+                  # 4. Wait for restore to complete (max 15min)
+                  for i in $(seq 1 90); do
                     PHASE=$(kubectl get restores.velero.io -n velero "$RESTORE" -o jsonpath='{.status.phase}' 2>/dev/null)
                     if [ "$PHASE" = "Completed" ]; then
                       echo "✓ Restore Completed"
@@ -143,7 +147,9 @@ spec:
 
                   # 5. Cleanup
                   kubectl delete restores.velero.io -n velero "$RESTORE" --ignore-not-found=true >/dev/null 2>&1
-                  kubectl delete ns "$TEST_NS" --ignore-not-found=true >/dev/null 2>&1
+                  # --wait=false: sonst blockiert der Delete bis der NS finalisiert ist und
+                  # der Job stirbt mit "timed out waiting for the condition" (2026-07-20).
+                  kubectl delete ns "$TEST_NS" --ignore-not-found=true --wait=false >/dev/null 2>&1
 
                   # 6. Final verdict — exit code triggers KubeJobFailed Prometheus alert
                   if [ "$PHASE" = "Completed" ]; then

--- a/kubernetes/tenants/drova/postgres/base/dr-verify-cronjob.yaml
+++ b/kubernetes/tenants/drova/postgres/base/dr-verify-cronjob.yaml
@@ -6,12 +6,15 @@
 #   2. Create test-namespace dr-verify-<ts>
 #   3. Copy backup-secret + ObjectStore CR
 #   4. Apply Cluster CR mit bootstrap.recovery
-#   5. Wait for "Cluster in healthy state" (max 10min)
+#   5. Wait for "Cluster in healthy state" (max 25min, fail-fast bei Fehler-Phase)
 #   6. Verify databases via psql
 #   7. Cleanup test-NS
 #   8. Notify Telegram (success/fail)
 #
-# Schedule: 04:00 UTC daily (off-peak)
+# Schedule: 04:30 UTC daily. War 04:00 und lief damit zeitgleich mit velero-restore-verify
+# plus dem 03:00-Backup-Nachlauf — alles I/O auf cephpool/Samsung, wo auch etcd + Ceph-OSDs
+# liegen. Ergebnis 2026-07-20: etcd-fsync-Spikes → "leader election lost" → CNPG-Operator
+# restartet mitten im Restore → "Unable to create required cluster objects".
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -53,7 +56,7 @@ metadata:
   name: cnpg-dr-verify
   namespace: drova
 spec:
-  schedule: "0 4 * * *"
+  schedule: "30 4 * * *"
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 5
   concurrencyPolicy: Forbid
@@ -139,20 +142,45 @@ spec:
                             serverName: drova-postgres
                   EOF
 
-                  # 6. Wait for "Cluster in healthy state" (max 15min)
-                  echo "→ Waiting for restore (max 15min)..."
-                  for i in $(seq 1 90); do
-                    PHASE=$(kubectl get cluster -n $TEST_NS $CLUSTER_NAME -o jsonpath='{.status.phase}' 2>/dev/null)
-                    echo "  [$(date +%H:%M:%S)] phase: $PHASE"
-                    if [ "$PHASE" = "Cluster in healthy state" ]; then
-                      break
+                  # 6. Wait for "Cluster in healthy state" (max 25min)
+                  # Bricht sofort ab statt blind weiterzupollen, wenn der Cluster in eine
+                  # Fehler-Phase geht ODER die CR verschwindet (= Operator hat sich
+                  # weggeschossen, z.B. "leader election lost" bei etcd-Latenz).
+                  echo "→ Waiting for restore (max 25min)..."
+                  PHASE=""
+                  GONE=0
+                  for i in $(seq 1 150); do
+                    if kubectl get cluster -n $TEST_NS $CLUSTER_NAME >/dev/null 2>&1; then
+                      GONE=0
+                      PHASE=$(kubectl get cluster -n $TEST_NS $CLUSTER_NAME -o jsonpath='{.status.phase}' 2>/dev/null)
+                      echo "  [$(date +%H:%M:%S)] phase: ${PHASE:-<leer>}"
+                      if [ "$PHASE" = "Cluster in healthy state" ]; then
+                        break
+                      fi
+                      case "$PHASE" in
+                        *"Unable to create"*|*Failed*)
+                          echo "✗ ABBRUCH: Cluster in Fehler-Phase"
+                          break
+                          ;;
+                      esac
+                    else
+                      GONE=$((GONE + 1))
+                      echo "  [$(date +%H:%M:%S)] Cluster-CR nicht abfragbar ($GONE/3)"
+                      if [ $GONE -ge 3 ]; then
+                        echo "✗ ABBRUCH: Restore-Cluster verschwunden (Operator-Restart?)"
+                        break
+                      fi
                     fi
                     sleep 10
                   done
 
                   if [ "$PHASE" != "Cluster in healthy state" ]; then
-                    echo "✗ FAIL: Restore did not reach healthy state after 15min"
-                    kubectl get events -n $TEST_NS --sort-by=.metadata.creationTimestamp | tail -10
+                    echo "✗ FAIL: Restore nicht healthy (letzte phase: ${PHASE:-<leer>})"
+                    echo "→ CNPG-Operator (Restarts = häufigste Ursache):"
+                    kubectl get pods -n cnpg-system 2>/dev/null | head -5
+                    echo "→ Events im Test-NS:"
+                    kubectl get events -n $TEST_NS --sort-by=.metadata.creationTimestamp 2>/dev/null | tail -15
+                    kubectl describe cluster -n $TEST_NS $CLUSTER_NAME 2>/dev/null | tail -25
                     exit 1
                   fi
 


### PR DESCRIPTION
Beide DR-Verify-CronJobs liefen auf `0 4 * * *` — zeitgleich miteinander und im Nachlauf der 03:00-Backups. Alles I/O auf cephpool/Samsung, wo auch etcd und die Ceph-OSDs osd.2/osd.4 liegen.

Folge in der Nacht 2026-07-20: etcd-fsync-Spikes → Lease-Renewal (5s) scheitert → `leader election lost` bei allen leader-electing Controllern (kube-scheduler 29x, kube-controller-manager 25x, rook-ceph-mgr 62x, cloudnative-pg 17x, barman-plugin 25x, cloudflared 35x). Der CNPG-Operator war mitten im Restore weg → `Unable to create required cluster objects` → DR-Verify pollte 15 Min ins Leere.

**Changes**

- `cnpg-dr-verify`: `0 4 * * *` → `30 4 * * *`; fail-fast bei Fehler-Phase oder verschwundener Cluster-CR statt blind weiterzupollen; Timeout 15 → 25 Min; Operator-Zustand + Events + describe im Fehlerfall
- `velero-restore-verify`: `0 4 * * *` → `30 7 * * *` (frei zwischen der 06:00- und 12:00-tier0-Welle); `delete ns --wait=false` — der blockierende Delete war die Quelle von `timed out waiting for the condition`; Restore-Poll 10 → 15 Min

Validiert: YAML parst, `bash -n` grün auf beiden Scripts, pre-commit durchgelaufen.