### PR TITLE
harden: lock redis-gateway rate-limit store

### DIFF
--- a/kubernetes/security/foundation/network-policies/kustomization.yaml
+++ b/kubernetes/security/foundation/network-policies/kustomization.yaml
@@ -14,6 +14,7 @@ kind: Kustomization
 resources:
   # Cluster-wide network policies
   - envoy-gateway.yaml          # Envoy ingress lock — public-only
+  - redis-gateway.yaml          # Rate-limit Redis lock — only envoy-ratelimit + monitoring
   # Tenant-specific (grouped per tenant for discoverability — DAX pattern)
   - tenants/drova
 

--- a/kubernetes/security/foundation/network-policies/redis-gateway.yaml
+++ b/kubernetes/security/foundation/network-policies/redis-gateway.yaml
@@ -1,0 +1,38 @@
+---
+# Lock the rate-limit Redis (redis-gateway): only the envoy-ratelimit pods (client), the
+# OpsTree redis-operator (manager) and monitoring (exporter) may reach it. The store runs
+# `protected-mode no` with no AUTH, so without this policy ANY pod in the cluster could read
+# or poison the rate-limit counters. Probes are exec (redis-cli ping, in-container) so they
+# bypass the policy — no host rule needed.
+# Selectors verified live 2026-07-21.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: redis-gateway-ingress-lock
+  namespace: gateway
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: redis-gateway
+  ingress:
+    # rate-limit service → Redis counter store
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: envoy-ratelimit
+      toPorts:
+        - ports:
+            - { port: "6379", protocol: TCP }
+    # OpsTree redis-operator manages this instance
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: redis-operator-system
+      toPorts:
+        - ports:
+            - { port: "6379", protocol: TCP }
+    # redis-exporter scrape (aktiv sobald redisExporter aktiviert wird)
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - { port: "9121", protocol: TCP }


### PR DESCRIPTION
Die Rate-Limit-Redis (redis-gateway) läuft mit `protected-mode no` und ohne AUTH — bisher ohne NetworkPolicy, d.h. jeder Pod im Cluster konnte die Rate-Limit-Zähler lesen oder vergiften.

Diese CiliumNetworkPolicy sperrt den Ingress auf:
- `envoy-ratelimit` → :6379 (der Client)
- `redis-operator-system` → :6379 (der OpsTree-Operator, managed die Instanz)
- `monitoring` → :9121 (redis-exporter, falls je aktiviert)

Selektoren live verifiziert (2026-07-21). Die Liveness/Readiness-Probes sind exec (redis-cli ping, in-container) → umgehen die Policy, daher kein host-Rule nötig.

Bewusst NICHT: Redis-HA / Persistenz / AUTH / TLS — Over-Engineering für einen ephemeren 64MB-LRU-Zähler-Store; die NetworkPolicy ist der richtig dimensionierte Wächter.