### PR TITLE
feat: custom 429 rate-limit page for drova

### DIFF
--- a/kubernetes/security/foundation/rate-limiting/tenants/drova/policy.yaml
+++ b/kubernetes/security/foundation/rate-limiting/tenants/drova/policy.yaml
@@ -20,6 +20,47 @@ spec:
             - headers:
                 - name: CF-Connecting-IP
                   type: Distinct
+  # Statt des nackten "local_rate_limited"-Textes eine gebrandete Warteseite beim 429.
+  responseOverride:
+    - match:
+        statusCodes:
+          - type: Value
+            value: 429
+      response:
+        contentType: text/html
+        body:
+          type: Inline
+          inline: |
+            <!DOCTYPE html>
+            <html lang="de">
+            <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width,initial-scale=1">
+            <title>Zu viele Anfragen</title>
+            <style>
+            :root{color-scheme:dark}
+            *{box-sizing:border-box}
+            body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;
+              font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+              background:radial-gradient(circle at 50% 30%,#1e293b,#0f172a);color:#e2e8f0}
+            .card{text-align:center;padding:2.5rem;max-width:30rem}
+            .code{font-size:5rem;font-weight:800;letter-spacing:-.05em;margin:0;
+              background:linear-gradient(90deg,#38bdf8,#818cf8);-webkit-background-clip:text;
+              background-clip:text;color:transparent}
+            h1{font-size:1.4rem;margin:.5rem 0 1rem}
+            p{color:#94a3b8;line-height:1.6;margin:0 0 1.25rem}
+            .hint{font-size:.85rem;color:#64748b}
+            </style>
+            </head>
+            <body>
+            <div class="card">
+            <p class="code">429</p>
+            <h1>Zu viele Anfragen</h1>
+            <p>Es gehen gerade ungewöhnlich viele Anfragen ein. Bitte warte einen kurzen Moment und lade die Seite dann neu.</p>
+            <p class="hint">Too many requests — please wait a moment and reload.</p>
+            </div>
+            </body>
+            </html>
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy


### PR DESCRIPTION
Beim DDoS auf drova (public) zeigte der Rate-Limiter nur den nackten `local_rate_limited`-Text. Diese `responseOverride` ersetzt den 429-Body durch eine gebrandete, self-contained Warteseite (inline HTML, dark, DE+EN).

- Envoy Gateway v1.6.7, `responseOverride`-Schema live verifiziert
- Ändert NICHT das Rate-Limit-Verhalten (300 req/min pro CF-Connecting-IP) — nur die Darstellung des 429
- Nur drova-app (die public/attackierte Route); n8n = gleicher 3-Zeilen-Patch als Follow-up möglich

⚠️ Wichtig: der eigentliche DDoS-Schild bleibt Cloudflare am Edge — das hier ist L7-UX-Politur fuer legit User, die ins Limit rutschen, KEINE Volumetric-DDoS-Abwehr.