### PR TITLE
fix: disable renovate for docker.n8n.io n8n image

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -167,9 +167,8 @@
       "registryUrls": ["https://bitnami.github.io/sealed-secrets"]
     },
     {
-      "description": "docker.n8n.io v2-API needs auth Renovate cannot do (401) — n8n is hand-pinned, skip digest refresh",
+      "description": "docker.n8n.io returns 401 for anonymous v2-API lookups so Renovate can't resolve digest or tags — n8n is hand-pinned/manually managed. Disable the package entirely (not just digest updates): matchUpdateTypes only filters AFTER the lookup, so the failing lookup still logged 'Could not determine new digest' on every run. enabled:false skips the lookup outright.",
       "matchPackageNames": ["docker.n8n.io/n8nio/n8n"],
-      "matchUpdateTypes": ["digest"],
       "enabled": false
     },
 


### PR DESCRIPTION
Renovate warnte auf JEDEM Branch 6× mit `Could not determine new digest for update (docker.n8n.io/n8nio/n8n)`.

Ursache: `docker.n8n.io` gibt 401 auf anonyme v2-API-Lookups → Renovate kann Digest/Tags nicht auflösen. Die bestehende Regel disablte nur `matchUpdateTypes: [digest]` — das filtert aber ERST NACH dem Lookup, also lief der fehlschlagende Lookup weiter und loggte den WARN.

Fix: das Paket komplett disablen (`enabled: false` ohne updateType-Filter) → der Lookup läuft gar nicht erst. n8n ist ohnehin hand-pinned/manuell verwaltet.