### PR TITLE
harden: envoy L7 DoS resilience (keepalive + http2 stream cap)

### DIFF
--- a/kubernetes/infrastructure/ingress/gateway/base/clienttraffic-policy.yaml
+++ b/kubernetes/infrastructure/ingress/gateway/base/clienttraffic-policy.yaml
@@ -24,7 +24,21 @@ spec:
     connectionLimit:
       value: 10000
       closeDelay: 5s
+  # Reap dead/abandoned downstream sockets fast so their connection slots free up
+  # (anti connection-exhaustion). Probes after 60s idle, every 10s, drop after 6 misses.
+  tcpKeepalive:
+    idleTime: 60s
+    interval: 10s
+    probes: 6
+  # HTTP/2 flood + Rapid-Reset (CVE-2023-44487) mitigation: cap concurrent streams per
+  # connection. One HTTP/2 conn opening thousands of streams is the classic amplification
+  # vector; 100 is generous for real browsers (~6-100).
+  http2:
+    maxConcurrentStreams: 100
   timeout:
     http:
+      # Slowloris: full request headers must arrive within 10s.
       requestReceivedTimeout: 10s
       idleTimeout: 300s
+      # BEWUSST kein streamIdleTimeout: drova nutzt WebSockets (Chat) + Live-Streams —
+      # ein aggressiver Stream-Timeout würde die abwürgen. Long-lived Streams erlaubt.


### PR DESCRIPTION
Erweitert die bestehende `ddos-protection` ClientTrafficPolicy (gateway-wide) um zwei sichere, wirksame L7-DoS-Hebel:

- **tcpKeepalive** (60s/10s/6) → tote/verwaiste Client-Sockets schnell erkennen + Connection-Slots freigeben (Anti-Connection-Exhaustion)
- **http2.maxConcurrentStreams: 100** → HTTP/2-Flood + Rapid-Reset (CVE-2023-44487) begrenzen; eine HTTP/2-Verbindung die tausende Streams öffnet ist der klassische Amplification-Vektor

Bleibt bestehen: 10k Connection-Limit, 10s Slowloris-requestReceivedTimeout, CF-Connecting-IP.

**Bewusst NICHT gebaut (verify-before-enforce):**
- aggressiver `streamIdleTimeout` → drova nutzt WebSockets (Chat) + Live-Streams, das wuerde sie abwuergen
- Circuit-Breaker → brauchen echte Last-Daten fuer sinnvolle Schwellen, sonst brechen sie legit Spitzen

Schema gegen Envoy Gateway v1.6.7 verifiziert.

⚠️ Ehrlich: das ist **L7-Resilienz (Defense-in-Depth)**, KEINE volumetrische DDoS-Abwehr — die bleibt Cloudflare am Edge.