### PR TITLE
add ml department tenant

### DIFF
--- a/kubernetes/applicationsets/tenants/tenants-config.yaml
+++ b/kubernetes/applicationsets/tenants/tenants-config.yaml
@@ -28,6 +28,7 @@ spec:
                 - { component: n8n-prod, appName: n8n-prod-config, namespace: n8n-prod, wave: "10" }
                 - { component: keycloak, appName: keycloak-config, namespace: keycloak, wave: "10" }
                 - { component: lldap,    appName: lldap-config,    namespace: lldap,    wave: "10" }
+                - { component: ml,       appName: ml-config,       namespace: ml,       wave: "10" }
   template:
     metadata:
       name: '{{.appName}}'

--- a/kubernetes/platform/ml/README.md
+++ b/kubernetes/platform/ml/README.md
@@ -1,0 +1,33 @@
+# ML Platform — GEPARKT (wartet auf Hardware)
+
+**Status: Platzhalter, deployt NICHTS.** Dieser Ordner ist von keiner kustomization und
+keinem AppSet referenziert — er dokumentiert nur, wo die ML-Platform-Tools hinkommen,
+sobald neue Hardware (GPU-Node) da ist.
+
+## Das Zwei-Hälften-Muster
+
+| Hälfte | Pfad | Inhalt | Status |
+|--------|------|--------|--------|
+| Workspace | `kubernetes/tenants/ml/` | Namespace, Quota, LimitRange, RBAC | ✅ live (PR #508) |
+| Tools (dieser Ordner) | `kubernetes/platform/ml/` + `infrastructure/operators/` | MLflow, KServe, Argo Workflows | ⏸️ geparkt |
+
+Analog zum Rest des Repos: Strimzi-Operator (`infrastructure/operators/strimzi/`)
+↔ drovas Kafka (`tenants/drova/kafka/`), CNPG-Operator ↔ n8ns Postgres.
+
+## Geplanter Stack (CPU-first, siehe notes/CLAUDE-MLOPS.md)
+
+```
+platform/ml/mlflow/                      → Experiment-Tracking (zentraler Server)
+infrastructure/operators/kserve/         → Model-Serving-Operator
+infrastructure/operators/argo-workflows/ → Pipeline-Engine
+```
+
+**Bewusst KEIN Full-Kubeflow:** 10+ Komponenten, RAM-Fresser, eigener Istio-Zwang —
+MLflow + KServe + Argo Workflows liefern dieselben Capabilities modular und leicht.
+
+## Aktivierung (wenn Hardware da)
+
+1. GPU-Node in tofu/tfvars aktivieren (FUTURE-NODES-Block, worker-6-ai)
+2. Operator-Ordner hier + in `infrastructure/operators/` anlegen (base + overlays/prod)
+3. In controllers-stack bzw. identity-stack-Muster als AppSet-Elemente verdrahten
+4. GPU-Quota in `tenants/ml/resourcequota.yaml` einkommentieren

--- a/kubernetes/projects/platform.yaml
+++ b/kubernetes/projects/platform.yaml
@@ -21,6 +21,8 @@ spec:
       server: https://kubernetes.default.svc
     - namespace: n8n-prod
       server: https://kubernetes.default.svc
+    - namespace: ml
+      server: https://kubernetes.default.svc
 
   # Platform can use platform layer resources
   sourceRepos:

--- a/kubernetes/tenants/kustomization.yaml
+++ b/kubernetes/tenants/kustomization.yaml
@@ -5,4 +5,6 @@ resources:
   - n8n-prod/
   - keycloak/
   - lldap/
+  - ml/
+  # - oms/   # geparkt — Tenant-Template, aktivieren wenn gebraucht
 

--- a/kubernetes/tenants/ml/README.md
+++ b/kubernetes/tenants/ml/README.md
@@ -1,0 +1,39 @@
+# ML — Machine Learning Department (Tenant)
+
+Namespace-isolierter Tenant für Drovas ML-Workloads. Gleiches Muster wie jeder andere
+Tenant (`namespace` + `resourcequota` + `limitrange` + `rbac`), gescoped auf die
+`ml`-Namespace, deployed über die `tenants-config` AppSet (Project `platform`, manual-sync).
+
+## Wofür (Drova-ML-Use-Cases)
+
+- **Dynamic Pricing** — Surge-Preise aus Angebot/Nachfrage (trip-service Events)
+- **ETA-Prediction** — Ankunftszeit-Modell (driver-service Geo-Daten)
+- **Fraud-Detection** — Auffällige Zahlungen (payment-service)
+- **Matching** — Driver↔Rider Zuordnung
+
+## Geplanter Stack (CPU-first, GPU-gated)
+
+| Layer | Tool | Status |
+|-------|------|--------|
+| Experiment-Tracking | MLflow | geplant |
+| Model-Serving | KServe | geplant |
+| Pipelines | Argo Workflows | geplant |
+| Feature-Store | Feast | geplant |
+
+**Status:** Department-Struktur + Guardrails stehen (Namespace, Quota, LimitRange, RBAC).
+Tools kommen inkrementell — GPU-Workloads sind geblockt bis ein GPU-Node da ist
+(CPU-first Starter zuerst). Volle Landkarte: `notes/CLAUDE-MLOPS.md`.
+
+## Ownership / RBAC
+
+- ServiceAccount `ml-admin-sa` (interim, wie oms)
+- OIDC-Pfad vorbereitet: Keycloak-Gruppe `keycloak-ml-engineers` → Namespace-Admin
+  (in `rbac.yaml` einkommentieren sobald die LLDAP/Keycloak-Gruppe existiert)
+
+## Aktivieren
+
+`ml` ist bereits in der `tenants-config` AppSet verdrahtet. Deployen (manual-sync/DAX-Gate):
+
+```bash
+argocd app sync ml-config
+```

--- a/kubernetes/tenants/ml/kustomization.yaml
+++ b/kubernetes/tenants/ml/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ml
+
+resources:
+- namespace.yaml
+- resourcequota.yaml
+- limitrange.yaml
+- rbac.yaml
+
+labels:
+- pairs:
+    app.kubernetes.io/managed-by: argocd
+    platform.homelab/tenant: ml

--- a/kubernetes/tenants/ml/limitrange.yaml
+++ b/kubernetes/tenants/ml/limitrange.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: ml-limits
+  namespace: ml
+spec:
+  limits:
+  - max:
+      cpu: "4"
+      memory: 8Gi
+    min:
+      cpu: 20m
+      memory: 64Mi
+    default:
+      cpu: 200m
+      memory: 256Mi
+    defaultRequest:
+      cpu: 100m
+      memory: 128Mi
+    type: Container

--- a/kubernetes/tenants/ml/namespace.yaml
+++ b/kubernetes/tenants/ml/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ml
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"

--- a/kubernetes/tenants/ml/rbac.yaml
+++ b/kubernetes/tenants/ml/rbac.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ml-admin-sa
+  namespace: ml
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ml-admin
+  namespace: ml
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ml-admin-binding
+  namespace: ml
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ml-admin
+subjects:
+  - kind: ServiceAccount
+    name: ml-admin-sa
+    namespace: ml
+  # OIDC-Team-Binding (Enterprise-Pfad): Keycloak-Gruppe -> Namespace-Admin
+  # Gruppe in LLDAP/Keycloak anlegen, dann einkommentieren:
+  # - kind: Group
+  #   name: keycloak-ml-engineers
+  #   apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/tenants/ml/resourcequota.yaml
+++ b/kubernetes/tenants/ml/resourcequota.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: ml-quota
+  namespace: ml
+spec:
+  hard:
+    requests.cpu: "8"
+    requests.memory: 16Gi
+    limits.cpu: "16"
+    limits.memory: 32Gi
+    persistentvolumeclaims: "15"
+    services.loadbalancers: "0"
+    # requests.nvidia.com/gpu: "0"   # aktivieren sobald GPU-Node da (MLOps-Roadmap, notes/CLAUDE-MLOPS.md)


### PR DESCRIPTION
Neuer namespace-isolierter Tenant \`ml\` fürs Drova-ML-Department — gleiches Muster wie oms/drova (namespace + resourcequota + limitrange + rbac), deployed über die tenants-config AppSet (project platform, manual-sync/DAX-Gate).

Struktur + Guardrails stehen; ML-Tools (MLflow/KServe/Argo-Workflows) kommen inkrementell, GPU-Workloads gated bis GPU-Node da (CPU-first, notes/CLAUDE-MLOPS.md). Aktivieren nach Merge via \`argocd app sync ml-config\`.

Nebenbei: oms als sichtbar-geparkter Kommentar in tenants/kustomization.yaml (Template, nicht deployen). kustomize build grün für tenants/ (ml=1, oms=0), projects/, applicationsets/.