### PR TITLE
add night freeze sync windows

### DIFF
--- a/kubernetes/projects/apps.yaml
+++ b/kubernetes/projects/apps.yaml
@@ -11,6 +11,17 @@ metadata:
 spec:
   description: " Enterprise Applications Layer - User-Facing Services"
 
+  # Nacht-Freeze 02-05 Uhr (Backup-Fenster, niemand wach): kein Auto-Sync/selfHeal,
+  # manueller Sync bleibt als Break-Glass erlaubt
+  syncWindows:
+    - kind: deny
+      schedule: '0 2 * * *'
+      duration: 3h
+      timeZone: Europe/Berlin
+      applications:
+        - '*'
+      manualSync: true
+
   #  SECURITY: Restrict source repositories ()
   sourceRepos:
     - 'https://github.com/Tim275/talos-homelab'

--- a/kubernetes/projects/infrastructure.yaml
+++ b/kubernetes/projects/infrastructure.yaml
@@ -9,6 +9,17 @@ metadata:
     team: timour
 spec:
   description: "Infrastructure Layer - Core Cluster Services"
+
+  # Nacht-Freeze 02-05 Uhr (Backup-Fenster, niemand wach): kein Auto-Sync/selfHeal,
+  # manueller Sync bleibt als Break-Glass erlaubt
+  syncWindows:
+    - kind: deny
+      schedule: '0 2 * * *'
+      duration: 3h
+      timeZone: Europe/Berlin
+      applications:
+        - '*'
+      manualSync: true
   sourceRepos:
     - 'https://github.com/Tim275/talos-homelab'
     - 'https://victoriametrics.github.io/helm-charts'  # VictoriaMetrics Helm Repository

--- a/kubernetes/projects/platform.yaml
+++ b/kubernetes/projects/platform.yaml
@@ -11,6 +11,17 @@ metadata:
 spec:
   description: " Enterprise Platform Services - Google/AWS/Netflix Level"
 
+  # Nacht-Freeze 02-05 Uhr (Backup-Fenster, niemand wach): kein Auto-Sync/selfHeal,
+  # manueller Sync bleibt als Break-Glass erlaubt
+  syncWindows:
+    - kind: deny
+      schedule: '0 2 * * *'
+      duration: 3h
+      timeZone: Europe/Berlin
+      applications:
+        - '*'
+      manualSync: true
+
   # Platform layer — auf echte Namespaces gescoped (kein Wildcard)
   destinations:
     - namespace: drova

--- a/kubernetes/projects/security.yaml
+++ b/kubernetes/projects/security.yaml
@@ -11,6 +11,17 @@ metadata:
 spec:
   description: " Enterprise Security Foundation - Zero Trust Architecture"
 
+  # Nacht-Freeze 02-05 Uhr (Backup-Fenster, niemand wach): kein Auto-Sync/selfHeal,
+  # manueller Sync bleibt als Break-Glass erlaubt
+  syncWindows:
+    - kind: deny
+      schedule: '0 2 * * *'
+      duration: 3h
+      timeZone: Europe/Berlin
+      applications:
+        - '*'
+      manualSync: true
+
   # Security layer — security-foundation/compliance verteilen NetworkPolicies, Rate-Limits,
   # mTLS-Policies + Tetragon/Honeypot über viele Namespaces → alle Ziel-NS explizit gelistet.
   destinations:

--- a/kubernetes/projects/storage.yaml
+++ b/kubernetes/projects/storage.yaml
@@ -4,6 +4,16 @@ metadata:
   name: storage
   namespace: argocd
 spec:
+  # Nacht-Freeze 02-05 Uhr (Backup-Fenster, niemand wach): kein Auto-Sync/selfHeal,
+  # manueller Sync bleibt als Break-Glass erlaubt
+  syncWindows:
+    - kind: deny
+      schedule: '0 2 * * *'
+      duration: 3h
+      timeZone: Europe/Berlin
+      applications:
+        - '*'
+      manualSync: true
   sourceRepos:
     - 'https://github.com/Tim275/talos-homelab'
   destinations:


### PR DESCRIPTION
Sync-/Freeze-Windows für alle 5 AppProjects (infrastructure, platform, apps, security, storage): deny-Window täglich 02:00-05:00 Europe/Berlin.

Rationale: im Backup-Fenster rollt nichts automatisch aus (Auto-Sync/selfHeal pausiert, niemand wach zum Reagieren), \`manualSync: true\` = Break-Glass bleibt jederzeit möglich. Syntax gegen argo-cd sync_windows-Doku verifiziert + server-side dry-run gegen die Live-API (alle 6 AppProjects configured).

default-Project bewusst OHNE Window (Meta-Layer, trägt nur die Bootstrap-projects-App).