### PR TITLE
dedicated ml appproject

### DIFF
--- a/kubernetes/applicationsets/tenants/tenants-config.yaml
+++ b/kubernetes/applicationsets/tenants/tenants-config.yaml
@@ -24,11 +24,11 @@ spec:
                   environment: prod
           - list:
               elements:
-                - { component: drova,    appName: drova-config,    namespace: drova,    wave: "10" }
-                - { component: n8n-prod, appName: n8n-prod-config, namespace: n8n-prod, wave: "10" }
-                - { component: keycloak, appName: keycloak-config, namespace: keycloak, wave: "10" }
-                - { component: lldap,    appName: lldap-config,    namespace: lldap,    wave: "10" }
-                - { component: ml,       appName: ml-config,       namespace: ml,       wave: "10" }
+                - { component: drova,    appName: drova-config,    appProject: platform, namespace: drova,    wave: "10" }
+                - { component: n8n-prod, appName: n8n-prod-config, appProject: platform, namespace: n8n-prod, wave: "10" }
+                - { component: keycloak, appName: keycloak-config, appProject: platform, namespace: keycloak, wave: "10" }
+                - { component: lldap,    appName: lldap-config,    appProject: platform, namespace: lldap,    wave: "10" }
+                - { component: ml,       appName: ml-config,       appProject: ml,       namespace: ml,       wave: "10" }
   template:
     metadata:
       name: '{{.appName}}'
@@ -40,7 +40,7 @@ spec:
       annotations:
         argocd.argoproj.io/sync-wave: '{{.wave}}'
     spec:
-      project: platform
+      project: '{{.appProject}}'
       source:
         repoURL: https://github.com/Tim275/talos-homelab
         targetRevision: main

--- a/kubernetes/projects/kustomization.yaml
+++ b/kubernetes/projects/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - default.yaml
   - apps.yaml
   - infrastructure.yaml
+  - ml.yaml
   - platform.yaml
   - security.yaml
   - storage.yaml

--- a/kubernetes/projects/ml.yaml
+++ b/kubernetes/projects/ml.yaml
@@ -1,0 +1,57 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: ml
+  namespace: argocd
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    app.kubernetes.io/part-of: timour-homelab
+    app.kubernetes.io/layer: ml
+    team: timour
+spec:
+  description: "ML Department - Training, Serving, Experiment-Tracking"
+
+  # Nacht-Freeze 02-05 Uhr (Backup-Fenster, niemand wach): kein Auto-Sync/selfHeal,
+  # manueller Sync bleibt als Break-Glass erlaubt
+  syncWindows:
+    - kind: deny
+      schedule: '0 2 * * *'
+      duration: 3h
+      timeZone: Europe/Berlin
+      applications:
+        - '*'
+      manualSync: true
+
+  sourceRepos:
+    - 'https://github.com/Tim275/talos-homelab'
+
+  destinations:
+    - namespace: ml
+      server: https://kubernetes.default.svc
+
+  # Cluster-scoped: nur was der Tenant LIVE nutzt (Namespace via tenant-kustomization).
+  # Neues Kind -> Sync-Fehler "not permitted in project" -> hier nachtragen.
+  clusterResourceWhitelist:
+    - group: ''
+      kind: Namespace
+
+  namespaceResourceWhitelist:
+    - group: '*'
+      kind: '*'
+
+  roles:
+    - name: ml-admin
+      description: "Full access to ml workloads"
+      policies:
+        - p, proj:ml:ml-admin, applications, *, ml/*, allow
+        - p, proj:ml:ml-admin, exec, *, ml/*, allow
+      groups:
+        - timour:ml-admins
+
+    - name: ml-operator
+      description: "Operational access to ml workloads"
+      policies:
+        - p, proj:ml:ml-operator, applications, get, ml/*, allow
+        - p, proj:ml:ml-operator, applications, sync, ml/*, allow
+      groups:
+        - timour:ml-operators

--- a/kubernetes/projects/platform.yaml
+++ b/kubernetes/projects/platform.yaml
@@ -32,8 +32,6 @@ spec:
       server: https://kubernetes.default.svc
     - namespace: n8n-prod
       server: https://kubernetes.default.svc
-    - namespace: ml
-      server: https://kubernetes.default.svc
 
   # Platform can use platform layer resources
   sourceRepos:


### PR DESCRIPTION
Roadmap ②: eigenes AppProject \`ml\` fürs ML-Department statt Mitfahren unter \`platform\` — evidenzbasierte Whitelist (nur Namespace cluster-scoped), destinations nur ns ml, ml-admin/ml-operator-Rollen, Nacht-Freeze-Window konsistent zu #509.

tenants-config AppSet: \`appProject\` jetzt per Element (Muster wie storage-stack), ml-config wechselt auf project ml, die 4 anderen bleiben explizit auf platform. platform-Project: ml-destination wieder raus (evidence-based).

Server-side dry-run: appproject ml created; kustomize build projects/+applicationsets/ grün.