### PR TITLE
real department groups

### DIFF
--- a/kubernetes/platform/identity/lldap/base/bootstrap-config.yaml
+++ b/kubernetes/platform/identity/lldap/base/bootstrap-config.yaml
@@ -105,5 +105,9 @@ data:
       {"name": "developers"},
       {"name": "deployers"},
       {"name": "viewers"},
-      {"name": "drova-admins"}
+      {"name": "drova-admins"},
+      {"name": "platform-engineers"},
+      {"name": "sre-team"},
+      {"name": "security-team"},
+      {"name": "ml-engineers"}
     ]

--- a/kubernetes/projects/apps.yaml
+++ b/kubernetes/projects/apps.yaml
@@ -97,8 +97,7 @@ spec:
         - p, proj:apps:apps-admin, exec, *, apps/*, allow
         - p, proj:apps:apps-admin, logs, *, apps/*, allow
       groups:
-        - timour:apps-admins
-        - timour:developers
+        - developers
 
     - name: apps-operator
       description: "Apps monitoring and troubleshooting"
@@ -107,8 +106,7 @@ spec:
         - p, proj:apps:apps-operator, applications, sync, apps/*, allow
         - p, proj:apps:apps-operator, logs, get, apps/*, allow
       groups:
-        - timour:apps-operators
-        - timour:sre-team
+        - sre-team
 
     - name: apps-viewer
       description: "Read-only apps access"
@@ -116,8 +114,7 @@ spec:
         - p, proj:apps:apps-viewer, applications, get, apps/*, allow
         - p, proj:apps:apps-viewer, logs, get, apps/*, allow
       groups:
-        - timour:developers
-        - timour:apps-viewers
+        - viewers
 
   # ORPHANED RESOURCES: Enterprise cleanup policy
   orphanedResources:

--- a/kubernetes/projects/infrastructure.yaml
+++ b/kubernetes/projects/infrastructure.yaml
@@ -252,8 +252,7 @@ spec:
         - p, proj:infrastructure:infrastructure-admin, exec, *, infrastructure/*, allow
         - p, proj:infrastructure:infrastructure-admin, logs, *, infrastructure/*, allow
       groups:
-        - timour:infrastructure-admins
-        - timour:platform-engineers
+        - platform-engineers
 
     - name: infrastructure-operator
       description: "Infrastructure monitoring and troubleshooting"
@@ -262,8 +261,7 @@ spec:
         - p, proj:infrastructure:infrastructure-operator, applications, sync, infrastructure/*, allow
         - p, proj:infrastructure:infrastructure-operator, logs, get, infrastructure/*, allow
       groups:
-        - timour:infrastructure-operators
-        - timour:sre-team
+        - sre-team
 
     - name: infrastructure-viewer
       description: "Read-only infrastructure access"
@@ -271,8 +269,8 @@ spec:
         - p, proj:infrastructure:infrastructure-viewer, applications, get, infrastructure/*, allow
         - p, proj:infrastructure:infrastructure-viewer, logs, get, infrastructure/*, allow
       groups:
-        - timour:developers
-        - timour:infrastructure-viewers
+        - developers
+        - viewers
 
   orphanedResources:
     warn: false  # Disable warnings - resources managed via excludes

--- a/kubernetes/projects/ml.yaml
+++ b/kubernetes/projects/ml.yaml
@@ -46,7 +46,7 @@ spec:
         - p, proj:ml:ml-admin, applications, *, ml/*, allow
         - p, proj:ml:ml-admin, exec, *, ml/*, allow
       groups:
-        - timour:ml-admins
+        - ml-engineers
 
     - name: ml-operator
       description: "Operational access to ml workloads"
@@ -54,4 +54,4 @@ spec:
         - p, proj:ml:ml-operator, applications, get, ml/*, allow
         - p, proj:ml:ml-operator, applications, sync, ml/*, allow
       groups:
-        - timour:ml-operators
+        - sre-team

--- a/kubernetes/projects/platform.yaml
+++ b/kubernetes/projects/platform.yaml
@@ -72,7 +72,7 @@ spec:
         - p, proj:platform:platform-admin, applications, *, platform/*, allow
         - p, proj:platform:platform-admin, exec, *, platform/*, allow
       groups:
-        - timour:platform-admins
+        - platform-engineers
 
     - name: platform-operator
       description: "Operational access to platform services"
@@ -80,7 +80,7 @@ spec:
         - p, proj:platform:platform-operator, applications, get, platform/*, allow
         - p, proj:platform:platform-operator, applications, sync, platform/*, allow
       groups:
-        - timour:platform-operators
+        - sre-team
 
   # ORPHANED RESOURCES: Enterprise cleanup policy
   orphanedResources:

--- a/kubernetes/projects/security.yaml
+++ b/kubernetes/projects/security.yaml
@@ -84,7 +84,7 @@ spec:
         - p, proj:security:security-admin, applications, *, security/*, allow
         - p, proj:security:security-admin, exec, *, security/*, allow
       groups:
-        - timour:security-admins
+        - security-team
 
     - name: security-operator
       description: "Operational access to security policies"
@@ -92,7 +92,7 @@ spec:
         - p, proj:security:security-operator, applications, get, security/*, allow
         - p, proj:security:security-operator, applications, sync, security/*, allow
       groups:
-        - timour:security-operators
+        - sre-team
 
   # ORPHANED RESOURCES: Enterprise cleanup policy
   orphanedResources:


### PR DESCRIPTION
Roadmap ④: die \`timour:*\`-Platzhalter-Gruppen in den AppProject-Rollen waren TOT — sie existieren weder in LLDAP noch im Keycloak-groups-claim (bekanntes P2 "Taxonomie LLDAP↔ArgoCD inkonsistent").

Fix in zwei Teilen:
1. **LLDAP bootstrap (additiv):** 4 neue Department-Gruppen deklarativ — platform-engineers, sre-team, security-team, ml-engineers. Bootstrap-CronJob legt sie beim nächsten Lauf an; bestehende Gruppen/User unberührt.
2. **AppProject-Rollen → echte Gruppen:** admin-Rollen auf die Department-Gruppe (platform-engineers / security-team / ml-engineers / developers), operator-Rollen einheitlich auf sre-team, viewer-Rollen auf developers/viewers (existieren bereits).

Blast-Radius: null — tim275 ist cluster-admins → role:admin via policy.csv (unberührt); die ersetzten Gruppen matchten nie jemanden. Verify: kein timour:* mehr in projects/, groups.json valide, kustomize+server-dry-run grün.