### PR TITLE
mlflow phase 1

### DIFF
--- a/kubernetes/applicationsets/kustomization.yaml
+++ b/kubernetes/applicationsets/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - infrastructure/storage-stack.yaml          # 4 Apps (rook-ceph, rgw, csi-snapshot, velero) — velero-ui standalone
   - infrastructure/observability-stack.yaml    # 15 Apps (prom, loki, tempo, grafana, jaeger, ES, ...)
   - platform/identity-stack.yaml               # 3 Apps (keycloak-db, lldap, keycloak)
+  - platform/ml-stack.yaml                     # 1 App (mlflow) — ML-Platform, project ml
   - apps/apps-stack.yaml                       # 2 Apps (audiobookshelf, cloudbeaver)
   - security/security-stack.yaml               # 3 Apps (foundation, compliance, kyverno)
 

--- a/kubernetes/applicationsets/platform/ml-stack.yaml
+++ b/kubernetes/applicationsets/platform/ml-stack.yaml
@@ -1,0 +1,58 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: ml-stack
+  namespace: argocd
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    platform.homelab/layer: ml-platform
+    team: timour
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  # AppSet weg (z.B. PR-Zeile verloren) => Apps ueberleben als Orphans
+  # statt Kaskaden-Delete+prune aller Layer-Workloads.
+  syncPolicy:
+    preserveResourcesOnDeletion: true
+  generators:
+    - matrix:
+        generators:
+          - clusters:
+              selector:
+                matchLabels:
+                  argocd.argoproj.io/secret-type: cluster
+                  environment: prod
+          - list:
+              elements:
+                - { component: mlflow, appName: mlflow, namespace: ml, wave: "20" }
+  template:
+    metadata:
+      name: '{{.appName}}'
+      labels:
+        app.kubernetes.io/managed-by: argocd
+        platform.homelab/layer: ml-platform
+        platform.homelab/component: '{{.component}}'
+        team: timour
+      annotations:
+        argocd.argoproj.io/sync-wave: '{{.wave}}'
+    spec:
+      project: ml
+      source:
+        repoURL: https://github.com/Tim275/talos-homelab
+        targetRevision: main
+        path: 'kubernetes/platform/ml/{{.component}}/overlays/prod'
+      destination:
+        server: '{{.server}}'
+        namespace: '{{.namespace}}'
+      syncPolicy:
+        # manual sync = DAX-Gate (Workload-Layer, wie Tenants)
+        syncOptions:
+          - CreateNamespace=true
+          - PrunePropagationPolicy=foreground
+          - PruneLast=true
+          - RespectIgnoreDifferences=true
+          - ServerSideApply=true
+          - ApplyOutOfSyncOnly=true
+        retry:
+          limit: 5
+          backoff: { duration: 5s, factor: 2, maxDuration: 3m }

--- a/kubernetes/platform/ml/README.md
+++ b/kubernetes/platform/ml/README.md
@@ -1,8 +1,7 @@
-# ML Platform — GEPARKT (wartet auf Hardware)
+# ML Platform
 
-**Status: Platzhalter, deployt NICHTS.** Dieser Ordner ist von keiner kustomization und
-keinem AppSet referenziert — er dokumentiert nur, wo die ML-Platform-Tools hinkommen,
-sobald neue Hardware (GPU-Node) da ist.
+**Status: Phase 1 LIVE (MLflow).** Deployed über die `ml-stack` AppSet (project `ml`,
+manual-sync/DAX-Gate). GPU-gebundene Tools (Training-Workloads) warten weiter auf Hardware.
 
 ## Das Zwei-Hälften-Muster
 
@@ -17,9 +16,11 @@ Analog zum Rest des Repos: Strimzi-Operator (`infrastructure/operators/strimzi/`
 ## Geplanter Stack (CPU-first, siehe notes/CLAUDE-MLOPS.md)
 
 ```
-platform/ml/mlflow/                      → Experiment-Tracking (zentraler Server)
-infrastructure/operators/kserve/         → Model-Serving-Operator
-infrastructure/operators/argo-workflows/ → Pipeline-Engine
+platform/ml/mlflow/                      → ✅ LIVE: Tracking+Registry, sqlite auf Ceph-PVC,
+                                           Artefakte → Ceph-RGW S3 (OBC mlflow-artifacts),
+                                           https://mlflow.timourhomelab.org (VPN-only)
+infrastructure/operators/kserve/         → ⏸️ kommt mit dem ERSTEN Modell (keine leere Hülle)
+infrastructure/operators/argo-workflows/ → ⏸️ kommt mit der ERSTEN Pipeline
 ```
 
 **Bewusst KEIN Full-Kubeflow:** 10+ Komponenten, RAM-Fresser, eigener Istio-Zwang —

--- a/kubernetes/platform/ml/mlflow/base/deployment.yaml
+++ b/kubernetes/platform/ml/mlflow/base/deployment.yaml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mlflow
+  namespace: ml
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mlflow
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mlflow
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: mlflow
+          image: burakince/mlflow:3.14.0
+          command:
+            - mlflow
+            - server
+            - --host=0.0.0.0
+            - --port=5000
+            - --backend-store-uri=sqlite:////data/mlflow.db
+            - --artifacts-destination=s3://$(BUCKET_NAME)
+            - --serve-artifacts
+          env:
+            - name: BUCKET_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: mlflow-artifacts
+                  key: BUCKET_HOST
+            - name: BUCKET_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: mlflow-artifacts
+                  key: BUCKET_PORT
+            - name: BUCKET_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: mlflow-artifacts
+                  key: BUCKET_NAME
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: mlflow-artifacts
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mlflow-artifacts
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: MLFLOW_S3_ENDPOINT_URL
+              value: 'http://$(BUCKET_HOST):$(BUCKET_PORT)'
+          ports:
+            - name: http
+              containerPort: 5000
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: backend
+              mountPath: /data
+      volumes:
+        - name: backend
+          persistentVolumeClaim:
+            claimName: mlflow-backend

--- a/kubernetes/platform/ml/mlflow/base/httproute.yaml
+++ b/kubernetes/platform/ml/mlflow/base/httproute.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mlflow
+  namespace: ml
+spec:
+  parentRefs:
+    - name: envoy-gateway
+      namespace: gateway
+      sectionName: https
+  hostnames:
+    - mlflow.timourhomelab.org
+  rules:
+    - backendRefs:
+        - name: mlflow
+          port: 5000

--- a/kubernetes/platform/ml/mlflow/base/kustomization.yaml
+++ b/kubernetes/platform/ml/mlflow/base/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ml
+
+resources:
+  - obc.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml
+
+labels:
+  - pairs:
+      app.kubernetes.io/managed-by: argocd
+      platform.homelab/component: mlflow

--- a/kubernetes/platform/ml/mlflow/base/obc.yaml
+++ b/kubernetes/platform/ml/mlflow/base/obc.yaml
@@ -1,0 +1,10 @@
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: mlflow-artifacts
+  namespace: ml
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  bucketName: mlflow-artifacts
+  storageClassName: rook-ceph-bucket

--- a/kubernetes/platform/ml/mlflow/base/pvc.yaml
+++ b/kubernetes/platform/ml/mlflow/base/pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mlflow-backend
+  namespace: ml
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: rook-ceph-block-enterprise-retain
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/platform/ml/mlflow/base/service.yaml
+++ b/kubernetes/platform/ml/mlflow/base/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mlflow
+  namespace: ml
+spec:
+  selector:
+    app.kubernetes.io/name: mlflow
+  ports:
+    - name: http
+      port: 5000
+      targetPort: http

--- a/kubernetes/platform/ml/mlflow/overlays/prod/kustomization.yaml
+++ b/kubernetes/platform/ml/mlflow/overlays/prod/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base


### PR DESCRIPTION
MLOps Phase 1 nach notes/CLAUDE-MLOPS.md (CPU-first, minimaler Footprint): MLflow Tracking+Registry in ns \`ml\`.

- Backend: sqlite auf Ceph-PVC 5Gi (retain-SC — Experiment-Historie ist wertvoll)
- Artefakte: Ceph-RGW S3 via ObjectBucketClaim \`mlflow-artifacts\` (rook-ceph-bucket, kein MinIO) — Creds/Endpoint aus OBC-Secret/ConfigMap, kein manuelles Secret
- Image burakince/mlflow:3.14.0 (offizielle MLflow + boto3, Tag hub-verifiziert), non-root + drop-ALL + seccomp (server-dry-run durch Kyverno-Admission bestanden)
- HTTPRoute mlflow.timourhomelab.org (VPN-only via external-dns/.152-Pattern)
- Neue AppSet \`ml-stack\` (project ml, manual-sync/DAX-Gate, preserveResourcesOnDeletion, wave 20)
- KServe/Argo-Workflows bewusst NICHT (kommen mit erstem Modell/erster Pipeline — keine leeren Hüllen), README aktualisiert

Requests 100m/512Mi, Limits 1CPU/1Gi — passt in die ml-Quota (8/16Gi). Deploy nach Merge: \`argocd app sync mlflow\`.