### PR TITLE
tim275 department memberships

### DIFF
--- a/kubernetes/platform/identity/lldap/base/bootstrap-config.yaml
+++ b/kubernetes/platform/identity/lldap/base/bootstrap-config.yaml
@@ -61,7 +61,7 @@ data:
         "lastName": "Miagol",
         "displayName": "Timour Miagol - Cluster Admin",
         "password": "${LLDAP_USER_PASSWORD}",
-        "groups": ["cluster-admins", "lldap_admin"]
+        "groups": ["cluster-admins", "lldap_admin", "platform-engineers", "sre-team", "security-team", "ml-engineers"]
       },
       {
         "id": "anna",


### PR DESCRIPTION
Follow-up zu #511: tim275 deklarativ in die 4 Department-Gruppen (platform-engineers, sre-team, security-team, ml-engineers) — als Solo-Operator trägt er faktisch alle Hüte, jetzt steht es auch im IdP. Bootstrap-Job ist idempotent und added Memberships auch für bestehende User (verifiziert im Job-Script: addUserToGroup läuft nach "Exists"). Kein Passwort-/Rechte-Change — cluster-admins→role:admin bleibt der wirksame Global-Admin-Pfad.