### PR TITLE
fix mlflow pvc sync wave

### DIFF
--- a/kubernetes/platform/ml/mlflow/base/pvc.yaml
+++ b/kubernetes/platform/ml/mlflow/base/pvc.yaml
@@ -4,7 +4,10 @@ metadata:
   name: mlflow-backend
   namespace: ml
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    # gleiche Wave wie das Deployment: die SC ist WaitForFirstConsumer — PVC bindet
+    # erst wenn der Pod sie nutzt; fruehere Wave = Sync-Deadlock (PVC wartet auf Pod,
+    # ArgoCD wartet auf PVC)
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
PVC-SC rook-ceph-block-enterprise-retain ist WaitForFirstConsumer — PVC in Wave 1 vor dem Deployment (Wave 2) deadlockt den Sync (PVC wartet auf Pod, ArgoCD wartet auf PVC-Health). Fix: PVC in dieselbe Wave wie das Deployment, Kommentar als Erinnerung.