### PR TITLE
fix mlflow oom

### DIFF
--- a/kubernetes/platform/ml/mlflow/base/deployment.yaml
+++ b/kubernetes/platform/ml/mlflow/base/deployment.yaml
@@ -35,6 +35,8 @@ spec:
             - --backend-store-uri=sqlite:////data/mlflow.db
             - --artifacts-destination=s3://$(BUCKET_NAME)
             - --serve-artifacts
+            # solo-Betrieb: default 4 gunicorn-Worker sprengen das Memory-Limit (OOM)
+            - --workers=1
           env:
             - name: BUCKET_HOST
               valueFrom:
@@ -84,7 +86,7 @@ spec:
               memory: 512Mi
             limits:
               cpu: "1"
-              memory: 1Gi
+              memory: 2Gi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
mlflow server startet default 4 gunicorn-Worker (je ~300-400MB Imports) → OOMKilled-Loop bei 1Gi-Limit. Fix: --workers=1 (Solo-Betrieb) + Limit auf 2Gi Headroom.