### PR TITLE
fix: enforce drova signatures

### DIFF
--- a/kubernetes/security/compliance/kyverno-policies.yaml
+++ b/kubernetes/security/compliance/kyverno-policies.yaml
@@ -89,7 +89,12 @@ kind: ClusterPolicy
 metadata:
   name: audit-verify-drova-signatures
 spec:
-  failurePolicy: Ignore
+  # ENFORCE seit 2026-07-21: Signatur-Gate ist scharf (Name behalten für
+  # Report-Kontinuität; Umbenennung = kosmetisches Follow-up).
+  # failurePolicy Fail = fail-closed: Webhook-Ausfall darf kein stiller
+  # Bypass sein, sonst ist das Gate dekorativ. Scope: NUR ns drova,
+  # NUR ghcr.io/tim275/drova/* — Platform-Images unberührt.
+  failurePolicy: Fail
   webhookTimeoutSeconds: 30
   background: false
   rules:
@@ -102,7 +107,7 @@ spec:
       verifyImages:
         - imageReferences:
             - "ghcr.io/tim275/drova/*"
-          failureAction: Audit
+          failureAction: Enforce
           mutateDigest: false
           verifyDigest: false
           required: true


### PR DESCRIPTION
## Supply-Chain-Gate scharf schalten
`audit-verify-drova-signatures`: **Audit → Enforce** + **failurePolicy Ignore → Fail** (fail-closed — ein Webhook-Ausfall darf kein stiller Bypass sein).

## Voraussetzungen — alle erfüllt
1. ✅ Kyverno läuft mit `--enableTuf=true` (Sigstore-Trust-Root, seit 2026-07-15)
2. ✅ drova#289 gemergt: cosign auf **v2.6.0 gepinnt** (legacy `.sig`-Format, das Kyverno 1.15 verifiziert) + **Nachsignier-Step** für Bestands-Digests
3. ✅ v0.22.14 gebaut + deployt: alle 8 Service-Digests tragen legacy-Signaturen
4. ⏳ **Merge-Gate: PolicyReports müssen für die v0.22.14-Pods PASS zeigen** (wird vor dem Merge verifiziert)

## Wirkung
- Neue Pods in **ns drova** mit `ghcr.io/tim275/drova/*`-Images werden nur admittiert, wenn keyless-Signatur (GitHub-OIDC, `docker-build-push.yaml`) via Rekor verifiziert
- Laufende Pods unberührt (admission-only, `background: false`)
- Platform-Images (Kafka, Postgres, Redis, …) unberührt — Policy matcht nur das Drova-Prefix

## Bewusste Trade-offs
- **Fail-closed:** Rekor/Fulcio-Ausfall oder fehlender Egress ⇒ keine NEUEN drova-Pods bis behoben (laufende bleiben). Das ist der Sinn eines Supply-Chain-Gates.
- **Rollback auf alte Versionen:** Digests, die sich seit dem cosign-3-Bump geändert haben und nie legacy nachsigniert wurden, würden geblockt. Unveränderte (re-tagged) Digests wurden vom Nachsignier-Step geheilt.
- Name `audit-…` bleibt vorerst (Report-Kontinuität); Umbenennung = kosmetisches Follow-up.