### PR TITLE
enable drova waypoint

### DIFF
--- a/kubernetes/tenants/drova/kustomization.yaml
+++ b/kubernetes/tenants/drova/kustomization.yaml
@@ -8,7 +8,10 @@ resources:
 - limitrange.yaml
 - rbac.yaml
 - atlas-allowlist-sync.yaml
-# - waypoint.yaml  # geparkt 2026-07-10: drova unmeshed, waypoint erst mit Ambient-Re-Enroll (siehe Istio-Guide)
+- waypoint.yaml
+# waypoint aktiviert 2026-07-21 (drova ist ambient-re-meshed seit 10.07):
+# L7-Layer der Ambient-Architektur, Enforcement-Beweis im Wegwerf-NS erbracht
+# (GET 200 / POST 403 / Probes stabil — kubelet-Probes laufen NICHT durch den Waypoint)
 
 labels:
 - pairs:

--- a/kubernetes/tenants/drova/namespace.yaml
+++ b/kubernetes/tenants/drova/namespace.yaml
@@ -4,5 +4,6 @@ metadata:
   name: drova
   labels:
     istio.io/dataplane-mode: ambient
+    istio.io/use-waypoint: waypoint
   annotations:
     argocd.argoproj.io/sync-wave: "-1"


### PR DESCRIPTION
Istio-Ambient Phase ⑤: Waypoint (L7-Layer) für drova aktiviert — waypoint.yaml entparkt (der Park-Kommentar "drova unmeshed" war stale, drova ist seit 10.07 re-meshed PERMISSIVE) + \`istio.io/use-waypoint\`-Label an der Namespace.

Beweis vorab im Wegwerf-NS erbracht (waypoint-test): Traffic läuft durch den Waypoint, L7-AuthorizationPolicy enforced (GET 200 / POST 403), Probes bleiben 1/1 stabil — der STRICT-Blocker (ztunnel-Probe-Source-Rewrite) greift beim Waypoint-Pfad NICht, weil kubelet-Probes direkt zum Pod gehen.

Bewusst NOCH KEINE AuthorizationPolicy auf drova (ALLOW-Policy = implizites default-deny für alles Ungematchte — erst Waypoint-L7-Telemetrie beobachten, dann gezielte Policy). Waypoint = 1 Replica (bekannter SPOF, HA-Skalierung Follow-up).

Rollback: \`kubectl label ns drova istio.io/use-waypoint-\` (Sekunden, manual-sync-App healt nicht zurück).