### PR TITLE
waypoint ha

### DIFF
--- a/kubernetes/tenants/drova/kustomization.yaml
+++ b/kubernetes/tenants/drova/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - rbac.yaml
 - atlas-allowlist-sync.yaml
 - waypoint.yaml
+- waypoint-ha.yaml
 # waypoint aktiviert 2026-07-21 (drova ist ambient-re-meshed seit 10.07):
 # L7-Layer der Ambient-Architektur, Enforcement-Beweis im Wegwerf-NS erbracht
 # (GET 200 / POST 403 / Probes stabil — kubelet-Probes laufen NICHT durch den Waypoint)

--- a/kubernetes/tenants/drova/waypoint-ha.yaml
+++ b/kubernetes/tenants/drova/waypoint-ha.yaml
@@ -1,0 +1,30 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: waypoint
+  namespace: drova
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: waypoint
+  minReplicas: 2
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: waypoint
+  namespace: drova
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      gateway.networking.k8s.io/gateway-name: waypoint


### PR DESCRIPTION
Waypoint war 1 Replica = SPOF für drova-Mesh-Traffic (Kafka/PG laufen durch). Fix: HPA min 2/max 3 (cpu 80%) + PDB minAvailable 1 — istiod kämpft nicht um replicas, HPA-Pattern ist der dokumentierte Weg für Waypoint-Skalierung.