### PR TITLE
fix critical-infra soak for helm charts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -268,7 +268,7 @@
     },
 
     {
-      "description": "Extra soak: critical-infrastructure (21d for minor/major). 2026-05-16 disaster: Strimzi 0.51 auto-merged after 14d soak, broke Kafka prod — NEVER auto-merge critical-infra.",
+      "description": "Extra soak: critical-infrastructure (21d for minor/major). 2026-05-16 disaster: Strimzi 0.51 auto-merged after 14d soak, broke Kafka prod — NEVER auto-merge critical-infra. Bare names = helm charts (matchen sonst nicht, Gap gefunden 2026-07-21: cilium-helm-PRs liefen ohne critical-Label).",
       "matchPackageNames": [
         "/cilium/cilium/",
         "/cert-manager/cert-manager/",
@@ -278,7 +278,15 @@
         "/kyverno/kyverno/",
         "/keycloak/keycloak/",
         "/strimzi/strimzi-kafka-operator/",
-        "/rook/rook/"
+        "/rook/rook/",
+        "/^cilium$/",
+        "/^cert-manager$/",
+        "/^cloudnative-pg$/",
+        "/^argo-cd$/",
+        "/^kyverno$/",
+        "/^strimzi-kafka-operator$/",
+        "/^rook-ceph$/",
+        "/^gateway-helm$/"
       ],
       "matchUpdateTypes": ["patch", "minor", "major"],
       "minimumReleaseAge": "21 days",


### PR DESCRIPTION
Gap gefunden: die 21d-critical-infrastructure-Soak-Regel matchte nur Docker-Pfad-Patterns (/cilium\/cilium/) — Helm-Releases heißen aber bare (cilium, cert-manager, rook-ceph...) und liefen daher OHNE critical-Label + 21d-Soak durch (Beweis: #486 cilium-helm hat nur patch-Label). Fix: bare Helm-Namen als exakte Anker-Patterns ergänzt, + gateway-helm neu drin (Envoy-Gateway-Controller = WAF-WASM-Churn-Risiko).