### PR TITLE
waypoint authz baseline

### DIFF
--- a/kubernetes/tenants/drova/kustomization.yaml
+++ b/kubernetes/tenants/drova/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - atlas-allowlist-sync.yaml
 - waypoint.yaml
 - waypoint-ha.yaml
+- waypoint-authz.yaml
 # waypoint aktiviert 2026-07-21 (drova ist ambient-re-meshed seit 10.07):
 # L7-Layer der Ambient-Architektur, Enforcement-Beweis im Wegwerf-NS erbracht
 # (GET 200 / POST 403 / Probes stabil — kubelet-Probes laufen NICHT durch den Waypoint)

--- a/kubernetes/tenants/drova/waypoint-authz.yaml
+++ b/kubernetes/tenants/drova/waypoint-authz.yaml
@@ -1,0 +1,15 @@
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: waypoint-allow-known
+  namespace: drova
+spec:
+  targetRefs:
+    - kind: Gateway
+      group: gateway.networking.k8s.io
+      name: waypoint
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            namespaces: ["drova", "gateway"]


### PR DESCRIPTION
Erste L7-AuthorizationPolicy auf dem drova-Waypoint, evidence-based: ztunnel-Identitäten-Inventur ergab nur drova/gateway als gemeshte Quellen → ALLOW genau dieser beiden Namespaces. Heute null Verhaltensänderung (Beweis: 200s, Kafka 3/3, 0 RBAC-Denies nach Live-Test), aber echtes Guardrail: jede KÜNFTIG gemeshte Namespace ist am drova-Waypoint default-DENIED bis explizit erlaubt. Live bereits applied (identisches Manifest, manual-sync-App = kein Drift-Konflikt).