### PR TITLE
kafka single broker prep

### DIFF
--- a/kubernetes/tenants/drova/kafka/base/kafka-cluster.yaml
+++ b/kubernetes/tenants/drova/kafka/base/kafka-cluster.yaml
@@ -36,14 +36,14 @@ spec:
         kraftMetadata: shared
   resources:
     requests:
-      memory: "1Gi"
+      memory: "512Mi"  # prod: 1Gi
       cpu: "100m"
     limits:
-      memory: "1500Mi"
+      memory: "1Gi"  # prod: 1500Mi
       cpu: "1000m"
   jvmOptions:
-    "-Xms": "512m"
-    "-Xmx": "768m"
+    "-Xms": "256m"  # prod: 512m
+    "-Xmx": "384m"  # prod: 768m
   template:
     pod:
       priorityClassName: platform-critical
@@ -178,11 +178,11 @@ spec:
     authorization:
       type: simple
     config:
-      offsets.topic.replication.factor: 3
-      transaction.state.log.replication.factor: 3
-      transaction.state.log.min.isr: 2
-      default.replication.factor: 3
-      min.insync.replicas: 2
+      offsets.topic.replication.factor: 1  # prod: 3
+      transaction.state.log.replication.factor: 1  # prod: 3
+      transaction.state.log.min.isr: 1  # prod: 2
+      default.replication.factor: 1  # prod: 3
+      min.insync.replicas: 1  # prod: 2
       auto.create.topics.enable: "false"
       # KRaft quorum tuning — CRITICAL: election.timeout is when leader-less
       # controllers START an election. Setting it too high (e.g. 600000=10min)


### PR DESCRIPTION
Schritt 1/2 der Kafka-RAM-Diät (Entscheid: Funktion vor HA): RF-Defaults + minISR auf 1, Prod-Werte als Kommentar-Marker dokumentiert. MUSS vor dem Partition-Reassignment auf RF1 passieren — sonst brechen acks=all-Producer an min.insync.replicas=2.

Controller bleiben unangetastet (3×, Ressourcen original — 3→1 ist mit Strimzi 0.51 nicht möglich: statisches Quorum, dynamische Quorums unsupported, strimzi#9429; Roadmap-Punkt).

Danach separater PR: Reassignment aller Partitionen auf Broker 0 + Broker-Pool 3→1 (~2,4GB real). Strimzi rollt für diesen Config-PR die Broker einzeln, HA intakt.