### PR TITLE
kafka single broker

### DIFF
--- a/kubernetes/tenants/drova/kafka/base/kafka-cluster.yaml
+++ b/kubernetes/tenants/drova/kafka/base/kafka-cluster.yaml
@@ -81,7 +81,7 @@ metadata:
     strimzi.io/cluster: drova-kafka
     platform.homelab/tenant: drova
 spec:
-  replicas: 3
+  replicas: 1  # prod: 3
   roles:
     - broker
   storage:

--- a/kubernetes/tenants/drova/kafka/base/kafka-topics.yaml
+++ b/kubernetes/tenants/drova/kafka/base/kafka-topics.yaml
@@ -7,7 +7,7 @@ metadata:
     strimzi.io/cluster: drova-kafka
 spec:
   partitions: 6
-  replicas: 3
+  replicas: 1  # prod: 3
   config:
     retention.ms: "2592000000"
 ---
@@ -20,7 +20,7 @@ metadata:
     strimzi.io/cluster: drova-kafka
 spec:
   partitions: 6
-  replicas: 3
+  replicas: 1  # prod: 3
   config:
     retention.ms: "2592000000"
 ---
@@ -33,7 +33,7 @@ metadata:
     strimzi.io/cluster: drova-kafka
 spec:
   partitions: 6
-  replicas: 3
+  replicas: 1  # prod: 3
   config:
     retention.ms: "2592000000"
 ---
@@ -46,7 +46,7 @@ metadata:
     strimzi.io/cluster: drova-kafka
 spec:
   partitions: 6
-  replicas: 3
+  replicas: 1  # prod: 3
   config:
     retention.ms: "2592000000"
 ---
@@ -59,7 +59,7 @@ metadata:
     strimzi.io/cluster: drova-kafka
 spec:
   partitions: 3
-  replicas: 3
+  replicas: 1  # prod: 3
   config:
     retention.ms: "2592000000"
 ---
@@ -72,7 +72,7 @@ metadata:
     strimzi.io/cluster: drova-kafka
 spec:
   partitions: 3
-  replicas: 3
+  replicas: 1  # prod: 3
   config:
     retention.ms: "604800000"
 ---
@@ -85,7 +85,7 @@ metadata:
     strimzi.io/cluster: drova-kafka
 spec:
   partitions: 3
-  replicas: 3
+  replicas: 1  # prod: 3
   config:
     retention.ms: "604800000"
 ---
@@ -98,7 +98,7 @@ metadata:
     strimzi.io/cluster: drova-kafka
 spec:
   partitions: 3
-  replicas: 3
+  replicas: 1  # prod: 3
   config:
     retention.ms: "2592000000"
 ---
@@ -111,7 +111,7 @@ metadata:
     strimzi.io/cluster: drova-kafka
 spec:
   partitions: 3
-  replicas: 3
+  replicas: 1  # prod: 3
   config:
     retention.ms: "2592000000"
 ---
@@ -124,7 +124,7 @@ metadata:
     strimzi.io/cluster: drova-kafka
 spec:
   partitions: 3
-  replicas: 3
+  replicas: 1  # prod: 3
   config:
     retention.ms: "2592000000"
 ---
@@ -137,7 +137,7 @@ metadata:
     strimzi.io/cluster: drova-kafka
 spec:
   partitions: 3
-  replicas: 3
+  replicas: 1  # prod: 3
   config:
     retention.ms: "2592000000"
 ---
@@ -150,7 +150,7 @@ metadata:
     strimzi.io/cluster: drova-kafka
 spec:
   partitions: 3
-  replicas: 3
+  replicas: 1  # prod: 3
   config:
     retention.ms: "2592000000"
 ---
@@ -163,7 +163,7 @@ metadata:
     strimzi.io/cluster: drova-kafka
 spec:
   partitions: 6
-  replicas: 3
+  replicas: 1  # prod: 3
   config:
     retention.ms: "2592000000"
 ---
@@ -176,6 +176,6 @@ metadata:
     strimzi.io/cluster: drova-kafka
 spec:
   partitions: 6
-  replicas: 3
+  replicas: 1  # prod: 3
   config:
     retention.ms: "2592000000"


### PR DESCRIPTION
Schritt 2/2 der Kafka-RAM-Diät: Broker-Pool 3→1 + alle 14 KafkaTopic-CRs auf replicas 1 (Prod-Werte als Marker).

Vorarbeit erledigt & verifiziert: 36 MM2-Müll-Topics gelöscht (rekursive primary.*-heartbeats-Kaskade der alten same-cluster-Demo!), danach Reassignment ALLER 128 Partitionen auf Broker 0 mit RF1 — Vollbeweis: 128/128 Replicas=[0]. Strimzis Scale-Down-Check findet Broker 1+2 leer → entfernt sie sauber.

Erwartung: −~2,4GB real + 4Gi reserviert (zusätzlich zur Controller-Diät aus #522, live verifiziert 361-382Mi statt ~640Mi). PVCs der entfernten Broker bleiben (deleteClaim=false) → separater Cleanup.