### PR TITLE
blackbox probe all public services

### DIFF
--- a/kubernetes/infrastructure/observability/blackbox-exporter/base/probes.yaml
+++ b/kubernetes/infrastructure/observability/blackbox-exporter/base/probes.yaml
@@ -51,16 +51,28 @@ metadata:
     release: kube-prometheus-stack
 spec:
   jobName: blackbox-homelab
-  module: http_2xx
+  module: http_reachable
   prober:
     url: blackbox-exporter-prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
   targets:
     staticConfig:
       static:
-        - https://argocd.timourhomelab.org
-        - https://grafana.timourhomelab.org
+        - https://argo.timourhomelab.org
+        - https://audiobookshelf.timourhomelab.org
+        - https://ceph.timourhomelab.org
         - https://drova.timourhomelab.org
+        - https://grafana.timourhomelab.org
+        - https://hubble.timourhomelab.org
         - https://iam.timourhomelab.org
+        - https://jaeger.timourhomelab.org
+        - https://kiali.timourhomelab.org
+        - https://kibana.timourhomelab.org
+        - https://lldap.timourhomelab.org
+        - https://mlflow.timourhomelab.org
+        - https://n8n.timourhomelab.org
+        - https://redpanda.timourhomelab.org
+        - https://renovate.timourhomelab.org
+        - https://status.timourhomelab.org
       labels:
         env: prod
         type: public

--- a/kubernetes/infrastructure/observability/blackbox-exporter/base/values.yaml
+++ b/kubernetes/infrastructure/observability/blackbox-exporter/base/values.yaml
@@ -21,6 +21,19 @@ config:
         fail_if_ssl: false
         fail_if_not_ssl: false
         preferred_ip_protocol: "ip4"
+    # "hat geantwortet = UP" — auth-gated (401/403) + login-redirects (302) zaehlen als up,
+    # nur refused/timeout/5xx = down. Fuer heterogene interne Services ohne False-Downs.
+    http_reachable:
+      prober: http
+      timeout: 5s
+      http:
+        valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+        valid_status_codes: [200, 201, 202, 204, 301, 302, 303, 307, 308, 401, 403, 405]
+        method: GET
+        no_follow_redirects: true
+        fail_if_ssl: false
+        fail_if_not_ssl: false
+        preferred_ip_protocol: "ip4"
     http_post_2xx:
       prober: http
       timeout: 5s

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/observability/blackbox-exporter.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/community-dashboards/observability/blackbox-exporter.yaml
@@ -1,0 +1,17 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: blackbox-exporter
+  namespace: grafana
+spec:
+  uid: blackbox-exporter
+  instanceSelector:
+    matchLabels:
+      app: grafana
+  allowCrossNamespaceImport: true
+  folder: "Observability"
+  resyncPeriod: 5m
+  datasources:
+    - inputName: "DS_PROMETHEUS"
+      datasourceName: "prometheus"
+  url: "https://grafana.com/api/dashboards/7587/revisions/3/download"

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/kustomization.yaml
@@ -55,10 +55,11 @@ resources:
   - community-dashboards/data/redis-operator.yaml
   - community-dashboards/data/elasticsearch.yaml
 
-  # Observability self (3)
+  # Observability self (4)
   - community-dashboards/observability/prometheus.yaml
   - community-dashboards/observability/loki-stack.yaml
   - community-dashboards/observability/otel-collector.yaml
+  - community-dashboards/observability/blackbox-exporter.yaml
 
   # GitOps (1)
   - community-dashboards/gitops/argocd-overview.yaml

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/infrastructure/external.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/infrastructure/external.yaml
@@ -42,3 +42,18 @@ spec:
             dashboard_url: "/d/proxmox-cluster"
             summary: "External TLS cert expires <14d: {{ $labels.target }}"
             action: "Check the cert for {{ $labels.target }}; cert-manager (internal) or the external CA; <14d to expiry."
+
+    - name: homelab-services
+      interval: 1m
+      rules:
+        - alert: HomelabPublicServiceDown
+          expr: probe_success{job="blackbox-homelab"} == 0
+          for: 5m
+          labels:
+            severity: warning
+            component: ingress
+          annotations:
+            dashboard_url: "/d/blackbox-exporter"
+            summary: "Homelab service unreachable: {{ $labels.target }}"
+            description: "Blackbox probe to {{ $labels.target }} returned no valid HTTP response for >5min (refused/timeout/5xx)."
+            action: "curl --resolve HOST:443:192.168.0.152 https://HOST/ ; check app pod + HTTPRoute + Envoy filter-chain."


### PR DESCRIPTION
Enterprise-IaC-Monitoring: die homelab-public-services Probe-CRD von 4 auf ALLE 16 exposten HTTPRoute-Hostnames erweitert — "alles im Cluster überwachen" als Code, nicht Click-Ops.

- Neues Blackbox-Modul http_reachable (valid_status_codes inkl. 302/401/403, no_follow_redirects): "hat geantwortet = UP". Verhindert False-Downs bei auth-gated (jaeger/kiali/redpanda/renovate=401, mlflow=403) + redirect-Endpoints (grafana/kibana/iam/hubble/status=302). Ground-truth-gemessen aus dem blackbox-Pod.
- BUGFIX: Probe-Target war argocd.timourhomelab.org, HTTPRoute ist aber argo. → tote Messung, jetzt korrekt.
- Neuer Alert HomelabPublicServiceDown (probe_success{job=blackbox-homelab}==0, 5m, warning). SSL-Ablauf deckt TLSCertificateExpiringSoonExternal schon ab (job=~blackbox-.*).
- Grafana-Dashboard "Blackbox Exporter" (7587) als GrafanaDashboard-CR, Folder Observability.

Verifiziert: kustomize+helm baut, 16 distinct Targets, release-label da, Alert-Syntax ok.