### PR TITLE
fix: user-service smtp egress

### DIFF
--- a/kubernetes/security/foundation/network-policies/tenants/drova/user-service-smtp-egress.yaml
+++ b/kubernetes/security/foundation/network-policies/tenants/drova/user-service-smtp-egress.yaml
@@ -1,0 +1,20 @@
+---
+# user-service verschickt Aktivierungs-Mails via Gmail SMTP (smtp.gmail.com:587,
+# app-config SMTP_HOST/PORT). Ohne diese FQDN-Allow läuft der SMTP-Connect in
+# den default-deny → Registrierungsmails kommen nie an (erster echter Signup
+# 2026-07-21 deckte es auf). DNS-Auflösung deckt die Baseline (matchPattern "*").
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: user-service-smtp-egress
+  namespace: drova
+spec:
+  endpointSelector:
+    matchLabels:
+      app: user-service
+  egress:
+    - toFQDNs:
+        - matchName: smtp.gmail.com
+      toPorts:
+        - ports:
+            - { port: "587", protocol: TCP }


### PR DESCRIPTION
Aktivierungsmails kamen nie an: default-deny + keine SMTP-Regel. Neue schmale CNP nur für user-service → smtp.gmail.com:587. Aufgedeckt durch den ersten echten Signup (21.07).