### PR TITLE
fix: brevo egress

### DIFF
--- a/kubernetes/security/foundation/network-policies/tenants/drova/user-service-smtp-egress.yaml
+++ b/kubernetes/security/foundation/network-policies/tenants/drova/user-service-smtp-egress.yaml
@@ -1,5 +1,5 @@
 ---
-# user-service verschickt Aktivierungs-Mails via Gmail SMTP (smtp.gmail.com:587,
+# user-service verschickt Aktivierungs-Mails via Gmail SMTP (smtp-relay.brevo.com:587,
 # app-config SMTP_HOST/PORT). Ohne diese FQDN-Allow läuft der SMTP-Connect in
 # den default-deny → Registrierungsmails kommen nie an (erster echter Signup
 # 2026-07-21 deckte es auf). DNS-Auflösung deckt die Baseline (matchPattern "*").
@@ -14,7 +14,7 @@ spec:
       app: user-service
   egress:
     - toFQDNs:
-        - matchName: smtp.gmail.com
+        - matchName: smtp-relay.brevo.com
       toPorts:
         - ports:
             - { port: "587", protocol: TCP }


### PR DESCRIPTION
SMTP-Egress von smtp.gmail.com auf smtp-relay.brevo.com (Mailer-Umzug, Gmail-App-Passwort war revoked). Live bereits appliziert + verifiziert.