### PR TITLE
kuma 2.4.0

### DIFF
--- a/kubernetes/apps/uptime-kuma/base/deployment.yaml
+++ b/kubernetes/apps/uptime-kuma/base/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         fsGroup: 0
       containers:
         - name: uptime-kuma
-          image: louislam/uptime-kuma:2.3.2@sha256:9aeb4e51d038047f414309c77a1af553281ca535723cb88907d907269d0a908e
+          image: louislam/uptime-kuma:2.4.0@sha256:91e963bfda569ba115206e843febb446f473ab525add4e08b2b9e3beffa16985
           ports:
             - containerPort: 3001
               name: http


### PR DESCRIPTION
Security-Fix (LiquidJS RCE, GHSA-gf2q-c269-pqgc) + Bearer-Token-Support. Digest-pinned wie üblich.