### PR TITLE
codify cloudflare + netbird as iac

### DIFF
--- a/tofu/cloudflare/.terraform.lock.hcl
+++ b/tofu/cloudflare/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/cloudflare/cloudflare" {
+  version     = "5.22.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:EOm3pWL+XqsFNVhupvcedWz7XrYurk52G6ElTSJ+Fxk=",
+    "h1:H3XmcpcMLeDyuGU6QsBXeVOB2CQGnIVRt6PJf7hfrtE=",
+    "h1:IqMMtu1KnqHhdRt3He18R1VZ6yijKjCVGL+qvGh5wbM=",
+    "h1:Mj/TBYAK+oLz4qkb3RBX6qMnCPA215ToNzH1b5VRIE8=",
+    "h1:RPY1abVjmPNOL79CeRmh1wgpgxoSXskz11HOU01ZX9c=",
+    "h1:bEk4C6AqKLPIUFijHpzP4yxim+hybvDX15smKqhlL1M=",
+    "h1:dEU3MBWyHJQh3OHGYi4QTiBxWtcuQKtijYa403txMaM=",
+    "h1:u3j/+0nmwTHvVg4lTziT8c9YvzGLlJOmFEOv/42yPuQ=",
+    "zh:45f3b7c50254b1da1dc21e77e03cd1e931cab40fb75c7cba822a53ed54cd232e",
+    "zh:8437138c0af1a1a557b516ca42dae54499933cc81072396abe7eefd267218f79",
+    "zh:9140044a3c909e1a2767c8b2dd95370b8152bcbc7cb26c47e376e81f75512d32",
+    "zh:b69a80d2bb33059e93dec94490065fe210c621d8bdf32d745b1d1972aa85abbf",
+    "zh:ca4bf16742a7e59319a482f003d32f6f6abbc5fbf862916ce1a136278e6d420d",
+    "zh:cd767016ea7382e384e560f6ddb302637ecb1b53ece15c9326032010effe6c33",
+    "zh:d952f92ae1a688ed376757127ae1aa3b625571bf1fc606214a5822eae98213e0",
+    "zh:f5213814c8ca0d736623438b283143b9a7f98e72ca4992eb906966e7f8cc383b",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}

--- a/tofu/cloudflare/README.md
+++ b/tofu/cloudflare/README.md
@@ -1,0 +1,44 @@
+# tofu/cloudflare — Public-Exposure als Code
+
+Managed die **public DNS-Records** → cloudflared-Tunnel. Eigener State (`cloudflare.tfstate`),
+isoliert von Cluster + NetBird.
+
+## Scope (bewusst klein gehalten)
+```
+✅ DNS-Records:  drova · n8n · iam · status → Tunnel (proxied/WAF)   ← die echte manuelle Lücke
+🟢 Allowlist (Tunnel-Ingress)  → bleibt GitOps (cloudflared/base/config.yaml, schon IaC)
+⚪ Zero Trust Access           → Scaffold in main.tofu (auskommentiert, optional)
+```
+**Sicherheits-Plus:** explizite Records statt Wildcard → `grafana.timourhomelab.org` &
+Co. resolven **gar nicht mehr public** (NXDOMAIN) — Infra ist via DNS unsichtbar, nur
+über NetBird-VPN + Split-DNS erreichbar.
+
+## Voraussetzungen
+1. **API-Token:** Cloudflare → My Profile → API Tokens → Create → Permissions:
+   `Zone:DNS:Edit` (+ `Account:Cloudflare Tunnel:Read` falls du Access dazunimmst).
+2. **Zone-ID:** Dashboard → timourhomelab.org → Overview (rechte Spalte).
+
+## Apply
+```bash
+cd tofu/cloudflare
+export TF_VAR_cloudflare_api_token="xxx"
+cp terraform.tfvars.example terraform.tfvars   # zone_id eintragen
+tofu init
+tofu plan      # erst ansehen!
+tofu apply
+```
+
+## ⚠️ Reconciliation — bestehende DNS-Records
+Wenn schon ein **Wildcard `*.timourhomelab.org`** in Cloudflare existiert (manuell):
+1. `tofu apply` legt die 4 **spezifischen** Records an
+2. **Wildcard im Dashboard löschen** → dann resolven nur noch die 4 public Hosts
+   (sonst resolved der Wildcard weiter alles zum Tunnel)
+Bestehende einzelne Records ggf. `tofu import cloudflare_dns_record.public["drova"] <zone>/<record-id>`.
+
+## Zusammenspiel mit dem Rest
+```
+Cloudflare-tofu (DNS)  →  4 public Hosts resolven public
+cloudflared ConfigMap  →  Tunnel-Allowlist (serviert nur die 4, 404 sonst)   [GitOps, Phase 1]
+NetBird Split-DNS      →  Infra-Hosts → interner Gateway (nur VPN-Clients)    [tofu/netbird]
+```
+Drei Layer, jeder sein Tool — sauberes ZTNA.

--- a/tofu/cloudflare/imports.tofu
+++ b/tofu/cloudflare/imports.tofu
@@ -1,0 +1,24 @@
+# Einmalige Import-Blocks — bringen bestehende, manuell angelegte Cloudflare-
+# Ressourcen unter Terraform-Kontrolle, OHNE sie neu zu erstellen. `tofu plan`
+# muss danach 0 Changes zeigen (reiner State-Import, keine Live-Änderung).
+# IDs per Cloudflare-API ermittelt (2026-07-22).
+
+import {
+  to = cloudflare_dns_record.public["drova"]
+  id = "${var.zone_id}/84e707913df89622b5844c8a4d8d8e91"
+}
+
+import {
+  to = cloudflare_dns_record.public["n8n"]
+  id = "${var.zone_id}/12c539761a50f86685a21087b026d7c2"
+}
+
+import {
+  to = cloudflare_dns_record.apex[0]
+  id = "${var.zone_id}/dc74853794e05a8cc8aff4b46bd985fc"
+}
+
+import {
+  to = cloudflare_dns_record.wildcard_internal
+  id = "${var.zone_id}/81e58abfe8f7b2e2925e323ea71af561"
+}

--- a/tofu/cloudflare/main.tofu
+++ b/tofu/cloudflare/main.tofu
@@ -1,0 +1,70 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Cloudflare Public-Exposure als Code
+# Managed NUR die public DNS-Records → cloudflared-Tunnel.
+# Allowlist (Tunnel-Ingress) bleibt GitOps (cloudflared/base/config.yaml).
+# Prinzip: explizite Records statt Wildcard → Infra-Subdomains resolven NICHT public.
+# ─────────────────────────────────────────────────────────────────────────────
+
+locals {
+  tunnel_cname = "${var.tunnel_id}.cfargotunnel.com"
+}
+
+# ── Public Subdomains → Tunnel (proxied) ─────────────────────────────────────
+# drova · n8n · iam · status — der Rest existiert hier bewusst NICHT.
+resource "cloudflare_dns_record" "public" {
+  for_each = toset(var.public_hosts)
+
+  zone_id = var.zone_id
+  name    = "${each.value}.${var.zone_name}"
+  type    = "CNAME"
+  content = local.tunnel_cname
+  proxied = true # orange-cloud = WAF/DDoS-Schutz + verbirgt Origin
+  ttl     = 1    # 1 = automatic (Pflicht wenn proxied)
+  comment = "public via tunnel — managed by tofu/cloudflare"
+}
+
+# ── Apex (optional) ──────────────────────────────────────────────────────────
+resource "cloudflare_dns_record" "apex" {
+  count = var.publish_apex ? 1 : 0
+
+  zone_id = var.zone_id
+  name    = var.zone_name
+  type    = "CNAME"
+  content = local.tunnel_cname
+  proxied = true
+  ttl     = 1
+  comment = "apex via tunnel — managed by tofu/cloudflare"
+}
+
+# ── Wildcard → Envoy-LB-IP (VPN-only, DNS-only/grau) ─────────────────────────
+# "Gilt für ALLES": jede Subdomain, die NICHT in public_hosts steht, löst auf die
+# private Envoy-LB-IP auf. DoH-Browser bekommen sie übers echte DNS (umgehen
+# /etc/hosts), aber 192.168.0.152 ist nur im VPN/LAN erreichbar. Neue interne App
+# = einfach HTTPRoute anlegen, DNS passt automatisch — KEINE Liste pflegen.
+# public_hosts (explizite CNAME) haben Vorrang (DNS-Spezifität schlägt Wildcard).
+resource "cloudflare_dns_record" "wildcard_internal" {
+  zone_id = var.zone_id
+  name    = "*.${var.zone_name}"
+  type    = "A"
+  content = var.envoy_lb_ip
+  proxied = false # grau = DNS-only, private IP NICHT durch Cloudflare-Proxy
+  ttl     = 300
+  comment = "wildcard → envoy LB (VPN-only, DoH-safe) — managed by tofu/cloudflare"
+}
+
+# ── Zero Trust Access (optional, auskommentiert) ─────────────────────────────
+# Falls du public Apps zusätzlich mit SSO-Gate schützen willst (statt nur App-Auth):
+#
+# resource "cloudflare_zero_trust_access_application" "n8n" {
+#   account_id = var.account_id
+#   name       = "n8n"
+#   domain     = "n8n.${var.zone_name}"
+#   type       = "self_hosted"
+#   session_duration = "24h"
+# }
+# resource "cloudflare_zero_trust_access_policy" "n8n_allow" {
+#   account_id = var.account_id
+#   name       = "allow-team"
+#   decision   = "allow"
+#   include = [{ email_domain = { domain = "outlook.de" } }]
+# }

--- a/tofu/cloudflare/outputs.tofu
+++ b/tofu/cloudflare/outputs.tofu
@@ -1,0 +1,9 @@
+output "public_fqdns" {
+  value       = [for h in var.public_hosts : "${h}.${var.zone_name}"]
+  description = "Die einzigen public Hostnames (resolven zum Tunnel)."
+}
+
+output "tunnel_cname" {
+  value       = local.tunnel_cname
+  description = "Tunnel-CNAME-Ziel, auf das die public Records zeigen."
+}

--- a/tofu/cloudflare/providers.tofu
+++ b/tofu/cloudflare/providers.tofu
@@ -1,0 +1,22 @@
+terraform {
+  # Eigener State — isoliert vom Cluster + von NetBird (Blast-Radius-Trennung).
+  backend "azurerm" {
+    resource_group_name  = "rg-tofu-state"
+    storage_account_name = "tofustatehomelab"
+    container_name       = "tfstate"
+    key                  = "cloudflare.tfstate"
+    use_azuread_auth     = true
+    subscription_id      = "72c89487-4bc9-4c91-a0f7-0cc51fc89336"
+  }
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5"
+    }
+  }
+}
+
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}

--- a/tofu/cloudflare/terraform.tfvars.example
+++ b/tofu/cloudflare/terraform.tfvars.example
@@ -1,0 +1,10 @@
+# Kopiere zu terraform.tfvars (gitignored) ODER nutze TF_VAR_* env-vars.
+# Token NIE committen.
+
+# cloudflare_api_token = "xxx"   # besser: export TF_VAR_cloudflare_api_token=...
+zone_id = "DEINE_ZONE_ID"        # Cloudflare → timourhomelab.org → Overview (rechts)
+
+# Optional (haben Defaults):
+# tunnel_id    = "b5f4258e-8cd9-4454-b46e-6f4f34219bb4"
+# public_hosts = ["drova", "n8n", "iam", "status"]
+# publish_apex = false

--- a/tofu/cloudflare/variables.tofu
+++ b/tofu/cloudflare/variables.tofu
@@ -1,0 +1,40 @@
+variable "cloudflare_api_token" {
+  type        = string
+  sensitive   = true
+  description = "Cloudflare API-Token (Zone:DNS:Edit + Account:Cloudflare Tunnel:Read). NIE committen → TF_VAR_cloudflare_api_token."
+}
+
+variable "zone_id" {
+  type        = string
+  description = "Cloudflare Zone-ID von timourhomelab.org (Dashboard → Domain → Overview, rechts unten)."
+}
+
+variable "zone_name" {
+  type        = string
+  default     = "timourhomelab.org"
+  description = "Die Domain."
+}
+
+variable "tunnel_id" {
+  type        = string
+  default     = "b5f4258e-8cd9-4454-b46e-6f4f34219bb4"
+  description = "cloudflared-Tunnel-ID (aus cloudflared/base/config.yaml)."
+}
+
+variable "public_hosts" {
+  type        = list(string)
+  default     = ["drova", "n8n"]
+  description = "NUR diese Subdomains sind public (explizite CNAME → cloudflared-Tunnel, Vorrang vor Wildcard). Alles andere (iam/Keycloak, status, grafana, argo, …) fällt auf den Wildcard → Envoy-LB = VPN/LAN-only. NetBird ist der ZTNA-Perimeter, interne Apps + IdP werden nicht internet-exponiert."
+}
+
+variable "publish_apex" {
+  type        = bool
+  default     = false
+  description = "true wenn timourhomelab.org (apex) auch public sein soll (Landing-Page)."
+}
+
+variable "envoy_lb_ip" {
+  type        = string
+  default     = "192.168.0.152"
+  description = "Cilium-L2 LoadBalancer-IP des Envoy-Gateway (im Heim-LAN). VPN-Clients erreichen sie über die NetBird-LAN-Route."
+}

--- a/tofu/netbird/.terraform.lock.hcl
+++ b/tofu/netbird/.terraform.lock.hcl
@@ -1,0 +1,38 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/netbirdio/netbird" {
+  version     = "0.0.9"
+  constraints = "~> 0.0.9"
+  hashes = [
+    "h1:0Vi0MLMk+K1CEuBZB+ByU55wXx87eGd5j0fGACekCDQ=",
+    "h1:2ska0C0jDxvbjApKlUmdkfrXQFjHiNf/KKYt355Isgo=",
+    "h1:H8GG0MZqAAXqnrMCw0Q3vcE3gGFEqYmDF9YY2RnD18Y=",
+    "h1:HKmwtSPE6k++umLH99WkpT/HcNzy69OWRTVZMsDFJh8=",
+    "h1:KFbgGf03fTGEgJRIpzAryWB26BHicfLQC8nuE5IiSys=",
+    "h1:VMUHvZOWIU/IWmK+NyEUIafKS88gGTvff+nK8N7NE3E=",
+    "h1:aFK3rhEjnnwiHU7Fl/nBDz5Y1b/2sRYXYomu4qewlwM=",
+    "h1:ba2yqgEM9Ssy+C/0nP3XHh209Y20gpYIErZtYVVb2k8=",
+    "h1:hC4RZOIVv5KTHcF+AuIHQe01hJmfw7yioSRTDb4ImDg=",
+    "h1:jaLhsZX1wOdBWKED+hJ0kyfV5TE3Laim6Kd7Uw+krzQ=",
+    "h1:mWLdkV/wXnK6SSMIKw+BJFJPonrts+7L5IEefRQ0rV8=",
+    "h1:nvVlkGxQSfphiXMNgGmvuTZQOOjhtdHMe/Upx3/HWjA=",
+    "h1:pjY52PZ8FJXUbeFcB0kSV8guz4h/xzlXLarWXelAwes=",
+    "h1:trYvM2c8h5lQ0m8+3Bgvgnbkm04+VOAL2pr6odmFfS8=",
+    "zh:1f34fba3ecfe0efa36d4b4bddf5714c69124e705d1e371e65abd291887d43385",
+    "zh:203f671af4d1f5376f4e20fb8d82cc8dc6c4fd136d9abffe8eb7b7f34e27197b",
+    "zh:21cb344302bdbadbc2779768116c7351d915bb7678a4847e9e2c8623d0032c48",
+    "zh:2368868e0f86b458f83b6598317ff5fde0d4079500d4567e99f46bf80c63f07a",
+    "zh:3237a426818eb3906153b1cf7fb6dfe9d52128972e7cab17c324d88788f86863",
+    "zh:427f8e8ba190d69cfd493b1598b4bf7940fe9a521a333df3540d2e0ea07543cf",
+    "zh:689cb219f3936500f5a3147299961f8740e505612b5182d93840cb8152d89b4f",
+    "zh:6e594e69d9e107c45ed4677a9bff68de2dd4232900b636327b24c819bee72c9e",
+    "zh:715634d6d0b052ac3f34aeb4c2df42960cdf44dd5c45d060867db78716aebb48",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:8cbbdde5a0b59f0bb427b403da8993b215d1a6231e0d6b9b4faa89db76b10705",
+    "zh:af92281c3e14c6af53fb93cee584c5118c5c7bee0acb938b5a367a219d9bc2e2",
+    "zh:bcdeef5fadf092e33228f28f013af7d8d9553b9d2fb2cecd1894351d5ad37a7a",
+    "zh:d6c31cb12f18b25c9663c14e737554e06144d4e270e607337bac7963ca3b9542",
+    "zh:e5873e8e0b29c8cbfd98f04759579da3c0529c8b38608c0f1ea92eb566c8ddc1",
+  ]
+}

--- a/tofu/netbird/README.md
+++ b/tofu/netbird/README.md
@@ -1,0 +1,49 @@
+# tofu/netbird — NetBird Control-Plane als Code (Phase 2)
+
+Kodifiziert die NetBird-Cloud-Config (Netz · Resource · Router · Split-DNS · Policy ·
+Setup-Key). **Eigener State** (`netbird.tfstate`) → voll isoliert vom Cluster, `tofu apply`
+hier kann die Talos-VMs nie anfassen.
+
+## Was es managed / NICHT managed
+```
+✅ NetBird-Control-Plane:  Netz, LAN-Resource, Router-Zuordnung, Split-DNS-Nameserver,
+                           Access-Policy, reusable Setup-Key, Groups
+❌ NICHT:  Routing-Peer-Install auf den Proxmox-Hosts  → Bash/cloud-init (siehe scripts/)
+           Client auf Geräten (Mac/Handy)              → manuell / MDM
+           der split-dns CoreDNS selbst                → GitOps (Phase 1, im Cluster)
+```
+
+## Voraussetzungen
+1. **NetBird API-Token (PAT):** Dashboard → User (oben rechts) → Settings → API Keys → Create.
+2. **split-dns IP:** erst nach Phase 1 (CoreDNS-Deploy im Cluster) bekannt → in `terraform.tfvars`.
+
+## Apply
+```bash
+cd tofu/netbird
+export TF_VAR_netbird_api_token="nbp_xxx"      # NIE committen
+cp terraform.tfvars.example terraform.tfvars   # split_dns_ip eintragen
+tofu init
+tofu plan      # IMMER erst plan ansehen
+tofu apply
+```
+
+## ⚠️ Reconciliation — das manuelle Setup von 2026-06-09
+Netz/Policy/Peers wurden anfangs **manuell** im Dashboard erstellt. Dieses tofu erstellt
+**neue** Resources → es würde ein ZWEITES "homelab"-Netz anlegen. Zwei Wege:
+
+**A) Sauber neu (empfohlen für klare IaC):** im Dashboard das manuelle "homelab"-Netz +
+Policy löschen → `tofu apply` legt alles frisch an → Routing-Peers mit dem neuen
+`routing_peer_setup_key` **neu** verbinden:
+```bash
+tofu output -raw routing_peer_setup_key   # neuen Key holen
+# auf msa2 + nipogi:  netbird up --setup-key <KEY>
+```
+
+**B) Import (Bestand behalten):** `tofu import netbird_network.homelab <network-id>` etc. —
+mehr Aufwand, nur wenn du die laufenden Peers nicht neu-keyen willst.
+
+## Peers anbinden (nach Apply)
+Setup-Key ist im Output (sensitive). Routing-Peer-Install: siehe `notes/CLAUDE-NETBIRD.md` §2.
+
+## Cloud vs Self-Hosted
+Gleicher Code — nur `netbird_management_url` ändern (Cloud-Default = api.netbird.io).

--- a/tofu/netbird/imports.tofu
+++ b/tofu/netbird/imports.tofu
@@ -1,0 +1,45 @@
+# Einmalige Import-Blocks — bringen die am 2026-06-09 manuell im NetBird-
+# Dashboard angelegten Ressourcen unter Terraform-Kontrolle, OHNE sie neu
+# zu erstellen. `tofu plan` muss danach 0 Changes zeigen. IDs per NetBird-API
+# ermittelt (2026-07-22). Reconciliation-Weg B aus README.md (Import, kein
+# Peer-Re-Keying).
+
+import {
+  to = netbird_group.routers
+  id = "d8k09pafadhs73daptpg"
+}
+
+import {
+  to = netbird_group.users
+  id = "d8k09pbl0ubs73cdok70"
+}
+
+import {
+  to = netbird_group.lan_resource
+  id = "d8k09pbl0ubs73cdok5g"
+}
+
+import {
+  to = netbird_network.homelab
+  id = "d8k09pafadhs73daptn0"
+}
+
+import {
+  to = netbird_network_resource.lan
+  id = "d8k09pafadhs73daptn0/d8k09pafadhs73dapu00"
+}
+
+import {
+  to = netbird_network_router.lan
+  id = "d8k09pafadhs73daptn0/d8k09pafadhs73dapu20"
+}
+
+import {
+  to = netbird_policy.users_to_lan
+  id = "d8k09pafadhs73dapu70"
+}
+
+import {
+  to = netbird_setup_key.routers
+  id = "d8k09pbl0ubs73cdokh0"
+}

--- a/tofu/netbird/main.tofu
+++ b/tofu/netbird/main.tofu
@@ -1,0 +1,70 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# NetBird ZTNA — Infra VPN-only (Phase 2 IaC)
+# Kodifiziert was am 2026-06-09 manuell im Dashboard eingerichtet wurde.
+# Managed die NetBird-CONTROL-PLANE (Netz/Policy/DNS/Keys), NICHT die Peer-Installs.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── Groups ───────────────────────────────────────────────────────────────────
+resource "netbird_group" "routers" {
+  name = "homelab-routers" # Routing-Peers (msa2proxmox, nipogi) landen hier via Setup-Key
+}
+
+resource "netbird_group" "users" {
+  name = "homelab-users" # Client-Geräte (Laptop, Handle) die aufs LAN dürfen
+}
+
+resource "netbird_group" "lan_resource" {
+  name = "homelab-lan" # Tag-Gruppe für die LAN-Resource (Policy-Ziel)
+}
+
+# ── Network ──────────────────────────────────────────────────────────────────
+resource "netbird_network" "homelab" {
+  name        = "homelab"
+  description = "Homelab LAN — VPN-only Infra-Zugriff (grafana, argocd, kibana, ...)"
+}
+
+# ── Resource: das LAN-Subnet ─────────────────────────────────────────────────
+resource "netbird_network_resource" "lan" {
+  name        = "homelab-lan"
+  description = "Heim-LAN — erreicht alle internen Services hinter dem Envoy-Gateway"
+  network_id  = netbird_network.homelab.id
+  address     = var.lan_cidr
+  groups      = [netbird_group.lan_resource.id]
+  enabled     = true
+}
+
+# ── Router: die Routing-Peers servieren das Netz (HA via peer_groups) ─────────
+resource "netbird_network_router" "lan" {
+  network_id  = netbird_network.homelab.id
+  peer_groups = [netbird_group.routers.id] # msa2 + nipogi → Failover
+  masquerade  = true
+  metric      = 9999
+  enabled     = true
+}
+
+# Split-DNS aus tofu ENTFERNT (2026-06-09) — der NetBird-Operator macht jetzt DNS
+# (Zone k8s.timourhomelab.org, Records pro exposed Service). Dieses Modul = nur noch LAN-Routing.
+
+# ── Access-Policy: users → LAN-Resource (Least-Privilege) ────────────────────
+resource "netbird_policy" "users_to_lan" {
+  name        = "homelab-users-to-lan"
+  description = "Erlaubt homelab-users den Zugriff auf das LAN-Subnet"
+  enabled     = true
+
+  rule {
+    name          = "users-to-lan"
+    action        = "accept"
+    bidirectional = true
+    protocol      = "all"
+    sources       = [netbird_group.users.id]
+    destinations  = [netbird_group.lan_resource.id]
+  }
+}
+
+# ── Setup-Key: für die Routing-Peers (reusable → mehrere Peers + HA) ──────────
+resource "netbird_setup_key" "routers" {
+  name        = "homelab-routing-peers"
+  type        = "reusable"
+  usage_limit = 0 # unlimited
+  auto_groups = [netbird_group.routers.id]
+}

--- a/tofu/netbird/outputs.tofu
+++ b/tofu/netbird/outputs.tofu
@@ -1,0 +1,12 @@
+output "routing_peer_setup_key" {
+  value       = netbird_setup_key.routers.key
+  sensitive   = true
+  description = "Reusable Setup-Key für die Routing-Peers. Abruf: tofu output -raw routing_peer_setup_key"
+}
+
+output "network_id" {
+  value       = netbird_network.homelab.id
+  description = "NetBird Network ID (homelab)"
+}
+
+# split_dns_nameserver_id ENTFERNT — Operator macht DNS

--- a/tofu/netbird/providers.tofu
+++ b/tofu/netbird/providers.tofu
@@ -1,0 +1,25 @@
+terraform {
+  # SEPARATER State-Key — voll isoliert vom Cluster (talos-homelab.tfstate).
+  # tofu apply hier kann die Talos-VMs NIE anfassen.
+  backend "azurerm" {
+    resource_group_name  = "rg-tofu-state"
+    storage_account_name = "tofustatehomelab"
+    container_name       = "tfstate"
+    key                  = "netbird.tfstate"
+    use_azuread_auth     = true
+    subscription_id      = "72c89487-4bc9-4c91-a0f7-0cc51fc89336"
+  }
+
+  required_providers {
+    netbird = {
+      source  = "netbirdio/netbird"
+      version = "~> 0.0.9"
+    }
+  }
+}
+
+provider "netbird" {
+  token = var.netbird_api_token
+  # Cloud-Default: https://api.netbird.io. Self-hosted: eigene URL setzen.
+  management_url = var.netbird_management_url
+}

--- a/tofu/netbird/terraform.tfvars.example
+++ b/tofu/netbird/terraform.tfvars.example
@@ -1,0 +1,9 @@
+# Kopiere zu terraform.tfvars (gitignored!) ODER nutze TF_VAR_* env-vars.
+# Den Token NIE committen.
+
+# netbird_api_token = "nbp_xxxxxxxxxxxxxxxxxxxx"   # besser: export TF_VAR_netbird_api_token=...
+
+# Optional (haben Defaults, matchen die Live-Config):
+# netbird_management_url = "https://api.netbird.io"
+# lan_cidr               = "192.168.0.0/24"
+# dns_domain             = "timourhomelab.org"

--- a/tofu/netbird/variables.tofu
+++ b/tofu/netbird/variables.tofu
@@ -1,0 +1,25 @@
+variable "netbird_api_token" {
+  type        = string
+  sensitive   = true
+  description = "NetBird Personal Access Token (Dashboard → User → Settings → API Keys). NIE committen — via TF_VAR_netbird_api_token oder Key Vault."
+}
+
+variable "netbird_management_url" {
+  type        = string
+  default     = "https://api.netbird.io"
+  description = "Cloud-Default. Self-hosted: https://netbird.deine-domain"
+}
+
+variable "lan_cidr" {
+  type        = string
+  default     = "192.168.0.0/24"
+  description = "Das Homelab-LAN, das die Routing-Peers ins Mesh announcen."
+}
+
+variable "dns_domain" {
+  type        = string
+  default     = "timourhomelab.org"
+  description = "Match-Domain für Split-DNS — wird auf die interne Gateway-IP aufgelöst (nur für VPN-Clients)."
+}
+
+# split_dns_ip ENTFERNT — Operator macht DNS (Zone k8s.timourhomelab.org)


### PR DESCRIPTION
Schließt die 2 letzten Click-Ops-Gaps (audit von heute): Cloudflare-Tunnel-DNS + NetBird-Control-Plane waren manuell im Dashboard gepflegt. Restauriert aus #412 (waren mal da, als "Leftovers" entfernt — Struktur/Design passt exakt zur aktuellen Live-Config, deshalb wiederverwendet statt neu designed).

**Beide via `import`-Blocks importiert, NICHT neu erstellt** — zero Blast-Radius, nichts appliziert:
- **netbird/**: 8/8 Ressourcen (2 Groups, Network, Resource, Router, Policy, Setup-Key) → `tofu plan` = "No changes. Your infrastructure matches the configuration." Perfekter 0-Diff.
- **cloudflare/**: 4 DNS-Records (drova, n8n, apex, wildcard-internal) → 3/4 exakt 0-Diff. Apex-Record hat 1 kosmetischen Diff (fehlender `comment`-Tag, rein additiv/nicht-destruktiv) — **bewusst NICHT applied**, wartet auf Freigabe.

Eigene States (`cloudflare.tfstate`, `netbird.tfstate`) — isoliert vom Cluster-State, `tofu apply` hier kann die Talos-VMs nie anfassen. Tokens NIE committed (TF_VAR_*, terraform.tfvars bleibt gitignored).

Scope bewusst klein: nur DNS-Records + NetBird-Control-Plane. Cloudflare-Tunnel-Resource selbst (cloudflare_zero_trust_tunnel_cloudflared) NICHT importiert — bräuchte einen Account-gescopten Token (Account>Cloudflare Tunnel:Edit), der bestehende Zone-Token reicht dafür nicht. Bleibt offener Punkt für später.