### PR TITLE
netbird hardening

### DIFF
--- a/tofu/netbird/imports.tofu
+++ b/tofu/netbird/imports.tofu
@@ -39,7 +39,11 @@ import {
   id = "d8k09pafadhs73dapu70"
 }
 
+# netbird_setup_key.routers: KEIN Import-Block mehr — durch das expiry_seconds-
+# Hardening (2026-07-22) destroy+recreated, State trägt bereits die neue ID
+# (Apply lief bereits, kein Re-Import nötig).
+
 import {
-  to = netbird_setup_key.routers
-  id = "d8k09pbl0ubs73cdokh0"
+  to = netbird_account_settings.hardening
+  id = "d8jsbeafadhs73c5f6dg"
 }

--- a/tofu/netbird/main.tofu
+++ b/tofu/netbird/main.tofu
@@ -45,6 +45,24 @@ resource "netbird_network_router" "lan" {
 # Split-DNS aus tofu ENTFERNT (2026-06-09) — der NetBird-Operator macht jetzt DNS
 # (Zone k8s.timourhomelab.org, Records pro exposed Service). Dieses Modul = nur noch LAN-Routing.
 
+# ── Account-Settings: Zero-Trust-Hardening (2026-07-22) ───────────────────────
+# "continuously authenticating" (NIST SP 800-207) — peer_approval + periodische
+# Re-Auth statt einmal verbinden und für immer vertrauen.
+resource "netbird_account_settings" "hardening" {
+  peer_approval_enabled         = true # neue Peers brauchen manuelle Freigabe
+  peer_login_expiration_enabled = true # User-Peers re-authen alle 24h
+  peer_login_expiration         = 86400
+  # unverändert gelassen (Live-Defaults, keine Absicht dahinter zu ändern):
+  peer_inactivity_expiration_enabled  = false
+  peer_inactivity_expiration          = 0
+  regular_users_view_blocked          = false
+  groups_propagation_enabled          = false
+  jwt_groups_enabled                  = false
+  jwt_groups_claim_name               = ""
+  jwt_allow_groups                    = []
+  routing_peer_dns_resolution_enabled = false
+}
+
 # ── Access-Policy: users → LAN-Resource (Least-Privilege) ────────────────────
 resource "netbird_policy" "users_to_lan" {
   name        = "homelab-users-to-lan"
@@ -55,9 +73,13 @@ resource "netbird_policy" "users_to_lan" {
     name          = "users-to-lan"
     action        = "accept"
     bidirectional = true
-    protocol      = "all"
-    sources       = [netbird_group.users.id]
-    destinations  = [netbird_group.lan_resource.id]
+    # tcp statt all (Hardening 2026-07-22): entfernt ungeprüften ICMP/UDP-Raw-Zugriff.
+    # Alle Homelab-Apps laufen über Envoy-Gateway (TCP/443) — bleibt voll funktionsfähig.
+    # Port-Scope (nur 443/22 etc.) bewusst NICHT verengt — fehlende Traffic-Telemetrie,
+    # Risiko ungeprüft etwas zu sperren > Nutzen; Folge-Schritt für einen ruhigen Tag.
+    protocol     = "tcp"
+    sources      = [netbird_group.users.id]
+    destinations = [netbird_group.lan_resource.id]
   }
 }
 
@@ -67,4 +89,8 @@ resource "netbird_setup_key" "routers" {
   type        = "reusable"
   usage_limit = 0 # unlimited
   auto_groups = [netbird_group.routers.id]
+  # Ablauf 2026-07-22 hinzugefügt (Hardening): Key selbst läuft ab, bereits
+  # verbundene Peers (msa2/nipogi) bleiben unberührt — Ablauf wirkt nur auf
+  # NEUE Verbindungsversuche mit dem Key (NetBird-Doku bestätigt).
+  expiry_seconds = 7776000 # 90 Tage
 }


### PR DESCRIPTION
Kodifiziert das ZTNA-Hardening von heute (live via API angewendet + verifiziert, jetzt in Terraform nachgezogen — 0-Diff bewiesen):

- **policy.protocol**: all → tcp (entfernt ungeprüften ICMP/UDP-Raw-Zugriff; Port-Scope bewusst NICHT verengt, fehlende Traffic-Telemetrie)
- **setup_key.expiry_seconds**: 90 Tage (war: nie ablaufend + unbegrenzte Nutzung). Verifiziert: destroy+recreate trennt bereits verbundene Routing-Peers NICHT (msa2/nipogi blieben connected=true, Doku-bestätigt + live getestet)
- **NEU netbird_account_settings**: peer_approval_enabled=true (neue Peers brauchen Freigabe) + peer_login_expiration_enabled=true/24h (periodische Re-Auth, NIST SP 800-207 "continuously authenticating")
- Live zusätzlich (außerhalb Terraform-Scope, "My First Network"-Onboarding-Cruft): 3 Default-Policies deaktiviert (Default All↔All, Users-to-Routing-Peers, Users-to-My-Subnet) — hebelten die sorgfältig gescopte homelab-users-to-lan-Policy aus

Jeder Schritt einzeln live getestet (grafana/argo/drova via VPN weiter 200/302, msa2/nipogi weiter connected) bevor der nächste kam. `tofu plan` = "No changes" nach jedem Apply.