### PR TITLE
add tofu lint ci

### DIFF
--- a/.github/workflows/tofu-lint.yml
+++ b/.github/workflows/tofu-lint.yml
@@ -1,0 +1,37 @@
+name: tofu-lint
+
+on:
+  pull_request:
+    paths:
+      - "tofu/**/*.tofu"
+      - "tofu/**/*.tf"
+
+permissions:
+  contents: read
+
+jobs:
+  fmt-validate:
+    name: fmt + validate
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        module: [".", "cloudflare", "netbird"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup OpenTofu
+        uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_version: "1.12.3"
+
+      - name: tofu fmt -check
+        working-directory: tofu/${{ matrix.module }}
+        run: tofu fmt -check -recursive
+
+      - name: tofu validate
+        working-directory: tofu/${{ matrix.module }}
+        # -backend=false: kein Azure-Login noetig, nur Syntax/Schema-Check.
+        # Kein Provider-Token noetig (kein plan/apply) -> keine Secrets in CI.
+        run: |
+          tofu init -backend=false -input=false
+          tofu validate


### PR DESCRIPTION
Ground-truth-Audit heute: es gab GAR KEINE tofu-CI im Repo — auch nicht für den Haupt-Cluster-Modul. Der Formatierungs-Fehler, den ich gerade selbst gemacht habe (unsauber alignter HCL-Block in netbird/main.tofu, lokal vom pre-commit-Hook gefangen), wäre auf einem PR ohne lokalen Hook (z.B. fremder Rechner) NIE aufgefallen.

Bewusst NUR fmt+validate, KEIN plan/apply in CI:
- fmt-check + validate brauchen KEINE Credentials (-backend=false, kein Azure-Login, keine Cloudflare/NetBird-Tokens in GitHub Secrets nötig) — reiner Syntax/Schema-Check
- plan/apply bräuchten echte Prod-Tokens in CI-Secrets — größere Angriffsfläche für ein Solo-Repo, wo ich (Claude) bzw. Tim eh lokal planen und den Diff direkt im PR-Body dokumentieren (wie heute Nacht bei #533/#534 praktiziert)
- apply bleibt PRINZIPIELL nie automatisiert — DAX-Regel "Diff zeigen, nie blind pushen. Merges/Deploys entscheidet Tim"

Matrix über alle 3 Module (root, cloudflare, netbird) — lokal vorab verifiziert, alle 3 grün.