### PR TITLE
add tofu plan+apply pipeline

### DIFF
--- a/.github/workflows/tofu-cd.yml
+++ b/.github/workflows/tofu-cd.yml
@@ -1,0 +1,110 @@
+name: tofu-cd
+
+# NUR cloudflare/ + netbird/ — der root-Cluster-Modul (tofu/) braucht Proxmox +
+# Talos + K8s-API, alle nur im LAN erreichbar. Ein GitHub-Runner (Cloud) kommt da
+# nie hin -> root bleibt bewusst manual-apply (siehe tofu-lint.yml fuer fmt/validate).
+#
+# Azure-Auth: OIDC (Workload Identity Federation) — keine gespeicherten Azure-
+# Secrets. ARM_USE_OIDC=true + die 3 Werte reichen, GitHub liefert das ID-Token
+# automatisch ueber die id-token:write-Permission. Kein azure/login-Step noetig
+# (der loggt nur die az-CLI ein, das propagiert NICHT zu Terraforms azurerm-
+# Backend — offizielles Microsoft-Sample bestaetigt: nur Env-Vars, kein Login-Step).
+
+on:
+  pull_request:
+    paths:
+      - "tofu/cloudflare/**"
+      - "tofu/netbird/**"
+  push:
+    branches: [main]
+    paths:
+      - "tofu/cloudflare/**"
+      - "tofu/netbird/**"
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+env:
+  ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+  ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+  ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+  ARM_USE_AZUREAD: true
+  ARM_USE_OIDC: true
+
+jobs:
+  plan:
+    if: github.event_name == 'pull_request'
+    name: plan (${{ matrix.module }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        module: [cloudflare, netbird]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup OpenTofu
+        uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_version: "1.12.3"
+
+      - name: tofu init
+        working-directory: tofu/${{ matrix.module }}
+        run: tofu init -input=false
+
+      - name: tofu plan
+        working-directory: tofu/${{ matrix.module }}
+        env:
+          TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          TF_VAR_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          TF_VAR_publish_apex: true
+          TF_VAR_netbird_api_token: ${{ secrets.NETBIRD_API_TOKEN }}
+        run: tofu plan -input=false -no-color 2>&1 | tee plan_output.txt
+
+      - name: Comment plan on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const output = fs.readFileSync('tofu/${{ matrix.module }}/plan_output.txt', 'utf8').slice(-60000);
+            const body = `#### tofu plan — \`${{ matrix.module }}\`\n<details><summary>Show plan</summary>\n\n\`\`\`\n${output}\n\`\`\`\n</details>`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number,
+            });
+            const marker = `tofu plan — \`${{ matrix.module }}\``;
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body });
+            }
+
+  apply:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    name: apply (${{ matrix.module }})
+    runs-on: ubuntu-latest
+    environment: tofu-apply # Required-Reviewer-Gate — nichts laeuft ohne manuelle Freigabe
+    strategy:
+      matrix:
+        module: [cloudflare, netbird]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup OpenTofu
+        uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_version: "1.12.3"
+
+      - name: tofu init
+        working-directory: tofu/${{ matrix.module }}
+        run: tofu init -input=false
+
+      - name: tofu apply
+        working-directory: tofu/${{ matrix.module }}
+        env:
+          TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          TF_VAR_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          TF_VAR_publish_apex: true
+          TF_VAR_netbird_api_token: ${{ secrets.NETBIRD_API_TOKEN }}
+        run: tofu apply -input=false -auto-approve -no-color

--- a/tofu/cloudflare/providers.tofu
+++ b/tofu/cloudflare/providers.tofu
@@ -6,6 +6,7 @@ terraform {
     container_name       = "tfstate"
     key                  = "cloudflare.tfstate"
     use_azuread_auth     = true
+    use_oidc             = true
     subscription_id      = "72c89487-4bc9-4c91-a0f7-0cc51fc89336"
   }
 

--- a/tofu/netbird/providers.tofu
+++ b/tofu/netbird/providers.tofu
@@ -7,6 +7,7 @@ terraform {
     container_name       = "tfstate"
     key                  = "netbird.tfstate"
     use_azuread_auth     = true
+    use_oidc             = true
     subscription_id      = "72c89487-4bc9-4c91-a0f7-0cc51fc89336"
   }
 


### PR DESCRIPTION
Enterprise-CI/CD für tofu/cloudflare + tofu/netbird: plan-on-PR (als Kommentar) + apply-on-merge (gated durch GitHub-Environment "tofu-apply" mit Required-Reviewer=Tim275).

- Azure-Auth: OIDC (Workload Identity Federation) — vorhandener Service Principal `github-talos-homelab-ci` war schon exakt für dieses Repo (pull_request + ref/heads/main) föderiert, brauchte nur die Storage-Rolle Reader→Contributor (für apply-Writes)
- Backend-Fix: `use_oidc = true` in beiden providers.tofu ergänzt (fehlte — ohne das keine OIDC-Auth). Lokal getestet: bricht meinen bisherigen az-CLI-Workflow NICHT (0-Diff-Plan weiterhin lokal möglich)
- Kein `azure/login`-Step — offizielles Microsoft-Sample bestätigt: nur 4 ARM_*-Env-Vars reichen, azure/login loggt nur die CLI ein, propagiert nicht zu Terraforms Backend-Auth
- root-Cluster-Modul (tofu/) bewusst NICHT dabei — braucht Proxmox/Talos/K8s-API, alle nur im LAN erreichbar, ein GitHub-Runner kommt da nie hin. Bleibt bei fmt+validate (tofu-lint.yml)
- Secrets: CLOUDFLARE_API_TOKEN, CLOUDFLARE_ZONE_ID, NETBIRD_API_TOKEN neu gesetzt (Azure-Secrets existierten schon)

Dieser PR selbst ist der erste Live-Test des plan-Jobs (ändert beide providers.tofu) — Plan-Kommentar sollte gleich hier auftauchen.