### PR TITLE
default-deny ingress fuer reconcile-getriebene infra-NS

### DIFF
--- a/kubernetes/security/foundation/network-policies/external-dns.yaml
+++ b/kubernetes/security/foundation/network-policies/external-dns.yaml
@@ -1,0 +1,29 @@
+---
+# Lock external-dns controller ingress: only monitoring (metrics scrape on :7979)
+# + host/apiserver (kubelet probe). external-dns is reconcile-driven (watches
+# Ingress/Service, egress to Cloudflare API); no legitimate in-cluster ingress
+# beyond probes/metrics. Blocks lateral movement.
+#
+# Allow-list derived from live state 2026-07-22:
+#   - ServiceMonitor external-dns (ns monitoring) scrapes port "http" (7979)
+#   - liveness/readiness probe → :7979 (from host/kubelet)
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: external-dns-ingress-lock
+  namespace: external-dns
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: external-dns
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - { port: "7979", protocol: TCP }
+    - fromEntities: [host, kube-apiserver]
+      toPorts:
+        - ports:
+            - { port: "7979", protocol: TCP }

--- a/kubernetes/security/foundation/network-policies/kustomization.yaml
+++ b/kubernetes/security/foundation/network-policies/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   # Cluster-wide network policies
   - envoy-gateway.yaml          # Envoy ingress lock — public-only
   - redis-gateway.yaml          # Rate-limit Redis lock — only envoy-ratelimit + monitoring
+  - sealed-secrets.yaml         # crown-jewel key lock — only monitoring + host probes
   # Tenant-specific (grouped per tenant for discoverability — DAX pattern)
   - tenants/drova
 

--- a/kubernetes/security/foundation/network-policies/kustomization.yaml
+++ b/kubernetes/security/foundation/network-policies/kustomization.yaml
@@ -16,6 +16,8 @@ resources:
   - envoy-gateway.yaml          # Envoy ingress lock — public-only
   - redis-gateway.yaml          # Rate-limit Redis lock — only envoy-ratelimit + monitoring
   - sealed-secrets.yaml         # crown-jewel key lock — only monitoring + host probes
+  - reloader.yaml               # reconcile-driven — only monitoring + host probes
+  - external-dns.yaml           # reconcile-driven — only monitoring + host probes
   # Tenant-specific (grouped per tenant for discoverability — DAX pattern)
   - tenants/drova
 

--- a/kubernetes/security/foundation/network-policies/reloader.yaml
+++ b/kubernetes/security/foundation/network-policies/reloader.yaml
@@ -1,0 +1,29 @@
+---
+# Lock reloader controller ingress: only monitoring (metrics) + host/apiserver
+# (kubelet probe on :9090). reloader is reconcile-driven (watches ConfigMaps/
+# Secrets, triggers rollouts — pure egress to apiserver); it has no legitimate
+# in-cluster ingress beyond probes/metrics. Blocks lateral movement.
+#
+# Allow-list derived from live state 2026-07-22:
+#   - container port 9090 serves both /healthz probe AND /metrics
+#   - no ServiceMonitor currently scrapes it; monitoring allowed defensively
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: reloader-ingress-lock
+  namespace: reloader
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: reloader
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - { port: "9090", protocol: TCP }
+    - fromEntities: [host, kube-apiserver]
+      toPorts:
+        - ports:
+            - { port: "9090", protocol: TCP }

--- a/kubernetes/security/foundation/network-policies/sealed-secrets.yaml
+++ b/kubernetes/security/foundation/network-policies/sealed-secrets.yaml
@@ -1,0 +1,32 @@
+---
+# Lock sealed-secrets controller ingress: only monitoring (metrics scrape) and
+# host/apiserver (kubelet /healthz probe + kubeseal --fetch-cert via apiserver-proxy).
+# Protects the crown-jewel encryption key from lateral movement — a compromised
+# pod in any other namespace cannot reach the controller.
+#
+# Allow-list derived from live state 2026-07-22:
+#   - ServiceMonitor sealed-secrets (ns monitoring) scrapes :8081/metrics
+#   - liveness/readiness probe → :8080 /healthz (from host/kubelet)
+#   - kubeseal --fetch-cert → :8080 via apiserver-proxy (kube-apiserver entity)
+# No in-cluster pod calls :8080 directly (ArgoCD applies SealedSecret CRs, the
+# controller decrypts internally — no ingress needed).
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: sealed-secrets-ingress-lock
+  namespace: sealed-secrets
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: sealed-secrets
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - { port: "8081", protocol: TCP }
+    - fromEntities: [host, kube-apiserver]
+      toPorts:
+        - ports:
+            - { port: "8080", protocol: TCP }


### PR DESCRIPTION
Schliesst die default-deny-Luecke pro Namespace — bisher hatte NUR drova eine Pod-Level default-deny, alle anderen (inkl. Kronjuwelen) liefen ohne East-West-Schutz.

Diese PR: die 3 SICHERSTEN Ziele zuerst (single-deployment, reconcile-getrieben, ingress = nur Metrics + Probes):
- **sealed-secrets** (Crown-Jewel Encryption-Key) — allow: monitoring:8081, host+apiserver:8080
- **reloader** — allow: monitoring:9090, host+apiserver:9090
- **external-dns** — allow: monitoring:7979, host+apiserver:7979

Alle 3 live vorab-getestet (2026-07-22): Controller blieben 1/1 healthy, Metrics-Scrape up=1, kubeseal cert-fetch ok — nichts gebrochen. Test-Applies entfernt, kommen via GitOps (security-foundation AUTO-sync) nach Merge.

BEWUSST NICHT in dieser PR:
- keycloak/lldap/n8n: ingress-allowlist wurde 2026-05-06 disabled weil sie KC-LLDAP-Federation brach (dokumentierte Landmine)
- velero/cnpg-system/cert-manager: komplexer (node-agents/jobs/webhooks) — eigene PR mit sorgfaeltiger Flow-Analyse

Naechste NS folgen als separate PRs, jeder einzeln verifiziert.