### PR TITLE
fix: wire smtp egress

### DIFF
--- a/kubernetes/security/foundation/network-policies/tenants/drova/kustomization.yaml
+++ b/kubernetes/security/foundation/network-policies/tenants/drova/kustomization.yaml
@@ -6,5 +6,6 @@ kind: Kustomization
 resources:
   # mtls.yaml — SPIRE-mTLS abgebaut 2026-07-10, ersetzt durch Istio ambient (ztunnel)
   - default-deny.yaml     # Drova Microservices Default-Deny (added 2026-05-08)
+  - user-service-smtp-egress.yaml  # Mailer-Egress (Brevo:587) — lebt live seit 2026-07-22, hier verdrahtet gegen Prune
   # - istio-strict-mtls.yaml  # STRICT killt kubelet-probes unter Cilium (cilium_host-SRC statt node-IP) — fix noetig
   # egress.yaml — parked, will re-enable when stripe/mapbox FQDN-egress validated


### PR DESCRIPTION
user-service-smtp-egress.yaml lag im Ordner, war aber NICHT in der kustomization (#526-Anfügepunkt existierte nur als Kommentar) — Policy lebte nur als Hand-Apply. Ohne Wiring würde ein Prune-Sync den Mailer-Egress löschen. Jetzt verdrahtet, Render verifiziert.