### PR TITLE
netbird device-posture check (Zero-Trust KP3b)

### DIFF
--- a/tofu/netbird/main.tofu
+++ b/tofu/netbird/main.tofu
@@ -63,11 +63,29 @@ resource "netbird_account_settings" "hardening" {
   routing_peer_dns_resolution_enabled = false
 }
 
-# ── Access-Policy: users → LAN-Resource (Least-Privilege) ────────────────────
+# ── Device-Posture: Mindest-NetBird-Client-Version (Zero-Trust KP3b) ─────────
+# Erzwingt, dass User-Geräte einen aktuellen NetBird-Client fahren, bevor sie
+# aufs LAN dürfen — veralteter Client = ungepatchte Angriffsfläche.
+# Schwelle 0.72.0 bewusst konservativ: homelab-users = aktuell NUR der MacBook
+# (live 2026-07-22: netbird 0.72.2 → besteht). Infra-Peers (msa2/nipogi/
+# clusterproxy) sind NICHT in homelab-users → unberührt. Neue User-Geräte mit
+# älterem Client würden geblockt (= gewollter Posture-Gate).
+resource "netbird_posture_check" "min_client" {
+  name        = "homelab-min-netbird-version"
+  description = "User-Geräte müssen NetBird-Client >= 0.72.0 fahren (Device-Health)"
+
+  netbird_version_check {
+    min_version = "0.72.0"
+  }
+}
+
+# ── Access-Policy: users → LAN-Resource (Least-Privilege + Posture) ───────────
 resource "netbird_policy" "users_to_lan" {
   name        = "homelab-users-to-lan"
   description = "Erlaubt homelab-users den Zugriff auf das LAN-Subnet"
   enabled     = true
+  # Posture-Gate: nur Geräte die den Version-Check bestehen kommen durch.
+  source_posture_checks = [netbird_posture_check.min_client.id]
 
   rule {
     name          = "users-to-lan"


### PR DESCRIPTION
Fuegt einen NetBird Posture-Check hinzu: User-Geraete muessen NetBird-Client >= 0.72.0 fahren, sonst kein LAN-Zugriff. Schliesst Zero-Trust Kontrollpunkt 3b (Device-Posture).

**Warum sicher (live 2026-07-22 verifiziert):**
- Gehaengt an Policy homelab-users-to-lan, deren Quelle homelab-users AKTUELL NUR den MacBook enthaelt (netbird 0.72.2 -> besteht 0.72.0-Schwelle)
- Infra-Peers (msa2/nipogi/clusterproxy) sind NICHT in homelab-users -> unberuehrt (wichtig: clusterproxy hat version=development, wuerde JEDEN Version-Check failen, ist aber nicht betroffen)
- Neue User-Geraete mit aelterem Client wuerden geblockt = gewollter Posture-Gate

**Apply = manuell (netbird-Muster, kein CI-apply):**
```
cd tofu/netbird
export TF_VAR_netbird_api_token=<token>   # aus Secret netbird-mgmt-api-key
tofu plan    # muss zeigen: +1 posture_check, ~1 policy (source_posture_checks)
tofu apply
```
Danach SOFORT verifizieren: MacBook bleibt connected (Peers-Liste). Break-Glass falls doch Problem: Posture-Check im NetBird-Dashboard von der Policy loesen.

Provider netbirdio/netbird ~> 0.0.9, Resource netbird_posture_check + policy.source_posture_checks. HCL validate gruen.