### PR TITLE
feat: drova l7 authz (dry-run)

### DIFF
--- a/kubernetes/tenants/drova/kustomization.yaml
+++ b/kubernetes/tenants/drova/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: drova
 
 resources:
+  - l7-authz.yaml
 - namespace.yaml
 - resourcequota.yaml
 - limitrange.yaml

--- a/kubernetes/tenants/drova/l7-authz.yaml
+++ b/kubernetes/tenants/drova/l7-authz.yaml
@@ -1,0 +1,58 @@
+# L7-AuthZ pro Backend-Service — enforced am WAYPOINT (targetRefs: Service).
+# Wichtig: der Waypoint sieht die ORIGINAL-Client-Identität (SPIFFE), re-originiert
+# zum Backend aber als sa/waypoint → Client-Unterscheidung geht NUR hier.
+# Ingress-facing Services (api-gateway/chat/frontend) bewusst NICHT policed:
+# gateway-ns ist nicht im Mesh — deren Traffic würde sonst identitätslos geblockt.
+# Kubelet-Probes sind mesh-exempt und von diesen Policies unberührt.
+#
+# PHASE 1: istio.io/dry-run=true — Shadow-Evaluation, blockt NICHTS.
+# Flip auf enforce = Annotation auf "false" + waypoint-allow-known entfernen.
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: trip-service-authz
+  namespace: drova
+  annotations: { istio.io/dry-run: "true" }
+spec:
+  targetRefs: [{ group: "", kind: Service, name: trip-service }]
+  action: ALLOW
+  rules:
+    - from: [{ source: { principals: ["cluster.local/ns/drova/sa/api-gateway"] } }]
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: driver-service-authz
+  namespace: drova
+  annotations: { istio.io/dry-run: "true" }
+spec:
+  targetRefs: [{ group: "", kind: Service, name: driver-service }]
+  action: ALLOW
+  rules:
+    - from: [{ source: { principals: ["cluster.local/ns/drova/sa/api-gateway"] } }]
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: user-service-authz
+  namespace: drova
+  annotations: { istio.io/dry-run: "true" }
+spec:
+  targetRefs: [{ group: "", kind: Service, name: user-service }]
+  action: ALLOW
+  rules:
+    - from: [{ source: { principals: ["cluster.local/ns/drova/sa/api-gateway", "cluster.local/ns/drova/sa/trip-service"] } }]
+---
+# payment-service: KEIN legitimer In-Mesh-Caller (rein Kafka-getrieben; 8h-Flow-
+# Matrix zeigte nur Probes). Leere rules = deny-all am Waypoint.
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: payment-service-authz
+  namespace: drova
+  annotations: { istio.io/dry-run: "true" }
+spec:
+  targetRefs: [{ group: "", kind: Service, name: payment-service }]
+  action: ALLOW
+  rules: []


### PR DESCRIPTION
Per-Service AuthorizationPolicies am Waypoint (targetRefs: Service) — Phase 1 im **istio.io/dry-run** (Shadow, blockt nichts): trip/driver ← api-gateway · user ← api-gateway+trip · payment ← niemand (kafka-only). Ingress-facing bewusst ungepoliced (gateway-ns nicht im Mesh). Flip nach Shadow-Auswertung = Annotation false + waypoint-allow-known raus. Voraussetzung (eigene SAs) seit gestern live; Ambient-Capture heute per Experiment bestätigt (amb-probe → SPIFFE-Identität via Waypoint).