### PR TITLE
fix: l7 kustomize indent

### DIFF
--- a/kubernetes/tenants/drova/kustomization.yaml
+++ b/kubernetes/tenants/drova/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 namespace: drova
 
 resources:
-  - l7-authz.yaml
+- l7-authz.yaml
 - namespace.yaml
 - resourcequota.yaml
 - limitrange.yaml


### PR DESCRIPTION
#544 fügte l7-authz.yaml mit falscher Einrückung ein (2-space in 0-indent-Liste) → kustomize-Build der tenants/drova-App brach. Repariert, Render verifiziert (inkl. der 4 neuen + waypoint-authz AuthorizationPolicies).