### PR TITLE
istio pilot.cni.enabled — prereq fuer sidecar STRICT-mTLS

### DIFF
--- a/kubernetes/infrastructure/network/istio-control-plane/istio-control-plane.yaml
+++ b/kubernetes/infrastructure/network/istio-control-plane/istio-control-plane.yaml
@@ -20,6 +20,14 @@ spec:
       network: network1
 
     pilot:
+      # cni.enabled: Sidecar-Injection nutzt die (schon für Ambient installierte)
+      # istio-cni statt eines istio-init-Containers mit NET_ADMIN/NET_RAW.
+      # OHNE das: Sidecar-Pods scheitern an PodSecurity (baseline/restricted).
+      # Prerequisite fuer STRICT-mTLS via Sidecar-Mode (Ambient-STRICT ist am
+      # Cilium-kubeProxyReplacement-Bug blockiert). Betrifft NUR Namespaces mit
+      # istio-injection=enabled — Ambient (drova) unberuehrt.
+      cni:
+        enabled: true
       resources:
         limits:
           cpu: 500m


### PR DESCRIPTION
Prerequisite fuer STRICT-mTLS via Istio Sidecar-Mode (Ambient-STRICT ist am Cilium-kubeProxyReplacement-Bug blockiert, istio#57911/cilium#36022 beide OPEN).

**Was:** `pilot.cni.enabled: true` im sail-operator Istio-CR. Sidecar-Injection nutzt dann die schon fuer Ambient installierte istio-cni statt eines istio-init-Containers mit NET_ADMIN/NET_RAW (den PodSecurity baseline/restricted blockt — verifiziert 2026-07-22 im Wegwerf-NS).

**Blast-Radius:** betrifft NUR Namespaces mit istio-injection=enabled. AKTUELL hat KEIN NS das Label → kein laufender Workload betroffen. Ambient (drova, via dataplane-mode=ambient) nutzt die Sidecar-Injection-Template NICHT → unberuehrt.

**server-dry-run:** valide gegen sailoperator.io CRD.

**Danach (separate Schritte, NICHT in dieser PR):**
1. diese PR mergen + apply → verify istiod/ztunnel/drova bleiben Healthy
2. Wegwerf-NS `istio-injection=enabled` + Test-App mit httpGet-Probes + STRICT-PeerAuth → 5min Probes beobachten (ZERO-Risk, drova unberuehrt)
3. gruen → drova ambient→sidecar migrieren (~3.3GB RAM), STRICT scharf = Tenet 2 erfuellt