### PR TITLE
park cruise control marker in kafka CR

### DIFF
--- a/kubernetes/tenants/drova/kafka/base/kafka-cluster.yaml
+++ b/kubernetes/tenants/drova/kafka/base/kafka-cluster.yaml
@@ -254,3 +254,21 @@ spec:
         limits:
           memory: "512Mi"
           cpu: "250m"
+
+  # ── GEPARKT: Cruise Control (Auto-Balancer) ────────────────────────────────
+  # NICHT deployed — bei EINEM Broker gibt es nichts zwischen Brokern zu
+  # balancieren. Erst sinnvoll wenn broker-NodePool wieder auf 3 (prod: 3,
+  # aktuell RAM-Diät auf 1). Dann uncommenten → Strimzi startet Cruise Control,
+  # Rebalancing via `KafkaRebalance`-CR (Vorschlag → approve → ausführen).
+  # cruiseControl:
+  #   resources:
+  #     requests: { cpu: "100m", memory: "512Mi" }
+  #     limits:   { memory: "1Gi" }
+  #   template:
+  #     pod:
+  #       securityContext:
+  #         runAsNonRoot: true
+  #         runAsUser: 1000
+  #         fsGroup: 1000
+  #         seccompProfile:
+  #           type: RuntimeDefault


### PR DESCRIPTION
Auskommentierter cruiseControl-Block im drova-kafka Kafka-CR als sichtbarer geparkt-Marker (euer Muster wie tenants/oms/ oder opencost.disabled/).

Warum geparkt: bei 1 Broker (RAM-Diaet, prod: 3) gibt es nichts zwischen Brokern zu balancieren. Bei broker-NodePool zurueck auf 3 → uncommenten, Strimzi startet Cruise Control, Rebalancing via KafkaRebalance-CR.

Inert: kustomize build gruen, Cruise Control NICHT aktiv (reiner Kommentar).