### PR TITLE
feat: sealed-secrets alerts

### DIFF
--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - cert-manager.yaml
   - operators.yaml
   - renovate.yaml
+  - sealed-secrets.yaml

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/sealed-secrets.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/sealed-secrets.yaml
@@ -1,0 +1,51 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: platform-sealed-secrets
+  labels:
+    release: kube-prometheus-stack
+spec:
+  # Keys are static by design (--key-renew-period 0, bootstrap pattern for cluster
+  # rebuilds) → cert expiry is a known constant, no x509-exporter needed.
+  # 2100123401 = notAfter of the 2026 key (Jul 19 2036, tofu/bootstrap/sealed-secrets).
+  # Update the timestamp on rotation. The 2025 key expired unnoticed for two months:
+  # kubeseal silently loses encryption while decryption keeps working.
+  groups:
+    - name: sealed-secrets-ticket
+      interval: 5m
+      rules:
+        - alert: SealedSecretsCertExpiresIn60Days
+          expr: vector(2100123401) - time() < 60 * 24 * 3600
+          for: 12h
+          labels:
+            severity: warning
+            component: platform
+            priority: P2
+          annotations:
+            summary: "sealed-secrets encryption cert expires in <60d"
+            description: "kubeseal loses encryption at expiry while decryption keeps working — exactly how the 2026 expiry went unnoticed for two months."
+            action: "Generate a fresh 10y keypair, add it as additional active bootstrap key (tofu/bootstrap/sealed-secrets), restart the controller, re-encrypt, then update this alert's timestamp."
+        - alert: SealedSecretNotSynced
+          expr: sealed_secrets_controller_condition_info{condition="Synced"} == 0
+          for: 15m
+          labels:
+            severity: warning
+            component: platform
+            priority: P2
+          annotations:
+            summary: "SealedSecret {{ $labels.exported_namespace }}/{{ $labels.name }} fails to unseal"
+            description: "Controller cannot decrypt or apply this SealedSecret — commonly a blob sealed with a key no longer in the ring (pre-rebuild leftovers: tailscale oauth, infisical) or metadata mismatch."
+            action: "kubectl -n sealed-secrets logs deploy/sealed-secrets-controller | grep {{ $labels.name }}; if 'no key could decrypt', re-seal the file with real values using the current cert."
+    - name: sealed-secrets-page
+      interval: 5m
+      rules:
+        - alert: SealedSecretsCertExpiresIn14Days
+          expr: vector(2100123401) - time() < 14 * 24 * 3600
+          for: 1h
+          labels:
+            severity: critical
+            component: platform
+          annotations:
+            summary: "sealed-secrets encryption cert expires in <14d — rotation overdue"
+            description: "After expiry no new secret can be sealed anywhere in the cluster. The 60d warning has been ignored for 46 days."
+            action: "Rotate now: fresh keypair as additional active bootstrap key, controller restart, re-encrypt, update this alert's timestamp."


### PR DESCRIPTION
Lehre aus dem Zert-Ablauf (2 Monate unbemerkt): 60d-Warnung + 14d-Critical vor Key-Expiry (statischer Timestamp — Keys sind by design statisch, kein x509-Exporter/Secret-Read-RBAC nötig) + SealedSecretNotSynced auf der live condition_info-Metrik (fängt tote Alt-Key-Blobs beim Deploy). Render 40 Rules ✓, Server-Dry-Run ✓.