### PR TITLE
re-enable tetragon runtime security

### DIFF
--- a/kubernetes/security/compliance/kustomization.yaml
+++ b/kubernetes/security/compliance/kustomization.yaml
@@ -7,5 +7,5 @@ resources:
   - kyverno-policies.yaml
   # - scheduling-policies.yaml   # parked 2026-07-10: enforce-governance zu viel Reibung fuer solo-ops (blockte istio-cni)
   # - kubescape   # disabled 2026-05-18 — OOMKill-loop on worker-1
-  # - tetragon   # parked 2026-07-10: 7x460Mi=3.2GB RAM; tracefs-mount-fix bleibt in values
+  - tetragon   # re-enabled 2026-07-23: tracefs-mount-fix in values, setuid-hook entfernt, RAM da
   # - honeytoken   # parked mit tetragon (Canary braucht Tetragon als Detektor)


### PR DESCRIPTION
Aktiviert Tetragon wieder (2026-07-10 fuer 3.2GB RAM waehrend Istio-Migration geparkt).

**Alle Disaster-Ursachen verifiziert gefixt:**
- tracefs-Mount /sys/kernel/tracing IST in values.yaml (extraHostPathMounts) — der Fix gegen das 4-Node-NotReady-Disaster 2026-05-13
- setuid-Syscall-Hook ENTFERNT (tracingpolicy-essentials.yaml: nur 2 sichere LSM-Hooks file/process)
- RAM da (Nodes 31-62%, ~460Mi/Node)
- one-node verifiziert auf worker-3 (2026-06-08)

**⚠️ Deploy = 6-Node-DaemonSet mit Kernel-eBPF (security-compliance ist AUTO-sync).**
Nach Merge: SOFORT alle Nodes auf Ready watchen — falls ein Node NotReady flappt, PR revert (Git). honeytoken bleibt geparkt (separater Canary-Detektor).

kustomize build --enable-helm gruen.