### PR TITLE
document ES single-node diet (prod markers)

### DIFF
--- a/kubernetes/infrastructure/observability/elasticsearch/base/cluster/elasticsearch-cluster.yaml
+++ b/kubernetes/infrastructure/observability/elasticsearch/base/cluster/elasticsearch-cluster.yaml
@@ -24,18 +24,24 @@ spec:
     fileRealm:
       - secretName: production-cluster-multi-filerealm
 
-  # 3-node cluster for proper replica allocation, green health, HA.
-  # Quorum=3 prevents split-brain. 2 nodes is INSUFFICIENT (split-brain risk).
-  # Upgrade from count=1 to count=3 (battle-tested 2026-05-14):
-  # - PVCs are reclaimPolicy=Retain → existing master-data-0 PV preserved
-  # - ECK adds master-data-1, master-data-2 sequentially (rolling)
-  # - cluster transitions yellow→green once replicas allocated
-  # - downstream consumers (jaeger, vector, loki) reconnect automatically
+  # ── SINGLE-NODE = BEWUSSTE RAM-DIÄT (kein Mangel!) ──────────────────────────
+  # Aktuell 1 Node mit kombinierter Rolle "dim" (data+ingest+master). Replicas
+  # nutzlos (kein 2. Node) → single-node-tuning.yaml forced replicas=0 → GREEN.
+  #
+  # PROD-Endstand (auskommentiert = geparkter Zielzustand, wie Kafka # prod:):
+  #   - count: 3  → Quorum=3 (kein Split-Brain; 2 wäre unsicher)
+  #   - dedizierte Master (3) + separate Data-Tiers (data_hot NVMe / data_warm
+  #     HDD / data_cold) → Enterprise-Hot-Warm-Cold, 60-80% Storage-Ersparnis
+  #   - Upgrade battle-tested 2026-05-14: PVCs reclaimPolicy=Retain → master-data-0
+  #     PV bleibt, ECK rollt master-data-1/2 sequenziell, yellow→green automatisch,
+  #     Consumer (jaeger/vector/loki) reconnecten selbst.
+  #   Aktivierung erst bei mehr RAM/Nodes — Hot-Warm-Cold lohnt ab TB-Volumen.
   nodeSets:
     - name: master-data
-      count: 1
+      count: 1  # prod: 3
       config:
-        # Master + Data + Ingest roles
+        # Rolle "dim" = master+data+ingest kombiniert (single-node).
+        # prod: in 3 dedizierte Master + data_hot/warm/cold-NodeSets aufsplitten.
         node.roles: ["master", "data", "ingest"]
         # CRITICAL FIX: Allow ALL indices for logging pipeline
         action.auto_create_index: "true"
@@ -92,9 +98,9 @@ spec:
                 - -c
                 - |
                   bin/elasticsearch-plugin install --batch repository-s3
-          # HOMELAB SPECS: 3-node cluster on large nodes (worker-1/2/3)
-          # Memory: 3GB per node, Heap: 1.5GB (50%), CPU: 500m-1500m
-          # Total: 9GB RAM for ES cluster
+          # HOMELAB SPECS (single-node Diät): 1 Node · 2Gi limit · Heap 1g (50%).
+          # prod: 3 Nodes × je (data_hot mehr Heap/NVMe · warm/cold weniger) —
+          #       Loki trägt den Log-Grossteil, ES nur SIEM-relevantes (Allowlist).
           containers:
             - name: elasticsearch
               # Single-node homelab sizing (Kafka pattern: heap+overhead < limit)


### PR DESCRIPTION
Macht die ES-CR-Kommentare akkurat: waren STALE (beschrieben '3-node cluster / Total 9GB' obwohl count:1 laeuft).

Jetzt klar dokumentiert (Kafka # prod:-Muster):
- count: 1  # prod: 3  (Quorum, kein Split-Brain)
- Rolle 'dim' (kombiniert) → prod: dedizierte Master + data_hot/warm/cold-Tiers (Hot-Warm-Cold, 60-80% Storage-Ersparnis)
- Single-Node = bewusste RAM-Diaet, replicas=0 forced → GREEN

Reiner Kommentar/Doku — KEINE Verhaltensaenderung. kustomize build gruen.