### PR TITLE
fix alert noise

### DIFF
--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/cert-manager.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/cert-manager.yaml
@@ -29,18 +29,23 @@ spec:
     - name: cert-manager-ticket
       interval: 5m
       rules:
-        - alert: CertExpiringIn30Days
-          expr: certmanager_certificate_expiration_timestamp_seconds - time() < 30 * 24 * 3600
-          for: 12h
+        - alert: CertRenewalStuck
+          # cert-manager auto-renews at renewalTime (~2/3 of lifetime). Fire only when that time
+          # has passed and the cert still isn't renewed — i.e. renewal is genuinely stuck (Issuer
+          # down, ACME failing). The old "expires <30d" alert just spammed during the normal
+          # renew window (cert-manager renewBefore < 30d), never actionable. CertExpiringIn7Days
+          # stays as the hard expiry backstop.
+          expr: certmanager_certificate_renewal_timestamp_seconds - time() < 0
+          for: 1h
           labels:
             severity: warning
             component: platform
             priority: P2
           annotations:
             dashboard_url: "/d/cert-manager"
-            summary: "TLS cert expires in <30d: {{ $labels.name }}"
-            description: "Renewal should happen automatically — verify cert-manager is healthy."
-            action: "Renewal is automatic — verify cert-manager pods healthy + the (Cluster)Issuer is Ready."
+            summary: "cert-manager renewal overdue: {{ $labels.name }}"
+            description: "Renewal time passed >1h ago but {{ $labels.name }} in {{ $labels.namespace }} still isn't renewed — cert-manager isn't handling it."
+            action: "kubectl describe certificate {{ $labels.name }} -n {{ $labels.namespace }}; check the Issuer is Ready + cert-manager logs."
 
         - alert: CertManagerDown
           expr: up{job="cert-manager"} == 0

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/rook-ceph.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/storage/rook-ceph.yaml
@@ -114,7 +114,7 @@ spec:
           annotations:
             dashboard_url: "/d/ceph-cluster"
             summary: "Ceph BlueStore slow operations on OSDs"
-            description: "Slow-ops sustained >15min — OSDs can't keep up (usually consumer-SSD write pressure, e.g. msa2 Crucial running 3 OSDs). Degraded, not failure."
+            description: "Slow-ops sustained >15min — one or more OSDs can't keep up (SSD write pressure; often a node whose few OSDs carry a full replica plus a co-located etcd/VM disk). Degraded, not failure — check 'ceph health detail' for which OSDs."
             action: "Toolbox: 'ceph health detail' (which OSDs) + 'ceph osd perf' (latency); check disk SMART + the heaviest write-load on that node."
 
         - alert: CephMonClockSkew

--- a/kubernetes/platform/gitops/renovate/base/orphan-pr-opener.yaml
+++ b/kubernetes/platform/gitops/renovate/base/orphan-pr-opener.yaml
@@ -26,6 +26,7 @@ spec:
   jobTemplate:
     spec:
       ttlSecondsAfterFinished: 600
+      activeDeadlineSeconds: 600
       backoffLimit: 1
       template:
         spec:
@@ -69,7 +70,7 @@ spec:
                     req = urllib.request.Request(url, data=data, headers=HEADERS, method=method)
                     if data: req.add_header("Content-Type", "application/json")
                     try:
-                      with urllib.request.urlopen(req) as r:
+                      with urllib.request.urlopen(req, timeout=30) as r:
                         return json.loads(r.read())
                     except urllib.error.HTTPError as e:
                       print(f"  ERR {method} {path}: {e.code} {e.reason}", flush=True)


### PR DESCRIPTION
renovate orphan-job hing (urlopen ohne timeout) → timeout + activeDeadlineSeconds. cert-alert von 30d-expiry-spam auf renewal-overdue umgebaut. ceph slow-ops text war falsch (msa2 → wandert, live nipogi osd.2/4).