### PR TITLE
allow tracingpolicy in security project

### DIFF
--- a/kubernetes/projects/security.yaml
+++ b/kubernetes/projects/security.yaml
@@ -71,6 +71,8 @@ spec:
       kind: ClusterRoleBinding
     - group: kyverno.io
       kind: '*'
+    - group: cilium.io
+      kind: TracingPolicy
 
   namespaceResourceWhitelist:
     - group: '*'


### PR DESCRIPTION
tetragon TracingPolicy-CRs waren nicht in der security-AppProject-Whitelist → security-compliance SyncFailed. eine Zeile.