### PR TITLE
chore(deps): update cloudflare-cloudflared to v2026.7 - autoclosed

### DIFF
--- a/kubernetes/infrastructure/ingress/cloudflared/base/daemon-set.yaml
+++ b/kubernetes/infrastructure/ingress/cloudflared/base/daemon-set.yaml
@@ -21,7 +21,7 @@ spec:
         fsGroup: 65532
       containers:
         - name: cloudflared
-          image: cloudflare/cloudflared:2026.7.2@sha256:4f6655284ab3d252b7f28fedb19fe6c8fc82ee5b1295c20ac74d475e5398a52d
+          image: cloudflare/cloudflared:2026.7.3@sha256:e39ee8da81ad5e05d77f38d2f51c60ca51bf2a8450ac3abab50c17fdb91d91bf
           securityContext:
             runAsNonRoot: true
             runAsUser: 65532


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/cloudflare-cloudflared-2026.7.x`
Filter passed: <24h old, <5 commits ahead.