### PR TITLE
chore(deps): update plugin-barman-cloud to v0.7 - autoclosed

### DIFF
--- a/kubernetes/infrastructure/operators/cloudnative-pg/base/kustomization.yaml
+++ b/kubernetes/infrastructure/operators/cloudnative-pg/base/kustomization.yaml
@@ -14,7 +14,7 @@ helmCharts:
 
   - name: plugin-barman-cloud
     repo: https://cloudnative-pg.github.io/charts
-    version: "0.7.0"
+    version: "0.7.1"
     releaseName: cnpg-plugin-barman-cloud
     namespace: cnpg-system
     includeCRDs: true


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/plugin-barman-cloud-0.7.x`
Filter passed: <24h old, <5 commits ahead.