### PR TITLE
fix repo-server spof + add restart alert

### DIFF
--- a/.github/tests/alerts/argocd_appset_test.yaml
+++ b/.github/tests/alerts/argocd_appset_test.yaml
@@ -87,3 +87,34 @@ tests:
       - eval_time: 40m
         alertname: ArgoCDAppsMassDeletion
         exp_alerts: []
+
+  # ── ArgoCDRepoServerRestartsHigh: FIRES — 3 Restarts in 15min (2026-08-02-Vorfall) ──
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_container_status_restarts_total{namespace="argocd", pod="argocd-repo-server-abc"}'
+        values: '0 0 0 1 1 1 1 1 2 2 2 3 3 3 3 3 3 3 3 3'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: ArgoCDRepoServerRestartsHigh
+        exp_alerts:
+          - exp_labels:
+              namespace: argocd
+              pod: argocd-repo-server-abc
+              severity: warning
+              component: platform
+              priority: P2
+            exp_annotations:
+              dashboard_url: "/d/argocd-overview"
+              summary: "argocd-repo-server restartet ungewöhnlich oft (argocd-repo-server-abc)"
+              description: "Der lokale git-Cache liegt auf emptyDir — ein Restart mitten im Schreiben kann ihn korrumpieren ('index file smaller than expected') und ArgoCD für alle Apps blind für Drift machen, ohne dass es sonst auffällt."
+              action: "kubectl get applications -n argocd -o json | jq -r '.items[] | select(.status.conditions[]?.type==\"ComparisonError\") | .metadata.name'; bei Treffern: kubectl rollout restart deployment/argocd-repo-server -n argocd (emptyDir-Cache wird dabei frisch geklont)."
+
+  # ── ArgoCDRepoServerRestartsHigh: NICHT bei nur 1 normalem Restart ──
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_container_status_restarts_total{namespace="argocd", pod="argocd-repo-server-abc"}'
+        values: '0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: ArgoCDRepoServerRestartsHigh
+        exp_alerts: []

--- a/.github/tests/alerts/argocd_appset_test.yaml
+++ b/.github/tests/alerts/argocd_appset_test.yaml
@@ -88,13 +88,17 @@ tests:
         alertname: ArgoCDAppsMassDeletion
         exp_alerts: []
 
-  # ── ArgoCDRepoServerRestartsHigh: FIRES — 3 Restarts in 15min (2026-08-02-Vorfall) ──
+  # ── ArgoCDRepoServerRestartsHigh: FIRES — 5 Restarts in 15min (2026-08-02-Vorfall) ──
+  # Sprung 0->5 bei t=3m, danach flach gehalten bis t=24m (weit über eval_time hinaus —
+  # NIE am Rand der Testdaten auswerten, promtool 2.x extrapoliert an der Kante anders
+  # als 3.x, s. Session-Fund). eval_time=15m liegt mittig im Fenster [3+5m, 3+15m]=[8,18],
+  # also lange genug im "for: 5m" drin UND weit weg vom Datenrand.
   - interval: 1m
     input_series:
       - series: 'kube_pod_container_status_restarts_total{namespace="argocd", pod="argocd-repo-server-abc"}'
-        values: '0 0 0 1 1 1 1 1 2 2 2 3 3 3 3 3 3 3 3 3'
+        values: '0 0 0 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5'
     alert_rule_test:
-      - eval_time: 20m
+      - eval_time: 15m
         alertname: ArgoCDRepoServerRestartsHigh
         exp_alerts:
           - exp_labels:
@@ -113,8 +117,8 @@ tests:
   - interval: 1m
     input_series:
       - series: 'kube_pod_container_status_restarts_total{namespace="argocd", pod="argocd-repo-server-abc"}'
-        values: '0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1'
+        values: '0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
     alert_rule_test:
-      - eval_time: 20m
+      - eval_time: 15m
         alertname: ArgoCDRepoServerRestartsHigh
         exp_alerts: []

--- a/kubernetes/infrastructure/argocd/base/values.yaml
+++ b/kubernetes/infrastructure/argocd/base/values.yaml
@@ -937,6 +937,18 @@ repoServer:
         - mountPath: /tmp
           name: cmp-tmp
   # Also avoid i5 server nodes
+  # NOTE 2026-08-02: "work-00"/"work-02" matchen KEINEN aktuellen Node-Namen
+  # (Cluster heißt ctrl-0/worker-1..5) — vermutlich stiller Rest von vor einer
+  # Node-Umbenennung, aktuell ein No-Op. Absichtlich unangetastet gelassen (Scope).
+  #
+  # podAntiAffinity NEU (2026-08-02): beide repo-server-Replicas liefen auf
+  # DEMSELBEN Node (worker-4) — der PDB (oben) schützt nur vor freiwilligen
+  # Drains, nicht davor, dass ein Node-Event BEIDE Pods gleichzeitig killt. Genau
+  # das passierte: beide restarteten zeitgleich, der lokale git-Cache (emptyDir)
+  # wurde dabei korrupt ("index file smaller than expected") -> ComparisonError
+  # auf 70/73 Apps, ArgoCD blind für Drift, bis manuell entdeckt. "preferred"
+  # statt "required": bei nur 5 Workern soll ein Node-Ausfall nicht 1 Replica
+  # unschedulable machen — im Normalfall verteilt der Scheduler sie jetzt trotzdem.
   affinity:
     nodeAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -948,6 +960,14 @@ repoServer:
                 values:
                   - work-00
                   - work-02
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: argocd-repo-server
+            topologyKey: kubernetes.io/hostname
 
 applicationSet:
 

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/argocd.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/platform/argocd.yaml
@@ -13,6 +13,30 @@ spec:
     - name: argocd-ticket
       interval: 60s
       rules:
+        # 2026-08-02: beide repo-server-Replicas restarteten zeitgleich (co-located auf
+        # 1 Node, kein CrashLoopBackOff — "Completed, exit 0", also von der generischen
+        # PodCrashLooping-Rule NICHT erfasst). Der lokale git-Cache (emptyDir) wurde dabei
+        # korrupt ("index file smaller than expected") -> ComparisonError auf 70/73 Apps,
+        # ArgoCD blind für Drift, bis manuell entdeckt. Geprüft + verworfen: sync_status
+        # bleibt auf dem letzten guten Wert eingefroren (reagiert NICHT auf ComparisonError,
+        # empirisch belegt) und argocd_git_fetch_fail_total hatte während des Vorfalls gar
+        # keine Serie (dieser Fehlertyp zählt intern nicht als "fetch fail"). Also: Restarts
+        # direkt beobachten, nicht auf eine ArgoCD-Metrik hoffen, die für DIESEN Fehler nicht
+        # reagiert. Strukturell verhindert die neue podAntiAffinity (values.yaml) die
+        # Ursache (gleichzeitiger Verlust beider Caches); dieser Alert ist die Absicherung.
+        - alert: ArgoCDRepoServerRestartsHigh
+          expr: increase(kube_pod_container_status_restarts_total{namespace="argocd", pod=~"argocd-repo-server-.*"}[15m]) > 2
+          for: 5m
+          labels:
+            severity: warning
+            component: platform
+            priority: P2
+          annotations:
+            dashboard_url: "/d/argocd-overview"
+            summary: "argocd-repo-server restartet ungewöhnlich oft ({{ $labels.pod }})"
+            description: "Der lokale git-Cache liegt auf emptyDir — ein Restart mitten im Schreiben kann ihn korrumpieren ('index file smaller than expected') und ArgoCD für alle Apps blind für Drift machen, ohne dass es sonst auffällt."
+            action: "kubectl get applications -n argocd -o json | jq -r '.items[] | select(.status.conditions[]?.type==\"ComparisonError\") | .metadata.name'; bei Treffern: kubectl rollout restart deployment/argocd-repo-server -n argocd (emptyDir-Cache wird dabei frisch geklont)."
+
         - alert: ArgoCDControllerDown
           expr: up{job="argocd-application-controller"} == 0
           for: 5m


### PR DESCRIPTION
ComparisonError auf 70/73 Apps heute morgen — repo-server-Cache (emptyDir) korrupt nach zeitgleichem Restart beider Replicas auf demselben Node (worker-4). Sofort-Fix live durchgeführt (rollout restart), 0/73 Apps jetzt fehlerhaft.

- podAntiAffinity für argocd-repo-server (soft, verteilt beide Replicas über Nodes)
- neuer Alert ArgoCDRepoServerRestartsHigh (>2 Restarts/15min) — geprüft und verworfen: argocd-eigene Metriken (sync_status, git_fetch_fail_total) reagieren empirisch NICHT auf diesen Fehlertyp
- promtool-Unit-Test (Fire + Negativ)