### PR TITLE
chore(deps): update keda to v2.20 - autoclosed

### DIFF
--- a/kubernetes/infrastructure/operators/keda/base/kustomization.yaml
+++ b/kubernetes/infrastructure/operators/keda/base/kustomization.yaml
@@ -9,7 +9,7 @@ helmCharts:
   # Kafka consumers on consumer-group lag via the Prometheus scaler.
   - name: keda
     repo: https://kedacore.github.io/charts
-    version: "2.20.1"
+    version: "2.20.2"
     releaseName: keda
     namespace: keda
     includeCRDs: true


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/keda-2.20.x`
Filter passed: <24h old, <5 commits ahead.