### PR TITLE
homepage dashboard + uptime-kuma

### DIFF
--- a/kubernetes/applicationsets/apps/apps-stack.yaml
+++ b/kubernetes/applicationsets/apps/apps-stack.yaml
@@ -26,7 +26,8 @@ spec:
                   environment: prod
           - list:
               elements:
-                - { component: audiobookshelf, appName: audiobookshelf, path: kubernetes/apps/audiobookshelf/overlays/prod,        namespace: audiobookshelf-prod, wave: "60" }
+                # audiobookshelf: geparkt 2026-08-04, ungenutzt
+                # - { component: audiobookshelf, appName: audiobookshelf, path: kubernetes/apps/audiobookshelf/overlays/prod,        namespace: audiobookshelf-prod, wave: "60" }
                 - { component: cloudbeaver,    appName: cloudbeaver,    path: kubernetes/apps/cloudbeaver/overlays/prod,           namespace: cloudbeaver,         wave: "60" }
   template:
     metadata:

--- a/kubernetes/applicationsets/apps/apps-stack.yaml
+++ b/kubernetes/applicationsets/apps/apps-stack.yaml
@@ -29,6 +29,7 @@ spec:
                 # audiobookshelf: geparkt 2026-08-04, ungenutzt
                 # - { component: audiobookshelf, appName: audiobookshelf, path: kubernetes/apps/audiobookshelf/overlays/prod,        namespace: audiobookshelf-prod, wave: "60" }
                 - { component: cloudbeaver,    appName: cloudbeaver,    path: kubernetes/apps/cloudbeaver/overlays/prod,           namespace: cloudbeaver,         wave: "60" }
+                - { component: uptime-kuma,    appName: uptime-kuma,    path: kubernetes/apps/uptime-kuma/overlays/prod,           namespace: uptime-kuma,         wave: "60" }
   template:
     metadata:
       name: '{{.appName}}'

--- a/kubernetes/applicationsets/infrastructure/observability-stack.yaml
+++ b/kubernetes/applicationsets/infrastructure/observability-stack.yaml
@@ -33,7 +33,8 @@ spec:
                 - { component: prometheus,             appName: kube-prometheus-stack-in-cluster, path: kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod, namespace: monitoring,   wave: "40" }
                 - { component: metrics-server,         appName: metrics-server,                   path: kubernetes/infrastructure/observability/metrics-server/overlays/prod,         namespace: kube-system,  wave: "0" }
                 - { component: blackbox-exporter,      appName: blackbox-exporter,                path: kubernetes/infrastructure/observability/blackbox-exporter/overlays/prod,      namespace: monitoring,   wave: "70" }
-                - { component: gatus,                  appName: gatus,                            path: kubernetes/infrastructure/observability/gatus/overlays/prod,                  namespace: monitoring,   wave: "70" }
+                # gatus: ersetzt durch uptime-kuma 2026-08-04
+                # - { component: gatus,                  appName: gatus,                            path: kubernetes/infrastructure/observability/gatus/overlays/prod,                  namespace: monitoring,   wave: "70" }
                 - { component: pve-exporter,           appName: pve-exporter,                     path: kubernetes/infrastructure/observability/pve-exporter/overlays/prod,           namespace: monitoring,   wave: "70" }
                 - { component: netbird-exporter,       appName: netbird-exporter,                 path: kubernetes/infrastructure/observability/netbird-exporter/overlays/prod,       namespace: monitoring,   wave: "70" }
                 - { component: kiali,                  appName: kiali,                            path: kubernetes/infrastructure/observability/dashboards/kiali,                     namespace: istio-system, wave: "70" }

--- a/kubernetes/applicationsets/infrastructure/observability-stack.yaml
+++ b/kubernetes/applicationsets/infrastructure/observability-stack.yaml
@@ -52,6 +52,7 @@ spec:
                 #  grafana/base/custom-dashboards/: ein Ort, ein Namespace)
                 - { component: grafana,                appName: grafana,                          path: kubernetes/infrastructure/observability/dashboards/grafana/overlays/prod,            namespace: grafana,      wave: "40" }
                 - { component: hubble,                 appName: hubble,                           path: kubernetes/infrastructure/observability/dashboards/hubble/overlays/prod,             namespace: kube-system,  wave: "70" }
+                - { component: homepage,               appName: homepage,                         path: kubernetes/infrastructure/observability/dashboards/homepage/overlays/prod,           namespace: homepage,     wave: "70" }
                 # ALERTING — PrometheusRules @ 70 (Prom CRDs available since wave 40)
                 - { component: infrastructure-alerts,  appName: infrastructure-alerts,            path: kubernetes/infrastructure/observability/alerting/alerts/overlays/prod,               namespace: monitoring,   wave: "70" }
   template:

--- a/kubernetes/applicationsets/platform/ml-stack.yaml
+++ b/kubernetes/applicationsets/platform/ml-stack.yaml
@@ -23,8 +23,9 @@ spec:
                   argocd.argoproj.io/secret-type: cluster
                   environment: prod
           - list:
-              elements:
-                - { component: mlflow, appName: mlflow, namespace: ml, wave: "20" }
+              elements: []
+                # mlflow: geparkt 2026-08-04, kein aktives ML-Modell/Pipeline
+                # - { component: mlflow, appName: mlflow, namespace: ml, wave: "20" }
   template:
     metadata:
       name: '{{.appName}}'

--- a/kubernetes/apps/uptime-kuma/base/backend-traffic-policy.yaml
+++ b/kubernetes/apps/uptime-kuma/base/backend-traffic-policy.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: uptime-kuma-websocket-policy
+  namespace: uptime-kuma
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: uptime-kuma
+  timeout:
+    http:
+      connectionIdleTimeout: 3600s
+      maxConnectionDuration: 0s
+    tcp:
+      connectTimeout: 15s
+  connection:
+    bufferLimit: 32768

--- a/kubernetes/apps/uptime-kuma/base/deployment.yaml
+++ b/kubernetes/apps/uptime-kuma/base/deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: uptime-kuma
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: uptime-kuma
+  template:
+    metadata:
+      labels:
+        app: uptime-kuma
+    spec:
+      # louislam/uptime-kuma's docker-entrypoint.sh chown's /app/data → braucht
+      # root. Image ist nicht rootless-fähig (battle-tested 2026-05-14).
+      # PolicyException für require-run-as-non-root deckt das ab.
+      securityContext:
+        fsGroup: 0
+      containers:
+        - name: uptime-kuma
+          image: louislam/uptime-kuma:2.4.0@sha256:91e963bfda569ba115206e843febb446f473ab525add4e08b2b9e3beffa16985
+          ports:
+            - containerPort: 3001
+              name: http
+          env:
+            - name: UPTIME_KUMA_PORT
+              value: "3001"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3001
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3001
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
+          securityContext:
+            runAsUser: 0
+            runAsNonRoot: false
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - CHOWN
+                - FOWNER
+                - DAC_OVERRIDE
+                - SETUID
+                - SETGID
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: uptime-kuma-data

--- a/kubernetes/apps/uptime-kuma/base/httproute.yaml
+++ b/kubernetes/apps/uptime-kuma/base/httproute.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: uptime-kuma
+spec:
+  parentRefs:
+    - name: envoy-gateway
+      namespace: gateway
+      sectionName: https
+  hostnames:
+    - status.timourhomelab.org
+  rules:
+    - backendRefs:
+        - name: uptime-kuma
+          port: 3001

--- a/kubernetes/apps/uptime-kuma/base/httproute.yaml
+++ b/kubernetes/apps/uptime-kuma/base/httproute.yaml
@@ -2,6 +2,12 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: uptime-kuma
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Status Page
+    gethomepage.dev/description: 🔒 Uptime Monitoring (VPN-only via NetBird)
+    gethomepage.dev/group: Observability
+    gethomepage.dev/icon: uptime-kuma.png
 spec:
   parentRefs:
     - name: envoy-gateway

--- a/kubernetes/apps/uptime-kuma/base/kustomization.yaml
+++ b/kubernetes/apps/uptime-kuma/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml
+  - backend-traffic-policy.yaml
+  - policy-exception.yaml

--- a/kubernetes/apps/uptime-kuma/base/namespace.yaml
+++ b/kubernetes/apps/uptime-kuma/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: uptime-kuma

--- a/kubernetes/apps/uptime-kuma/base/policy-exception.yaml
+++ b/kubernetes/apps/uptime-kuma/base/policy-exception.yaml
@@ -1,0 +1,29 @@
+# PolicyException für UptimeKuma (battle-tested 2026-05-14).
+#
+# louislam/uptime-kuma image ist auf DockerHub (nicht in allowlist).
+# initContainer braucht root für chown /app/data (PVC-permissions).
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: uptime-kuma
+  namespace: uptime-kuma
+spec:
+  background: false
+  match:
+    any:
+      - resources:
+          kinds: [Pod, Deployment, ReplicaSet]
+          namespaces: [uptime-kuma]
+  exceptions:
+    - policyName: restrict-image-registries
+      ruleNames:
+        - check-image-registry
+        - autogen-check-image-registry
+    - policyName: require-run-as-non-root
+      ruleNames:
+        - check-run-as-non-root
+        - autogen-check-run-as-non-root
+    - policyName: disallow-capabilities
+      ruleNames:
+        - adding-capabilities
+        - autogen-adding-capabilities

--- a/kubernetes/apps/uptime-kuma/base/pvc.yaml
+++ b/kubernetes/apps/uptime-kuma/base/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: uptime-kuma-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: rook-ceph-block-enterprise-retain
+  resources:
+    requests:
+      storage: 2Gi

--- a/kubernetes/apps/uptime-kuma/base/service.yaml
+++ b/kubernetes/apps/uptime-kuma/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: uptime-kuma
+spec:
+  selector:
+    app: uptime-kuma
+  ports:
+    - port: 3001
+      targetPort: 3001
+      name: http

--- a/kubernetes/apps/uptime-kuma/overlays/prod/kustomization.yaml
+++ b/kubernetes/apps/uptime-kuma/overlays/prod/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: uptime-kuma
+resources:
+  - ../../base

--- a/kubernetes/infrastructure/argocd/base/httproute.yaml
+++ b/kubernetes/infrastructure/argocd/base/httproute.yaml
@@ -3,6 +3,12 @@ kind: HTTPRoute
 metadata:
   name: argocd
   namespace: argocd
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: ArgoCD
+    gethomepage.dev/description: 🔒 GitOps Continuous Delivery (VPN-only via NetBird)
+    gethomepage.dev/group: Platform
+    gethomepage.dev/icon: argo-cd.png
 spec:
   parentRefs:
     - name: envoy-gateway

--- a/kubernetes/infrastructure/ingress/gateway/base/waf/coraza-waf.yaml
+++ b/kubernetes/infrastructure/ingress/gateway/base/waf/coraza-waf.yaml
@@ -46,5 +46,7 @@ spec:
             # Aendern; 920420 blockt /rest/ph/ (text/plain). Verifiziert Envoy-Coraza-Log 2026-07-15.
             # n8n = public, haengt hinter Cloudflare-Edge-WAF + App-Login -> Engine fuer den Host aus.
             - 'SecRule REQUEST_HEADERS:Host "@streq n8n.timourhomelab.org" "id:1100015,phase:1,pass,nolog,ctl:ruleEngine=Off"'
+            # uptime-kuma: Socket.IO (polling+WS-upgrade) verträgt keine WASM-Inspektion; VPN-only Host
+            - 'SecRule REQUEST_HEADERS:Host "@streq status.timourhomelab.org" "id:1100016,phase:1,pass,nolog,ctl:ruleEngine=Off"'
             - "Include @owasp_crs/*.conf"
         default_directives: "default"

--- a/kubernetes/infrastructure/network/cilium/base/hubble-httproute.yaml
+++ b/kubernetes/infrastructure/network/cilium/base/hubble-httproute.yaml
@@ -4,6 +4,12 @@ kind: HTTPRoute
 metadata:
   name: hubble
   namespace: kube-system
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Hubble
+    gethomepage.dev/description: 🔒 Cilium Network Observability (VPN-only via NetBird)
+    gethomepage.dev/group: Observability
+    gethomepage.dev/icon: cilium.png
 spec:
   parentRefs:
     - name: envoy-gateway

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/http-route.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/http-route.yaml
@@ -3,6 +3,12 @@ kind: HTTPRoute
 metadata:
   name: grafana-envoy
   namespace: grafana
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Grafana
+    gethomepage.dev/description: 🔒 Dashboards & Metrics (VPN-only via NetBird)
+    gethomepage.dev/group: Observability
+    gethomepage.dev/icon: grafana.png
 spec:
   parentRefs:
     - group: gateway.networking.k8s.io

--- a/kubernetes/infrastructure/observability/dashboards/homepage/base/configmap.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/homepage/base/configmap.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: homepage
+  namespace: homepage
+  labels:
+    app.kubernetes.io/name: homepage
+data:
+  settings.yaml: |
+    title: homelab
+    theme: dark
+    color: slate
+    layout:
+      # icon: netbird.png markiert Gruppen, die nur via NetBird-VPN erreichbar sind
+      # (Beschreibungstext pro Kachel traegt zusaetzlich 🔒/🌍 — Homepage kann nur
+      # 1 Icon pro Kachel, aber pro GRUPPE, darum hier statt auf jeder einzelnen Karte).
+      Platform:
+        icon: netbird.png
+        style: row
+        columns: 2
+      Observability:
+        icon: netbird.png
+        style: row
+        columns: 3
+      Identity:
+        icon: netbird.png
+        style: row
+        columns: 2
+      Storage:
+        icon: netbird.png
+        style: row
+        columns: 2
+      Data:
+        icon: netbird.png
+        style: row
+        columns: 2
+      Apps:
+        style: row
+        columns: 2
+
+  kubernetes.yaml: |
+    mode: cluster
+    gateway: true
+
+  widgets.yaml: |
+    - kubernetes:
+        cluster:
+          show: true
+          cpu: true
+          memory: true
+          showLabel: true
+          label: "cluster"
+        nodes:
+          show: true
+          cpu: true
+          memory: true
+          showLabel: true
+    - datetime:
+        text_size: xl
+        format:
+          dateStyle: long
+          timeStyle: short
+          hourCycle: h23
+
+  # Auto-Discovery via gateway:true (kubernetes.yaml) liest die HTTPRoutes selbst —
+  # keine statisch gepflegte Liste noetig. Nur externe, nicht-K8s-Links kommen hier rein.
+  bookmarks.yaml: |
+    - Developer:
+        - GitHub Repo:
+            - icon: github.png
+              href: https://github.com/Tim275/talos-homelab
+
+  services.yaml: |
+    []
+
+  custom.css: ""
+  custom.js: ""

--- a/kubernetes/infrastructure/observability/dashboards/homepage/base/deployment.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/homepage/base/deployment.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: homepage
+  namespace: homepage
+  labels:
+    app.kubernetes.io/name: homepage
+  annotations:
+    argocd.argoproj.io/sync-wave: "60"
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: homepage
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: homepage
+    spec:
+      serviceAccountName: homepage
+      automountServiceAccountToken: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: homepage
+          image: ghcr.io/gethomepage/homepage:v1.13.2@sha256:a0b71c8e757298d02560186bab9fbe3fc2d375c523a62cc1019177b37e48aa28
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+            readOnlyRootFilesystem: false
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOMEPAGE_ALLOWED_HOSTS
+              value: "$(MY_POD_IP):3000,homepage.timourhomelab.org"
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /api/healthcheck
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /api/healthcheck
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 15
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+          volumeMounts:
+            - { mountPath: /app/config/custom.js, name: config, subPath: custom.js }
+            - { mountPath: /app/config/custom.css, name: config, subPath: custom.css }
+            - { mountPath: /app/config/bookmarks.yaml, name: config, subPath: bookmarks.yaml }
+            - { mountPath: /app/config/kubernetes.yaml, name: config, subPath: kubernetes.yaml }
+            - { mountPath: /app/config/services.yaml, name: config, subPath: services.yaml }
+            - { mountPath: /app/config/settings.yaml, name: config, subPath: settings.yaml }
+            - { mountPath: /app/config/widgets.yaml, name: config, subPath: widgets.yaml }
+            - { mountPath: /app/config/logs, name: logs }
+      volumes:
+        - name: config
+          configMap:
+            name: homepage
+        - name: logs
+          emptyDir: {}

--- a/kubernetes/infrastructure/observability/dashboards/homepage/base/httproute.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/homepage/base/httproute.yaml
@@ -1,0 +1,22 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: homepage
+  namespace: homepage
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Homepage
+    gethomepage.dev/description: This dashboard
+    gethomepage.dev/group: Platform
+    gethomepage.dev/icon: homepage.png
+spec:
+  hostnames:
+    - homepage.timourhomelab.org
+  parentRefs:
+    - name: envoy-gateway
+      namespace: gateway
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: homepage
+          port: 3000

--- a/kubernetes/infrastructure/observability/dashboards/homepage/base/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/homepage/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - rbac.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml

--- a/kubernetes/infrastructure/observability/dashboards/homepage/base/namespace.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/homepage/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homepage

--- a/kubernetes/infrastructure/observability/dashboards/homepage/base/rbac.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/homepage/base/rbac.yaml
@@ -1,0 +1,33 @@
+# Read-only, scoped to what homepage actually discovers/renders — no Ingress/Traefik
+# rules (unused, we run Gateway API only).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: homepage
+  labels:
+    app.kubernetes.io/name: homepage
+rules:
+  - apiGroups: [""]
+    resources: [namespaces, pods, nodes]
+    verbs: [get, list]
+  - apiGroups: [gateway.networking.k8s.io]
+    resources: [httproutes, gateways]
+    verbs: [get, list]
+  - apiGroups: [metrics.k8s.io]
+    resources: [nodes, pods]
+    verbs: [get, list]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: homepage
+  labels:
+    app.kubernetes.io/name: homepage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: homepage
+subjects:
+  - kind: ServiceAccount
+    name: homepage
+    namespace: homepage

--- a/kubernetes/infrastructure/observability/dashboards/homepage/base/service.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/homepage/base/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: homepage
+  namespace: homepage
+  labels:
+    app.kubernetes.io/name: homepage
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3000
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: homepage

--- a/kubernetes/infrastructure/observability/dashboards/homepage/base/serviceaccount.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/homepage/base/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: homepage
+  namespace: homepage
+  labels:
+    app.kubernetes.io/name: homepage

--- a/kubernetes/infrastructure/observability/dashboards/homepage/overlays/prod/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/homepage/overlays/prod/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: homepage
+resources:
+  - ../../base

--- a/kubernetes/infrastructure/observability/dashboards/kiali/httproute.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/kiali/httproute.yaml
@@ -3,6 +3,11 @@ kind: HTTPRoute
 metadata:
   name: kiali
   namespace: istio-system
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Kiali
+    gethomepage.dev/description: 🔒 Istio Service Mesh (VPN-only via NetBird)
+    gethomepage.dev/group: Observability
 spec:
   parentRefs:
     - name: envoy-gateway

--- a/kubernetes/infrastructure/observability/jaeger/base/httproute.yaml
+++ b/kubernetes/infrastructure/observability/jaeger/base/httproute.yaml
@@ -3,6 +3,12 @@ kind: HTTPRoute
 metadata:
   name: jaeger
   namespace: jaeger
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Jaeger
+    gethomepage.dev/description: 🔒 Distributed Tracing (VPN-only via NetBird)
+    gethomepage.dev/group: Observability
+    gethomepage.dev/icon: jaeger.png
 spec:
   parentRefs:
     - name: envoy-gateway

--- a/kubernetes/infrastructure/observability/kibana/base/kibana-httproute.yaml
+++ b/kubernetes/infrastructure/observability/kibana/base/kibana-httproute.yaml
@@ -6,6 +6,12 @@ metadata:
   labels:
     app.kubernetes.io/name: kibana
     app.kubernetes.io/component: log-visualization
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Kibana
+    gethomepage.dev/description: 🔒 Log Analytics (VPN-only via NetBird)
+    gethomepage.dev/group: Observability
+    gethomepage.dev/icon: kibana.png
 spec:
   parentRefs:
     - name: envoy-gateway

--- a/kubernetes/infrastructure/operators/renovate/base/kustomization.yaml
+++ b/kubernetes/infrastructure/operators/renovate/base/kustomization.yaml
@@ -26,6 +26,12 @@ helmCharts:
           memory: 256Mi
       route:
         enabled: true
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: Renovate
+          gethomepage.dev/description: 🔒 Dependency Updates (VPN-only via NetBird)
+          gethomepage.dev/group: Platform
+          gethomepage.dev/icon: renovate.png
         hostnames:
           - renovate.timourhomelab.org
         parentRefs:

--- a/kubernetes/infrastructure/storage/rook-ceph/base/http-route.yaml
+++ b/kubernetes/infrastructure/storage/rook-ceph/base/http-route.yaml
@@ -3,6 +3,12 @@ kind: HTTPRoute
 metadata:
   name: ceph-dashboard
   namespace: rook-ceph
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Ceph Dashboard
+    gethomepage.dev/description: 🔒 Storage Cluster (VPN-only via NetBird)
+    gethomepage.dev/group: Storage
+    gethomepage.dev/icon: ceph.png
 spec:
   parentRefs:
     - group: gateway.networking.k8s.io

--- a/kubernetes/platform/identity/keycloak/base/httproute.yaml
+++ b/kubernetes/platform/identity/keycloak/base/httproute.yaml
@@ -8,6 +8,12 @@ metadata:
     app.kubernetes.io/name: keycloak
     app.kubernetes.io/component: oidc-provider
     app.kubernetes.io/part-of: platform-identity
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Keycloak
+    gethomepage.dev/description: 🔒 SSO / Identity Provider (VPN-only via NetBird)
+    gethomepage.dev/group: Identity
+    gethomepage.dev/icon: keycloak.png
 spec:
   hostnames:
   - iam.timourhomelab.org

--- a/kubernetes/platform/identity/lldap/base/httproute.yaml
+++ b/kubernetes/platform/identity/lldap/base/httproute.yaml
@@ -11,6 +11,12 @@ metadata:
     app.kubernetes.io/name: lldap
     app.kubernetes.io/component: identity-service
     app.kubernetes.io/part-of: platform-identity
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: LLDAP
+    gethomepage.dev/description: 🔒 User Directory (VPN-only via NetBird)
+    gethomepage.dev/group: Identity
+    gethomepage.dev/icon: lldap.png
 spec:
   hostnames:
     - lldap.timourhomelab.org

--- a/kubernetes/projects/infrastructure.yaml
+++ b/kubernetes/projects/infrastructure.yaml
@@ -92,6 +92,8 @@ spec:
       server: 'https://kubernetes.default.svc'
     - namespace: 'grafana'
       server: 'https://kubernetes.default.svc'
+    - namespace: 'homepage'
+      server: 'https://kubernetes.default.svc'
     - namespace: 'alertmanager'
       server: 'https://kubernetes.default.svc'
     - namespace: 'jaeger'

--- a/kubernetes/tenants/drova/console/httproute.yaml
+++ b/kubernetes/tenants/drova/console/httproute.yaml
@@ -3,6 +3,11 @@ kind: HTTPRoute
 metadata:
   name: redpanda-console
   namespace: drova
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Redpanda Console
+    gethomepage.dev/description: 🔒 Kafka UI (VPN-only via NetBird)
+    gethomepage.dev/group: Data
 spec:
   parentRefs:
     - name: envoy-gateway

--- a/kubernetes/tenants/n8n-prod/app/httproute.yaml
+++ b/kubernetes/tenants/n8n-prod/app/httproute.yaml
@@ -3,6 +3,12 @@ kind: HTTPRoute
 metadata:
   name: n8n-prod
   namespace: n8n-prod
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: n8n
+    gethomepage.dev/description: 🌍 Workflow Automation (Public via Cloudflare)
+    gethomepage.dev/group: Apps
+    gethomepage.dev/icon: n8n.png
 spec:
   parentRefs:
     - name: envoy-gateway


### PR DESCRIPTION
Homepage dashboard (gethomepage.dev) mit Gateway-API-Auto-Discovery statt statischer Service-Liste, Gruppen-Icons markieren NetBird-VPN-only-Bereiche.

uptime-kuma ersetzt Gatus (aus altem, nie gemergtem Commit wiederbelebt).

audiobookshelf, mlflow geparkt (ungenutzt) — Namespaces + Applications gelöscht.

homepage läuft unter infrastructure-Projekt (braucht ClusterRole für cluster-weite Discovery), uptime-kuma bleibt unter apps (reiner Prober, kein K8s-API-Zugriff).