### PR TITLE
fix homepage crashloop

### DIFF
--- a/kubernetes/infrastructure/observability/dashboards/homepage/base/configmap.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/homepage/base/configmap.yaml
@@ -61,13 +61,6 @@ data:
           dateStyle: long
           timeStyle: short
           hourCycle: h23
-    - openmeteo:
-        label: "Düsseldorf"
-        latitude: 51.2277
-        longitude: 6.7735
-        timezone: Europe/Berlin
-        units: metric
-        cache: 15
 
   # Auto-Discovery via gateway:true (kubernetes.yaml) liest die HTTPRoutes selbst —
   # keine statisch gepflegte Liste noetig. Nur externe, nicht-K8s-Links kommen hier rein.

--- a/kubernetes/infrastructure/observability/dashboards/homepage/base/configmap.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/homepage/base/configmap.yaml
@@ -61,6 +61,13 @@ data:
           dateStyle: long
           timeStyle: short
           hourCycle: h23
+    - openmeteo:
+        label: "Düsseldorf"
+        latitude: 51.2277
+        longitude: 6.7735
+        timezone: Europe/Berlin
+        units: metric
+        cache: 15
 
   # Auto-Discovery via gateway:true (kubernetes.yaml) liest die HTTPRoutes selbst —
   # keine statisch gepflegte Liste noetig. Nur externe, nicht-K8s-Links kommen hier rein.
@@ -72,6 +79,12 @@ data:
 
   services.yaml: |
     []
+
+  # Ohne diese Datei bricht der Container beim Start: Homepage haelt sie fuer
+  # PFLICHT und versucht sonst, sein eigenes Default-Skeleton reinzukopieren —
+  # scheitert am Read-Only-ConfigMap-Mount (EACCES) -> CrashLoopBackOff.
+  # Wir nutzen kein Docker, daher bewusst leer.
+  docker.yaml: ""
 
   custom.css: ""
   custom.js: ""

--- a/kubernetes/infrastructure/observability/dashboards/homepage/base/deployment.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/homepage/base/deployment.yaml
@@ -70,6 +70,7 @@ spec:
             - { mountPath: /app/config/custom.js, name: config, subPath: custom.js }
             - { mountPath: /app/config/custom.css, name: config, subPath: custom.css }
             - { mountPath: /app/config/bookmarks.yaml, name: config, subPath: bookmarks.yaml }
+            - { mountPath: /app/config/docker.yaml, name: config, subPath: docker.yaml }
             - { mountPath: /app/config/kubernetes.yaml, name: config, subPath: kubernetes.yaml }
             - { mountPath: /app/config/services.yaml, name: config, subPath: services.yaml }
             - { mountPath: /app/config/settings.yaml, name: config, subPath: settings.yaml }


### PR DESCRIPTION
docker.yaml fehlte in der ConfigMap — Homepage haelt sie fuer Pflicht, versucht sonst sein Default-Skeleton reinzukopieren, scheitert am Read-Only-Mount (EACCES) -> CrashLoopBackOff.

Weather-Widget (Duesseldorf) ergaenzt, gleiches Muster wie DACHS IT.