### PR TITLE
fix homepage proxmox.yaml crash

### DIFF
--- a/kubernetes/infrastructure/observability/dashboards/homepage/base/configmap.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/homepage/base/configmap.yaml
@@ -73,11 +73,14 @@ data:
   services.yaml: |
     []
 
-  # Ohne diese Datei bricht der Container beim Start: Homepage haelt sie fuer
-  # PFLICHT und versucht sonst, sein eigenes Default-Skeleton reinzukopieren —
-  # scheitert am Read-Only-ConfigMap-Mount (EACCES) -> CrashLoopBackOff.
-  # Wir nutzen kein Docker, daher bewusst leer.
+  # docker.yaml + proxmox.yaml: Homepage haelt BEIDE fuer Pflicht (verifiziert via
+  # /app/src/skeleton/ im Image, v1.13.2 — die offizielle Doku nennt nur 8 von 9
+  # Dateien, proxmox.yaml fehlte dort). Ohne sie versucht der Container, sein
+  # eigenes Default-Skeleton reinzukopieren -> scheitert am Read-Only-ConfigMap-
+  # Mount (EACCES) -> CrashLoopBackOff. Wir nutzen weder Docker noch Proxmox-
+  # Widget, daher bewusst leer.
   docker.yaml: ""
+  proxmox.yaml: ""
 
   custom.css: ""
   custom.js: ""

--- a/kubernetes/infrastructure/observability/dashboards/homepage/base/deployment.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/homepage/base/deployment.yaml
@@ -72,6 +72,7 @@ spec:
             - { mountPath: /app/config/bookmarks.yaml, name: config, subPath: bookmarks.yaml }
             - { mountPath: /app/config/docker.yaml, name: config, subPath: docker.yaml }
             - { mountPath: /app/config/kubernetes.yaml, name: config, subPath: kubernetes.yaml }
+            - { mountPath: /app/config/proxmox.yaml, name: config, subPath: proxmox.yaml }
             - { mountPath: /app/config/services.yaml, name: config, subPath: services.yaml }
             - { mountPath: /app/config/settings.yaml, name: config, subPath: settings.yaml }
             - { mountPath: /app/config/widgets.yaml, name: config, subPath: widgets.yaml }

--- a/kubernetes/infrastructure/observability/dashboards/homepage/base/rbac.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/homepage/base/rbac.yaml
@@ -1,5 +1,7 @@
-# Read-only, scoped to what homepage actually discovers/renders — no Ingress/Traefik
-# rules (unused, we run Gateway API only).
+# Read-only, scoped to what homepage actually discovers/renders. Kein Traefik
+# (nicht im Cluster). Ingress bleibt drin, obwohl wir nur Gateway API nutzen —
+# Homepage listet Ingresses beim Start unconditional, ohne die Rule loggt es
+# pro Poll einen 403 (nicht fatal, aber Log-Rauschen).
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -12,6 +14,9 @@ rules:
     verbs: [get, list]
   - apiGroups: [gateway.networking.k8s.io]
     resources: [httproutes, gateways]
+    verbs: [get, list]
+  - apiGroups: [networking.k8s.io]
+    resources: [ingresses]
     verbs: [get, list]
   - apiGroups: [metrics.k8s.io]
     resources: [nodes, pods]


### PR DESCRIPTION
Zweiter Pflicht-File-Crash nach dem docker.yaml-Fix: proxmox.yaml fehlte ebenfalls (verifiziert via /app/src/skeleton/ im Image — Doku nennt nur 8 von 9 Dateien).

RBAC: Ingress get/list ergaenzt, Homepage listet Ingresses unconditional beim Start, ohne die Rule spammt es 403 (nicht fatal, aber Log-Rauschen).