### PR TITLE
chore(deps): update docker.io-jaegertracing-jaeger to v2 - autoclosed

### DIFF
--- a/kubernetes/infrastructure/observability/jaeger/base/jaeger-v2.yaml
+++ b/kubernetes/infrastructure/observability/jaeger/base/jaeger-v2.yaml
@@ -8,7 +8,7 @@ metadata:
     prometheus.io/port: "14269"
 spec:
   mode: deployment
-  image: docker.io/jaegertracing/jaeger:2.19.0@sha256:ede4864215be4cd85bd8c3129a2fea6c5713c5653c7282c429dba123014bc68b
+  image: docker.io/jaegertracing/jaeger:2.20.0@sha256:46a886260e04002d8f45e213fc39063fa11a50446048fdaa64786fc0840cb9f8
   replicas: 2  # HA: 2 replicas (ES backend handles durability)
 
   env:


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/docker.io-jaegertracing-jaeger-2.x`
Filter passed: <24h old, <5 commits ahead.