### PR TITLE
add worker-6 on hpdesk

### DIFF
--- a/kubernetes/infrastructure/storage/rook-ceph/base/cluster.yaml
+++ b/kubernetes/infrastructure/storage/rook-ceph/base/cluster.yaml
@@ -253,6 +253,13 @@ spec:
         - effect: NoExecute
           operator: Exists
     mon:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: kubernetes.io/hostname
+                  operator: NotIn
+                  values: ["worker-6"]
       podAntiAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -260,6 +267,13 @@ spec:
                 app: rook-ceph-mon
             topologyKey: kubernetes.io/hostname
     mgr:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: kubernetes.io/hostname
+                  operator: NotIn
+                  values: ["worker-6"]
       podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100

--- a/tofu/talos_nodes.auto.tfvars
+++ b/tofu/talos_nodes.auto.tfvars
@@ -109,17 +109,20 @@ talos_nodes = {
   #   os_disk_size   = 50
   #   ceph_disk_size = 0
   # }
-  # "worker-6" = {
-  #   host_node      = "host3"
-  #   machine_type   = "worker"
-  #   ip             = "192.168.0.109"
-  #   mac_address    = "BC:24:11:2E:C8:B3"
-  #   vm_id          = 1008
-  #   cpu            = 12
-  #   ram_dedicated  = 32768
-  #   datastore_id   = "local-zfs"
-  #   os_disk_size   = 50
-  #   ceph_disk_size = 250
-  #   # pool         = "ai"
-  # }
+  "worker-6" = {
+    host_node     = "pve"
+    machine_type  = "worker"
+    ip            = "192.168.0.109"
+    mac_address   = "BC:24:11:2E:C8:B3"
+    vm_id         = 1008
+    cpu           = 6
+    ram_dedicated = 40960
+    # hpdesk: LVM-thin statt ZFS; 300G OS-Disk = Talos EPHEMERAL waechst mit,
+    # ~250G davon fuer local-path (AI-Cache/Scratch). Kein Ceph-OSD (eine geteilte
+    # DRAM-lose OEM-SSD, 26% wear).
+    datastore_id   = "local-lvm"
+    os_disk_size   = 300
+    ceph_disk_size = 0
+    # pool         = "stateful"
+  }
 }


### PR DESCRIPTION
worker-6 auf hpdesk (pve): 6 vCPU, 40GB, local-lvm, 300G OS-Disk. Kein Ceph-OSD (geteilte OEM-SSD).

mon/mgr per nodeAffinity NotIn von worker-6 ausgeschlossen (Rook-Pods tolerieren sonst alle Taints).