### PR TITLE
add hpdesk to proxmox host ips

### DIFF
--- a/tofu/talos/virtual-machines.tofu
+++ b/tofu/talos/virtual-machines.tofu
@@ -102,6 +102,7 @@ locals {
   proxmox_host_ips = {
     "nipogi"      = "192.168.0.57"
     "msa2proxmox" = "192.168.0.50"
+    "pve"         = "192.168.0.58"
   }
 }
 


### PR DESCRIPTION
proxmox_host_ips kannte nur nipogi/msa2 — Apply waere mit 'key does not exist in map' abgebrochen (Provisioner wird erst zur Apply-Zeit ausgewertet, Plan lief durch).