### PR TITLE
node pools as iac

### DIFF
--- a/tofu/talos/config.tofu
+++ b/tofu/talos/config.tofu
@@ -59,6 +59,7 @@ data "talos_machine_configuration" "this" {
       cluster_name       = var.cluster.proxmox_cluster
       node_name          = each.value.host_node
       kubernetes_version = var.cluster.kubernetes_version
+      pool               = each.value.pool
     }),
     each.value.machine_type == "controlplane" ?
     templatefile("${path.module}/machine-config/control-plane.yaml.tftpl", {

--- a/tofu/talos/machine-config/common.yaml.tftpl
+++ b/tofu/talos/machine-config/common.yaml.tftpl
@@ -58,8 +58,9 @@ machine:
   nodeLabels:
     topology.kubernetes.io/region: ${cluster_name}
     topology.kubernetes.io/zone: ${node_name}
-    # node-pool prep (inaktiv): Label kommt bei Aktivierung via talosctl patch, Design in talos_nodes.auto.tfvars
-    # node-pool: stateful|stateless
+%{ if pool != "" ~}
+    node-pool: ${pool}
+%{ endif ~}
   network:
     hostname: ${hostname}
     # upstream DNS = gateway directly. DHCP hands out 8.8.8.8 which times out from

--- a/tofu/talos/variables.tofu
+++ b/tofu/talos/variables.tofu
@@ -50,6 +50,9 @@ variable "nodes" {
     os_disk_size        = optional(number, 50)
     ceph_disk_size      = optional(number, 0)
     ceph_disk_datastore = optional(string)
+    # node-pool: leer = kein Label (Control-Planes). Kein node-restriction.kubernetes.io/-
+    # Prefix: den blockt NodeRestriction fuer kubelet-gesetzte Labels (2026-08-05 getestet).
+    pool = optional(string, "")
   }))
 }
 

--- a/tofu/talos_nodes.auto.tfvars
+++ b/tofu/talos_nodes.auto.tfvars
@@ -24,10 +24,8 @@ talos_nodes = {
     os_disk_size        = 50
     ceph_disk_size      = 280
     ceph_disk_datastore = "cephpool"
-    # node-pool prep (inaktiv bis neue Hardware): stateful=w1/w4/w5, stateless=w2/w3.
-    # Beide Pools spannen BEIDE Zonen — zone-Spread von drova-pg/kafka bricht sonst.
-    # Aktivierung OHNE tofu apply (Drift!): talosctl patch machineconfig nodeLabels + hier einkommentieren.
-    # pool              = "stateful"
+    # Pools spannen mehrere Zonen — sonst bricht der zone-Spread von drova-pg/kafka.
+    pool = "stateful"
   }
   "worker-2" = {
     host_node           = "nipogi"
@@ -41,7 +39,7 @@ talos_nodes = {
     os_disk_size        = 50
     ceph_disk_size      = 280
     ceph_disk_datastore = "cephpool"
-    # pool              = "stateless"
+    pool                = "stateless"
   }
   "worker-3" = {
     host_node      = "msa2proxmox"
@@ -54,7 +52,7 @@ talos_nodes = {
     datastore_id   = "local-zfs"
     os_disk_size   = 50
     ceph_disk_size = 250
-    # pool         = "stateless"
+    pool           = "stateless"
   }
   "worker-4" = {
     host_node      = "msa2proxmox"
@@ -67,7 +65,7 @@ talos_nodes = {
     datastore_id   = "local-zfs"
     os_disk_size   = 50
     ceph_disk_size = 250
-    # pool         = "stateful"
+    pool           = "stateful"
   }
   "worker-5" = {
     host_node      = "msa2proxmox"
@@ -80,7 +78,7 @@ talos_nodes = {
     datastore_id   = "local-zfs"
     os_disk_size   = 50
     ceph_disk_size = 250
-    # pool         = "stateful"
+    pool           = "stateful"
   }
 
   # ─── FUTURE NODES (vorbereitet, einkommentieren sobald neue Hardware da) ───
@@ -123,6 +121,6 @@ talos_nodes = {
     datastore_id   = "local-lvm"
     os_disk_size   = 300
     ceph_disk_size = 0
-    # pool         = "stateful"
+    pool           = "stateful"
   }
 }


### PR DESCRIPTION
node-pool war nur Live-Patch + Kommentare — geht bei jedem machine-config-apply verloren. Jetzt deklarativ: pool-Feld im Schema, conditional im Template, Werte in tfvars.

stateful = w1/w4/w5/w6, stateless = w2/w3 (beide Pools spannen mehrere Zonen). ctrl-0 bleibt ohne Pool.

Kein node-restriction.kubernetes.io/-Prefix: NodeRestriction blockt kubelet-gesetzte Labels mit dem Prefix (getestet).