### PR TITLE
webhook must not block cni pods

### DIFF
--- a/kubernetes/infrastructure/network/netbird-operator/base/kustomization.yaml
+++ b/kubernetes/infrastructure/network/netbird-operator/base/kustomization.yaml
@@ -14,3 +14,6 @@ resources:
   - pat-sealedsecret.yaml
   - clusterproxy.yaml
   - audit-export-cronjob.yaml
+
+patches:
+  - path: webhook-safety-patch.yaml

--- a/kubernetes/infrastructure/network/netbird-operator/base/webhook-safety-patch.yaml
+++ b/kubernetes/infrastructure/network/netbird-operator/base/webhook-safety-patch.yaml
@@ -1,0 +1,18 @@
+# 2026-08-05: der Chart-Default (failurePolicy Fail, kein namespaceSelector) hat den
+# Cluster verklemmt — ctrl-0 verlor kurz seinen cilium-Agent, dadurch erreichte der
+# apiserver keine Pod-IP mehr, dadurch schlug JEDER Webhook-Aufruf fehl, dadurch liess
+# sich kein Pod mehr erzeugen: auch nicht der cilium-Pod, der ctrl-0 geheilt haette.
+# kube-system raus + fail-open bricht den Zirkel.
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: netbird-operator-mpod-webhook
+webhooks:
+  - name: mpod-v1.netbird.io
+    failurePolicy: Ignore
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system


### PR DESCRIPTION
Chart-Default (failurePolicy Fail, kein namespaceSelector) hat den Cluster verklemmt: ctrl-0 verlor kurz seinen cilium-Agent -> apiserver erreichte keine Pod-IP -> jeder Webhook-Aufruf schlug fehl -> keine Pod-Erstellung mehr moeglich, auch nicht die des cilium-Pods der ctrl-0 geheilt haette.

kube-system per namespaceSelector raus + failurePolicy Ignore (gleiches Muster wie bei Kyverno).