### PR TITLE
pin stateful workloads to pool

### DIFF
--- a/kubernetes/infrastructure/observability/elasticsearch/base/cluster/elasticsearch-cluster.yaml
+++ b/kubernetes/infrastructure/observability/elasticsearch/base/cluster/elasticsearch-cluster.yaml
@@ -111,20 +111,17 @@ spec:
                 - name: ES_JAVA_OPTS
                   # Heap 1g (50% of 2Gi limit) — homelab right-size, Loki carries most logs.
                   value: "-Xms1g -Xmx1g"
-          # Affinity - schedule on large memory nodes (worker-1, worker-2 have 28GB)
-          # node-pool prep: bei Pool-Aktivierung hostname-Pinning ersetzen durch
-          #   - { key: node-pool, operator: In, values: [stateful] }
+          # stateful-Pool statt Hostnamen: waechst mit, wenn Nodes dazukommen, und
+          # ueberlebt eine Node-Umbenennung. 4 Nodes (w1/w4/w5/w6) statt vorher 3.
           affinity:
             nodeAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
                 nodeSelectorTerms:
                   - matchExpressions:
-                      - key: kubernetes.io/hostname
+                      - key: node-pool
                         operator: In
                         values:
-                          - worker-1
-                          - worker-2
-                          - worker-3
+                          - stateful
             podAntiAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
                 - labelSelector:

--- a/kubernetes/tenants/drova/kafka/base/kafka-cluster.yaml
+++ b/kubernetes/tenants/drova/kafka/base/kafka-cluster.yaml
@@ -47,14 +47,6 @@ spec:
   template:
     pod:
       priorityClassName: platform-critical
-      # node-pool prep (inaktiv bis neue Hardware, Design: tofu/talos_nodes.auto.tfvars):
-      # affinity:
-      #   nodeAffinity:
-      #     preferredDuringSchedulingIgnoredDuringExecution:
-      #       - weight: 100
-      #         preference:
-      #           matchExpressions:
-      #             - { key: node-pool, operator: In, values: [stateful] }
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -63,6 +55,12 @@ spec:
           type: RuntimeDefault
       # REQUIRED anti-affinity for controllers: lose 1 node = lose 1 voter = still have quorum
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - { key: node-pool, operator: In, values: [stateful] }
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
@@ -108,14 +106,6 @@ spec:
   template:
     pod:
       priorityClassName: platform-critical
-      # node-pool prep (inaktiv bis neue Hardware, Design: tofu/talos_nodes.auto.tfvars):
-      # affinity:
-      #   nodeAffinity:
-      #     preferredDuringSchedulingIgnoredDuringExecution:
-      #       - weight: 100
-      #         preference:
-      #           matchExpressions:
-      #             - { key: node-pool, operator: In, values: [stateful] }
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -124,6 +114,12 @@ spec:
           type: RuntimeDefault
       # Preferred anti-affinity for brokers (homelab has limited nodes)
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - { key: node-pool, operator: In, values: [stateful] }
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/kubernetes/tenants/drova/postgres/base/postgres-cluster.yaml
+++ b/kubernetes/tenants/drova/postgres/base/postgres-cluster.yaml
@@ -55,7 +55,16 @@ spec:
     # 8 worker nodes — plenty of capacity. preferred was a homelab-shortcut.
     podAntiAffinityType: required
     topologyKey: kubernetes.io/hostname
-    # node-pool prep (inaktiv): nodeSelector: {node-pool: stateful}
+    # preferred, nicht required: der harte zone-Spread unten laesst sonst bei
+    # einem Node-Ausfall keine Ausweichflaeche mehr.
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-pool
+                operator: In
+                values: [stateful]
   # Zone-Spread HART: nie alle 3 Instanzen auf einem Proxmox-Host.
   # ScheduleAnyway verlor gegen das RAM-Scoring (alle 3 landeten auf msa2 = Totalausfall-Risiko).
   # Trade-off: bei echtem Zonen-Ausfall kann die 3. Instanz Pending bleiben — akzeptiert,

--- a/kubernetes/tenants/n8n-prod/postgres/base/cluster.yaml
+++ b/kubernetes/tenants/n8n-prod/postgres/base/cluster.yaml
@@ -42,7 +42,14 @@ spec:
   affinity:
     podAntiAffinityType: required
     topologyKey: kubernetes.io/hostname
-    # node-pool prep (inaktiv): nodeSelector: {node-pool: stateful}
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-pool
+                operator: In
+                values: [stateful]
   topologySpreadConstraints:
     - maxSkew: 1
       topologyKey: topology.kubernetes.io/zone


### PR DESCRIPTION
Die node-pool-Labels waren bisher wirkungslos — kein Workload hat sie referenziert.

Postgres (drova + n8n), Kafka (controller + broker): preferred nodeAffinity auf node-pool=stateful. Preferred, damit ein Node-Ausfall neben dem harten zone-Spread nichts unschedulable macht.

Elasticsearch: Hostname-Pinning (worker-1/2/3) ersetzt durch node-pool=stateful — waechst mit neuen Nodes mit, ueberlebt Umbenennungen, 4 statt 3 Nodes.

Stateless bewusst NICHT gepinnt: die koennen ueberall laufen, Pinning wuerde nur Flexibilitaet kosten.

Wirkt erst beim naechsten Pod-Neustart (IgnoredDuringExecution), kein Big-Bang.