### PR TITLE
hpdesk monitoring + hypervisor swap alert

### DIFF
--- a/.github/tests/alerts/hypervisor_swap_test.yaml
+++ b/.github/tests/alerts/hypervisor_swap_test.yaml
@@ -1,0 +1,41 @@
+# promtool unit tests — HypervisorSwapInUse (Fire + Negativ).
+# Run: python3 .github/scripts/test-alerts.py
+rule_files:
+  - .rules.generated.yaml
+evaluation_interval: 1m
+tests:
+  # ── HypervisorSwapInUse: FIRES bei 50% Swap auf einem Hypervisor ──
+  # (nipogi-Fall 2026-08-05: 91% Swap, alte Regel blieb wegen MemAvailable-Klausel still)
+  - interval: 1m
+    input_series:
+      - series: 'node_memory_SwapTotal_bytes{job="proxmox-host-node",instance="192.168.0.57"}'
+        values: '8589934592x25'
+      - series: 'node_memory_SwapFree_bytes{job="proxmox-host-node",instance="192.168.0.57"}'
+        values: '4294967296x25'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: HypervisorSwapInUse
+        exp_alerts:
+          - exp_labels:
+              job: proxmox-host-node
+              instance: 192.168.0.57
+              severity: warning
+              component: hardware
+              priority: P2
+            exp_annotations:
+              dashboard_url: "/d/k8s-node-overview"
+              summary: "Hypervisor 192.168.0.57: 50% Swap belegt"
+              description: "Auf einem Virtualisierungs-Host bedeutet Swap fast immer ausgelagertes Gast-RAM → IO-Delay in den VMs, auch wenn der Host 'genug' RAM meldet. Ursache ist meist RAM-Ueberbuchung (VMs > ~85% Host-RAM)."
+              action: "ssh <host> 'swapoff -a && swapon -a' als Akut-Fix (nur wenn genug RAM frei); dauerhaft: VM-RAM right-sizen (qm set), Ziel <=85% Host-RAM."
+
+  # ── HypervisorSwapInUse: NICHT bei 10% Swap ──
+  - interval: 1m
+    input_series:
+      - series: 'node_memory_SwapTotal_bytes{job="proxmox-host-node",instance="192.168.0.57"}'
+        values: '8589934592x25'
+      - series: 'node_memory_SwapFree_bytes{job="proxmox-host-node",instance="192.168.0.57"}'
+        values: '7730941133x25'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: HypervisorSwapInUse
+        exp_alerts: []

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/host-sensors.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/hardware/host-sensors.yaml
@@ -45,6 +45,25 @@ spec:
             description: "NVMe running hot — thermal-throttles and degrades Ceph performance."
             action: "PHYSICAL: add/reseat heatsink, improve airflow/dust; reduce write load."
 
+        # 2026-08-05: nipogi hatte 91% Swap (6,8GB GAST-RAM ausgelagert, IO-delay 21%) und
+        # HostSwapUsageHigh unten blieb still — MemAvailable lag bei 22%, weil Page-Cache
+        # mitzaehlt. Auf einem HYPERVISOR ist ausgelagertes Gast-RAM aber immer schaedlich,
+        # egal was MemAvailable sagt → eigene Regel ohne die MemAvailable-Klausel.
+        - alert: HypervisorSwapInUse
+          expr: |
+            (node_memory_SwapTotal_bytes{job="proxmox-host-node"} - node_memory_SwapFree_bytes{job="proxmox-host-node"})
+              / clamp_min(node_memory_SwapTotal_bytes{job="proxmox-host-node"}, 1) > 0.3
+          for: 15m
+          labels:
+            severity: warning
+            component: hardware
+            priority: P2
+          annotations:
+            dashboard_url: "/d/k8s-node-overview"
+            summary: "Hypervisor {{ $labels.instance }}: {{ $value | humanizePercentage }} Swap belegt"
+            description: "Auf einem Virtualisierungs-Host bedeutet Swap fast immer ausgelagertes Gast-RAM → IO-Delay in den VMs, auch wenn der Host 'genug' RAM meldet. Ursache ist meist RAM-Ueberbuchung (VMs > ~85% Host-RAM)."
+            action: "ssh <host> 'swapoff -a && swapon -a' als Akut-Fix (nur wenn genug RAM frei); dauerhaft: VM-RAM right-sizen (qm set), Ziel <=85% Host-RAM."
+
         - alert: HostSwapUsageHigh
           # Feuert nur bei ECHTEM Thrashing: Swap voll UND wenig RAM frei.
           # (Swap>50% allein ist ein nachlaufender Wert — bleibt nach einem

--- a/kubernetes/infrastructure/observability/pve-exporter/base/scrape-config.yaml
+++ b/kubernetes/infrastructure/observability/pve-exporter/base/scrape-config.yaml
@@ -11,6 +11,7 @@ stringData:
         - targets:
             - 192.168.0.50:9100
             - 192.168.0.57:9100
+            - 192.168.0.58:9100
           labels:
             role: hypervisor
       metric_relabel_configs:
@@ -23,6 +24,7 @@ stringData:
         - targets:
             - 192.168.0.50:9633
             - 192.168.0.57:9633
+            - 192.168.0.58:9633
           labels:
             role: hypervisor
       metric_relabel_configs:


### PR DESCRIPTION
hpdesk (.58) war fuer Prometheus komplett blind — node_exporter + smartctl_exporter dort installiert (von msa2 kopiert, Hosts haben kein Internet), Targets in beide Scrape-Jobs.

HypervisorSwapInUse neu: nipogi stand bei 91% Swap (6,8GB Gast-RAM ausgelagert, IO-delay 21%) und HostSwapUsageHigh blieb still — die MemAvailable-Klausel zaehlt Page-Cache mit. Auf Hypervisoren ist Swap immer schaedlich → eigene Regel >30%/15m ohne die Klausel, promtool-Tests Fire+Negativ.