### PR TITLE
webhooks, federation, grafana alerting

### DIFF
--- a/kubernetes/applicationsets/infrastructure/observability-stack.yaml
+++ b/kubernetes/applicationsets/infrastructure/observability-stack.yaml
@@ -36,6 +36,7 @@ spec:
                 # gatus: ersetzt durch uptime-kuma 2026-08-04
                 # - { component: gatus,                  appName: gatus,                            path: kubernetes/infrastructure/observability/gatus/overlays/prod,                  namespace: monitoring,   wave: "70" }
                 - { component: pve-exporter,           appName: pve-exporter,                     path: kubernetes/infrastructure/observability/pve-exporter/overlays/prod,           namespace: monitoring,   wave: "70" }
+                - { component: prometheus-edge,        appName: prometheus-edge,                  path: kubernetes/infrastructure/observability/prometheus-edge/overlays/prod,        namespace: monitoring,   wave: "40" }
                 - { component: netbird-exporter,       appName: netbird-exporter,                 path: kubernetes/infrastructure/observability/netbird-exporter/overlays/prod,       namespace: monitoring,   wave: "70" }
                 - { component: kiali,                  appName: kiali,                            path: kubernetes/infrastructure/observability/dashboards/kiali,                     namespace: istio-system, wave: "70" }
                 # LOGS — Backends @ 40, shippers @ 70 (after apps exist)

--- a/kubernetes/infrastructure/observability/alerting/alerts/base/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/alerting/alerts/base/kustomization.yaml
@@ -13,7 +13,6 @@ resources:
   # alertmanager-config.yaml removed 2026-05-18 — was REFERENCE-only Secret,
   # unused by AM-pod (which uses operator-generated kube-prometheus-stack-alertmanager-generated).
   - slack-webhook-sealed.yaml           # Alertmanager Slack webhook (monitoring namespace, active)
-  # Ein Webhook pro Channel — der globale ignoriert das channel:-Feld (app-gebunden).
   - slack-webhook-critical-sealed.yaml  # -> #alerts-critical
   - slack-webhook-security-sealed.yaml  # -> #alerts-security
   # NOTE: argocd-slack-webhook-sealed.yaml moved to controllers/argocd/ (namespace must be argocd)

--- a/kubernetes/infrastructure/observability/alerting/alerts/base/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/alerting/alerts/base/kustomization.yaml
@@ -13,5 +13,8 @@ resources:
   # alertmanager-config.yaml removed 2026-05-18 — was REFERENCE-only Secret,
   # unused by AM-pod (which uses operator-generated kube-prometheus-stack-alertmanager-generated).
   - slack-webhook-sealed.yaml           # Alertmanager Slack webhook (monitoring namespace, active)
+  # Ein Webhook pro Channel — der globale ignoriert das channel:-Feld (app-gebunden).
+  - slack-webhook-critical-sealed.yaml  # -> #alerts-critical
+  - slack-webhook-security-sealed.yaml  # -> #alerts-security
   # NOTE: argocd-slack-webhook-sealed.yaml moved to controllers/argocd/ (namespace must be argocd)
   # NOTE: All PrometheusRule files migrated to kube-prometheus-stack/base/alerts/ (Golden Pattern: component-organized).

--- a/kubernetes/infrastructure/observability/alerting/alerts/base/slack-webhook-critical-sealed.yaml
+++ b/kubernetes/infrastructure/observability/alerting/alerts/base/slack-webhook-critical-sealed.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: slack-webhook-critical
+  namespace: monitoring
+spec:
+  encryptedData:
+    url: AgCmqqqHYE7NABNOjVq63phwBhUczcBiBV02E4lKvZ4Y2CgpuKC9Fzv5xbMMMPnJ5yJAaB0b6aLK5McGPfcH4A9gcDD/GC3nK+Da+UHQFQpYOVP4DAaRVV7cT/E/VXtTj2Jc/DvxcKi4nAT+dbkp5/bYcPOisfBC9LrY11UGMJhC3OpV2UM5zTH3ybaQkEQ05yI7sZ/DNM+Zta6WUflB2G+hIw6Q5xL/BcAF1/GicnIN26dGgFo6fzTyNOYzEYFhHp6i88spb40MsvjgI0gZyKWM5GsTlQgBZzj6v9a4stoW8ijBEyomQVOQC7agGAdLj/Xwsp87eINoDIPDIn8yVtKBLJOkvull5o3iS09wFSAC7+RFr/JbN7kcs6ZOTPb0IAhgTjWtDBfh0md0GbsNKI4Pa4vTjreEjZKG1CtLrL4jfsqWe+7lVEQ5rDGVzKC1is2uF2G1tu/AIXQpwSHLjY6KdK4vrHw6taZaswKjKQl0vjUfcfy2ib6ccI5PkMBUwefCdBd4hKkzaGRKNXcvlByA1hbLxOx6PfuwqBice3Fm9HyCRRCyeAv67MLx1ehiZKuKQltaPOsXZgMtMQRs4rECwpMRjsdLXqtxeswCjVGNfBaKwi2aedkTHrTebZQIBe/grJLHE+DMVYf3ic5yZq40azX3dH2uWYKgRW86zID2lNOuMYRvgMkGN4Le1yrbrB87kX43PTpCPp2DCXkTmeq34LlT8g3O97wvk3Chln3p4xE9CydE/IRZGow0ty2NuiaJDAEv6APJGT6qiRnnvEhf2RTA6LhtJ8o/Bh+RSUs4YxY=
+  template:
+    metadata:
+      name: slack-webhook-critical
+      namespace: monitoring

--- a/kubernetes/infrastructure/observability/alerting/alerts/base/slack-webhook-security-sealed.yaml
+++ b/kubernetes/infrastructure/observability/alerting/alerts/base/slack-webhook-security-sealed.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: slack-webhook-security
+  namespace: monitoring
+spec:
+  encryptedData:
+    url: AgCo9v2JbiqQ/+sj/xp/8JwcTxNmY1AJJ5IT2uCGEkM8dqNKiwNOl3qO6y3NhEyK7mvEouOjsxmD8bUc2JmRx777x3YH5xSp3ocFPkgfanysCp91dj2Z+0UlJs0tTIKAcgiBEPp5NjldbMh397vFD31VxDCqa3SLczDTgKYg/E/I47xEHQ/nkNirsCvcaz8PLK5NYBRk3kSph7Vk8zDr0LjIV8/2/FnPx4xsA8mvPX6FhFJgWKPgkMuCRwP8g6NdS6h1SzH3r5BGyDzDQDLcxChRPYNSRj4Y7eqflbQk/obmHPrJ69ojdEG2bgv9/J+OiJQUxFGwjRAUDP54HydCgwSaUStgEvktQo/3eJ0AlTirrt5Kuab/ZlxYvQDMqld5xsm8w+TlH+NIION7YYhoeNDBTDZjvVUCcFbwPb2TeDaelZ4nv/VkbVzosll4jOcjfXe+HnVFK/2X7fTFYG2bYHje6nu4wP7N503bf4EthqvJRCBJ6Myp6Wg3mH+1e8JrOaO+fMjveWH4Zd0vG+7T2mKUq+os14qYC3vj2SgTVw32GRmWkPuIH3bzsOC+GjKvkCgXW2Z3CvSsAOiPMDHhtLWVz6xHFHqHBD78xDdFk45h0/DL/eW02oz7UgbAy0sh+0JxpLfWt8OTXPE/DYBQRmuXC9Ikft6S+oO7GMQyuWrpqGMdC4oKn/cMc7xLkA2+Lc2TLytlBk3H0ytcw2PwAqpKyYua9yAn9imCaI4SYX5JVKUgyZ/JgZiNoYqsH9DoxJOeL1S5GxvyPfVrQyvj2OdEm3spi1AY3+GsANqJv69Xfts=
+  template:
+    metadata:
+      name: slack-webhook-security
+      namespace: monitoring

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/alerting/watchdog-rules.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/alerting/watchdog-rules.yaml
@@ -1,0 +1,112 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  name: alerting-watchdog
+  namespace: grafana
+spec:
+  title: Watchdog
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      app: grafana
+---
+# Grafana wertet diese Regeln selbst aus, unabhaengig von Prometheus' Rule-Engine.
+# Ist Prometheus degradiert, sind seine eigenen Alerts ueber sich selbst unzuverlaessig.
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaAlertRuleGroup
+metadata:
+  name: stack-watchdog
+  namespace: grafana
+spec:
+  folderRef: alerting-watchdog
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      app: grafana
+  interval: 2m
+  rules:
+    - uid: graf-prom-unreachable
+      title: GrafanaCannotQueryPrometheus
+      condition: C
+      for: 5m
+      execErrState: Alerting
+      noDataState: Alerting
+      labels:
+        severity: critical
+        component: observability
+        priority: P1
+        source: grafana
+      annotations:
+        summary: "Grafana erreicht Prometheus nicht"
+        description: "Unabhaengige Gegenprobe von ausserhalb der Prometheus-Rule-Engine. Feuert auch, wenn Prometheus seine eigenen Alerts nicht mehr auswerten kann."
+        action: "kubectl get pods -n monitoring -l app.kubernetes.io/name=prometheus; kubectl logs -n monitoring prometheus-kube-prometheus-stack-prometheus-0 -c prometheus --tail=50"
+      data:
+        - refId: A
+          datasourceUid: prometheus
+          relativeTimeRange:
+            from: 300
+            to: 0
+          model:
+            refId: A
+            expr: 'sum(up)'
+            instant: true
+        - refId: B
+          datasourceUid: __expr__
+          model:
+            refId: B
+            type: reduce
+            reducer: last
+            expression: A
+        - refId: C
+          datasourceUid: __expr__
+          model:
+            refId: C
+            type: threshold
+            expression: B
+            conditions:
+              - evaluator:
+                  type: lt
+                  params: [1]
+
+    - uid: graf-loki-stalled
+      title: GrafanaLokiIngestStalled
+      condition: C
+      for: 15m
+      execErrState: Alerting
+      noDataState: Alerting
+      labels:
+        severity: warning
+        component: observability
+        priority: P2
+        source: grafana
+      annotations:
+        summary: "Keine neuen Logs in Loki"
+        description: "kube-system produziert dauerhaft Logs. Bleibt der Zaehler bei null, steht die Vector-Loki-Pipeline — die Log-Alerts waeren dann still blind."
+        action: "kubectl get pods -n elastic-system -l app.kubernetes.io/name=vector; kubectl logs -n monitoring loki-0 -c loki --tail=50"
+      data:
+        - refId: A
+          datasourceUid: loki
+          relativeTimeRange:
+            from: 900
+            to: 0
+          model:
+            refId: A
+            expr: 'sum(count_over_time({namespace="kube-system"}[10m]))'
+            queryType: instant
+        - refId: B
+          datasourceUid: __expr__
+          model:
+            refId: B
+            type: reduce
+            reducer: last
+            expression: A
+        - refId: C
+          datasourceUid: __expr__
+          model:
+            refId: C
+            type: threshold
+            expression: B
+            conditions:
+              - evaluator:
+                  type: lt
+                  params: [1]

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/custom-dashboards/observability/jaeger-internals.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/custom-dashboards/observability/jaeger-internals.yaml
@@ -1,6 +1,3 @@
-# Jaeger v2 laeuft auf dem OTel-Collector -> Metriken heissen otelcol_* (ohne _total),
-# nicht jaeger_collector_*/jaeger_query_* wie in v1. Nur jaeger_storage_* blieb erhalten.
-# Tail-Sampling passiert im Gateway, nicht in Jaeger -> eigener job.
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/datasources/alertmanager-operated.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/datasources/alertmanager-operated.yaml
@@ -19,5 +19,5 @@ spec:
     isDefault: false
     uid: alertmanager
     jsonData:
-      handleGrafanaManagedAlerts: false
+      handleGrafanaManagedAlerts: true
       implementation: prometheus

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - elasticsearch-credentials.yaml
 
   # Datasources (5)
+  - alerting/watchdog-rules.yaml
   - datasources/alertmanager-operated.yaml
   - datasources/prometheus-operated.yaml
   - datasources/loki.yaml

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
@@ -303,6 +303,8 @@ alertmanager:
               storage: 5Gi
     secrets:
       - slack-webhook-url
+      - slack-webhook-critical
+      - slack-webhook-security
       - watchdog-webhook-url
       - telegram-bot-token
     resources:
@@ -539,6 +541,7 @@ alertmanager:
       - name: 'slack-critical'
         slack_configs:
           - channel: '#alerts-critical'
+            api_url_file: /etc/alertmanager/secrets/slack-webhook-critical/url
             send_resolved: true
             title: '{{ template "slack.title" . }}'
             text: '{{ template "slack.body" . }}'
@@ -580,6 +583,7 @@ alertmanager:
       - name: 'slack-security'
         slack_configs:
           - channel: '#alerts-security'
+            api_url_file: /etc/alertmanager/secrets/slack-webhook-security/url
             send_resolved: true
             title: ':lock: {{ template "slack.title" . }}'
             text: '{{ template "slack.body" . }}'

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
@@ -553,10 +553,10 @@ alertmanager:
                 # Path-only annotations like "/d/drova-slo" get prefixed automatically.
                 url: '{{ if (index .Alerts 0).Annotations.dashboard_url }}{{ template "alert.dashboard_url" . }}{{ else }}{{ if .CommonLabels.grafana_url }}{{ .CommonLabels.grafana_url }}{{ else }}https://grafana.timourhomelab.org{{ end }}{{ end }}'
               - type: button
-                text: 'Query :mag:'
-                url: '{{ (index .Alerts 0).GeneratorURL }}'
+                text: 'Explore :mag:'
+                url: 'https://grafana.timourhomelab.org/explore'
               - type: button
-                text: 'Silence 2h :no_bell:'
+                text: 'Silence :no_bell:'
                 url: '{{ template "slack.silenceURL" . }}'
         telegram_configs:
           - bot_token_file: /etc/alertmanager/secrets/telegram-bot-token/token
@@ -595,10 +595,10 @@ alertmanager:
             color: '{{ template "slack.color" . }}'
             actions:
               - type: button
-                text: 'Query :mag:'
-                url: '{{ (index .Alerts 0).GeneratorURL }}'
+                text: 'Explore :mag:'
+                url: 'https://grafana.timourhomelab.org/explore'
               - type: button
-                text: 'Silence 2h :no_bell:'
+                text: 'Silence :no_bell:'
                 url: '{{ template "slack.silenceURL" . }}'
 
       # ─────────────────────────────────────────────────────────────────────
@@ -709,14 +709,12 @@ alertmanager:
       {{ if gt (len .Alerts) 5 }}…and more alerts in this group (see Slack){{ end }}
       {{ end }}
 
+      {{/* .ExternalURL ist die cluster-interne Adresse und im Browser tot —
+           Alertmanager hat keine HTTPRoute. Silences laufen deshalb ueber
+           Grafana (VPN-only + SSO) gegen die Alertmanager-Datasource. */}}
       {{ define "slack.silenceURL" -}}
-      {{ .ExternalURL }}/#/silences/new?filter=%7B
-      {{- range $k, $v := .CommonLabels -}}
-      {{- if ne $k "alertname" -}}
-      {{ $k }}%3D%22{{ $v }}%22%2C
-      {{- end -}}
-      {{- end -}}
-      alertname%3D%22{{ .CommonLabels.alertname }}%22%7D
+      https://grafana.timourhomelab.org/alerting/silence/new?alertmanager=Alertmanager
+      {{- range $k, $v := .CommonLabels }}&matcher={{ $k }}%3D{{ $v | urlquery }}{{ end -}}
       {{- end }}
 
       {{ define "alert.dashboard_url" -}}

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
@@ -357,9 +357,6 @@ alertmanager:
           repeat_interval: 12h
           continue: false
 
-        # Dringlichkeit zuerst (Google SRE: page vs ticket), danach Ownership.
-        # continue: true, damit ein kritischer Security-Alert BEIDES erreicht:
-        # Page via Telegram und den Security-Channel.
         - matchers:
             - severity="critical"
             - priority=~"p0|P0"
@@ -386,10 +383,6 @@ alertmanager:
           repeat_interval: 1h
           continue: true
 
-        # Ownership-Achse: Security braucht eine andere Reaktion als Betrieb
-        # (forensisch nachsehen statt neustarten). Metrik- und Log-Alerts gemeinsam.
-        # Regex, weil die component-Taxonomie historisch gewachsen ist —
-        # Cert-/SealedSecrets-Alerts bleiben bewusst bei platform (Reliability, kein Incident).
         - matchers:
             - component=~"security|kyverno|trivy|identity"
           receiver: 'slack-security'
@@ -537,7 +530,6 @@ alertmanager:
             max_alerts: 1
 
       # ── PAGE tier (critical) → Slack #alerts-critical + Telegram (phone) ──
-      # Der einzige Receiver, der das Telefon weckt.
       - name: 'slack-critical'
         slack_configs:
           - channel: '#alerts-critical'
@@ -713,9 +705,6 @@ alertmanager:
       {{ if gt (len .Alerts) 5 }}…and more alerts in this group (see Slack){{ end }}
       {{ end }}
 
-      {{/* .ExternalURL ist die cluster-interne Adresse und im Browser tot —
-           Alertmanager hat keine HTTPRoute. Silences laufen deshalb ueber
-           Grafana (VPN-only + SSO) gegen die Alertmanager-Datasource. */}}
       {{ define "slack.silenceURL" -}}
       https://grafana.timourhomelab.org/alerting/silence/new?alertmanager=Alertmanager
       {{- range $k, $v := .CommonLabels }}&matcher={{ $k }}%3D{{ $v | urlquery }}{{ end -}}

--- a/kubernetes/infrastructure/observability/loki/base/alerting-rules.yaml
+++ b/kubernetes/infrastructure/observability/loki/base/alerting-rules.yaml
@@ -1,7 +1,3 @@
-# Zwei Fallen, beide live gefunden: es gibt KEIN job-Label (Vector schickt
-# namespace/pod/container/service/level/stream), und pod!~"loki.*" ist Pflicht bei
-# Regex ueber alle Namespaces — Loki loggt jede Query samt Query-String und findet
-# sonst seine eigenen Ruler-Logs.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -30,9 +26,6 @@ data:
               description: "Tetragon meldet Zugriff auf shadow/sudoers/authorized_keys — passiert im Normalbetrieb nie."
               action: "kubectl logs -n kube-system -l app.kubernetes.io/name=tetragon --since=15m | grep -E 'shadow|sudoers'"
 
-          # kube-audit liegt als eigener Stream in Loki (service_name), 233k Events/h.
-          # Baselines gegen 1h Live gemessen: exec 0, anonym 0, RBAC-durch-Menschen 0,
-          # Secret-Zugriff ohne ServiceAccount ~41/h.
           - alert: LogsAuditPodExec
             expr: 'sum(count_over_time({service_name="kube-audit"} |~ "pods/exec" [10m])) > 0'
             labels: {severity: warning, component: security, priority: P2, source: loki}
@@ -67,8 +60,6 @@ data:
               description: "ServiceAccounts sind ausgefiltert. Baseline liegt bei ~7 pro 10min — ein Vielfaches davon sieht nach Absammeln aus."
               action: "Loki: {service_name=\"kube-audit\"} |~ \"secrets\" !~ \"serviceaccount\" | json — user.name gruppieren."
 
-          # NetBird-Audit kommt per CronJob aus der Cloud-API (alle 15min, source=netbird-audit).
-          # Events sind selten (5 in 7 Tagen) — genau deshalb ist jedes eines.
           - alert: LogsNetBirdAccessChange
             expr: 'sum(count_over_time({namespace="netbird", pod=~"netbird-audit-export.*"} |~ "\"activity_code\":\"(rule|policy|route|group|nameserver)\\." [20m])) > 0'
             labels: {severity: warning, component: security, priority: P2, source: loki}

--- a/kubernetes/infrastructure/observability/prometheus-edge/base/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/prometheus-edge/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+
+resources:
+  - prometheus.yaml
+  - recording-rules.yaml

--- a/kubernetes/infrastructure/observability/prometheus-edge/base/prometheus.yaml
+++ b/kubernetes/infrastructure/observability/prometheus-edge/base/prometheus.yaml
@@ -1,0 +1,116 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-edge
+  namespace: monitoring
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: edge-scrape-configs
+  namespace: monitoring
+type: Opaque
+stringData:
+  prometheus-additional.yaml: |
+    - job_name: proxmox-host-node
+      static_configs:
+        - targets:
+            - 192.168.0.50:9100
+            - 192.168.0.57:9100
+            - 192.168.0.58:9100
+          labels:
+            role: hypervisor
+      metric_relabel_configs:
+        - source_labels: [__address__]
+          regex: '([^:]+):.*'
+          target_label: instance
+          replacement: '$1'
+    - job_name: proxmox-smart
+      static_configs:
+        - targets:
+            - 192.168.0.50:9633
+            - 192.168.0.57:9633
+            - 192.168.0.58:9633
+          labels:
+            role: hypervisor
+      metric_relabel_configs:
+        - source_labels: [__address__]
+          regex: '([^:]+):.*'
+          target_label: instance
+          replacement: '$1'
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: edge
+  namespace: monitoring
+spec:
+  serviceAccountName: prometheus-edge
+  replicas: 1
+  # Edge haelt bewusst wenig lokal — die Aggregate holt sich der zentrale per Federation.
+  retention: 24h
+  retentionSize: 2GB
+  scrapeInterval: 30s
+  evaluationInterval: 30s
+  externalLabels:
+    tier: edge
+    cluster: prod-talos
+  additionalScrapeConfigs:
+    name: edge-scrape-configs
+    key: prometheus-additional.yaml
+  ruleSelector:
+    matchLabels:
+      prometheus: edge
+  ruleNamespaceSelector: {}
+  # Kein Kubernetes-Discovery: der Edge scrapet ausschliesslich die Hypervisor-Ziele.
+  # Die Selektoren matchen absichtlich nichts.
+  serviceMonitorSelector:
+    matchLabels:
+      prometheus: edge
+  podMonitorSelector:
+    matchLabels:
+      prometheus: edge
+  probeSelector:
+    matchLabels:
+      prometheus: edge
+  scrapeConfigSelector:
+    matchLabels:
+      prometheus: edge
+  resources:
+    requests:
+      cpu: 50m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    fsGroup: 2000
+  storage:
+    volumeClaimTemplate:
+      spec:
+        storageClassName: rook-ceph-block-enterprise
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 5Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-edge
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: prometheus-edge
+spec:
+  # Eigener Service — prometheus-operated selektiert ALLE Prometheus-Pods im
+  # Namespace und wuerde beim Federieren zufaellig den zentralen treffen.
+  selector:
+    app.kubernetes.io/instance: edge
+    app.kubernetes.io/name: prometheus
+  ports:
+    - name: http-web
+      port: 9090
+      targetPort: 9090

--- a/kubernetes/infrastructure/observability/prometheus-edge/base/recording-rules.yaml
+++ b/kubernetes/infrastructure/observability/prometheus-edge/base/recording-rules.yaml
@@ -1,0 +1,48 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: edge-aggregates
+  namespace: monitoring
+  labels:
+    # NICHT release: kube-prometheus-stack — sonst wertet der zentrale Prometheus
+    # dieselben Regeln nochmal aus.
+    prometheus: edge
+spec:
+  groups:
+    - name: edge-hypervisor
+      interval: 60s
+      rules:
+        # Was der zentrale per Federation holt. 432 rohe CPU-Serien werden hier
+        # zu 3 — das ist der Sinn der Uebung, nicht rohe Metriken durchreichen.
+        - record: edge:node_cpu_busy_ratio
+          expr: 1 - avg by (instance) (rate(node_cpu_seconds_total{role="hypervisor",mode="idle"}[5m]))
+
+        - record: edge:node_memory_used_ratio
+          expr: |
+            1 - (
+              node_memory_MemAvailable_bytes{role="hypervisor"}
+              / node_memory_MemTotal_bytes{role="hypervisor"}
+            )
+
+        - record: edge:node_swap_used_ratio
+          expr: |
+            (node_memory_SwapTotal_bytes{role="hypervisor"} - node_memory_SwapFree_bytes{role="hypervisor"})
+            / clamp_min(node_memory_SwapTotal_bytes{role="hypervisor"}, 1)
+
+        - record: edge:node_filesystem_used_ratio:max
+          expr: |
+            max by (instance) (
+              1 - (
+                node_filesystem_avail_bytes{role="hypervisor",fstype!~"tmpfs|overlay|squashfs"}
+                / node_filesystem_size_bytes{role="hypervisor",fstype!~"tmpfs|overlay|squashfs"}
+              )
+            )
+
+        - record: edge:smartctl_wear_ratio:max
+          expr: max by (instance) (smartctl_device_percentage_used{role="hypervisor"}) / 100
+
+        - record: edge:smartctl_temperature:max
+          expr: max by (instance) (smartctl_device_temperature{role="hypervisor",temperature_type="current"})
+
+        - record: edge:target_up
+          expr: min by (instance, job) (up{role="hypervisor"})

--- a/kubernetes/infrastructure/observability/prometheus-edge/overlays/prod/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/prometheus-edge/overlays/prod/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+
+resources:
+  - ../../base

--- a/kubernetes/infrastructure/observability/pve-exporter/base/scrape-config.yaml
+++ b/kubernetes/infrastructure/observability/pve-exporter/base/scrape-config.yaml
@@ -32,3 +32,15 @@ stringData:
           regex: '([^:]+):.*'
           target_label: instance
           replacement: '$1'
+    # Holt NUR die Aggregate vom Edge-Prometheus, keine rohen Serien.
+    # honor_labels behaelt instance/tier aus dem Edge statt sie zu ueberschreiben.
+    - job_name: federate-edge
+      scrape_interval: 60s
+      honor_labels: true
+      metrics_path: /federate
+      params:
+        'match[]':
+          - '{__name__=~"edge:.*"}'
+      static_configs:
+        - targets:
+            - prometheus-edge.monitoring.svc.cluster.local:9090

--- a/kubernetes/infrastructure/observability/tempo/base/values.yaml
+++ b/kubernetes/infrastructure/observability/tempo/base/values.yaml
@@ -234,9 +234,6 @@ gateway:
       cpu: 250m
       memory: 256Mi
 
-# tempo-distributed kennt KEINEN root-level serviceMonitor-Key — der lebt unter
-# metaMonitoring. Helm ignoriert unbekannte Values still, deshalb lief Tempo
-# monatelang ungescrapet (0 ServiceMonitors gerendert).
 metaMonitoring:
   serviceMonitor:
     enabled: true


### PR DESCRIPTION
Slack: der globale Webhook ist app-gebunden und ignoriert channel: still — Testalarme kamen mit HTTP 200 durch, landeten aber alle in #alerts. Jetzt ein Webhook je Channel als SealedSecret, pro Receiver via api_url_file. Entschluesselung im Cluster verifiziert.

Zwei Action-Buttons zeigten auf cluster-interne Adressen und waren im Browser tot (Prometheus/Alertmanager haben keine HTTPRoute). Beide laufen jetzt ueber Grafana — Explore fuer Queries, Silence-UI gegen die Alertmanager-Datasource, damit auch ueber SSO.

Federation: Edge-Prometheus uebernimmt die Hypervisor-Ziele mit 24h lokaler Retention und aggregiert per Recording-Rules. Der zentrale foederiert nur die edge:*-Aggregate, keine rohen Serien — 432 CPU-Serien werden zu 3. Alle 7 Regeln gegen Live-Daten geprueft.

Grafana-Alerting: zwei Watchdog-Regeln, die Grafana unabhaengig von der Prometheus-Rule-Engine auswertet und an denselben Alertmanager schickt (handleGrafanaManagedAlerts). Kein zweiter Eskalationsweg.