### PR TITLE
fix log level detection

### DIFF
--- a/kubernetes/infrastructure/network/coredns/base/coredns-config.yaml
+++ b/kubernetes/infrastructure/network/coredns/base/coredns-config.yaml
@@ -14,8 +14,10 @@ data:
             lameduck 5s
         }
         ready
+        # class all loggte JEDE Abfrage — 39k Zeilen/h nach Loki, davon fast alles
+        # NOERROR. denial behaelt NXDOMAIN/SERVFAIL/REFUSED, also das Diagnostische.
         log . {
-            class all
+            class denial
         }
         prometheus :9153
 

--- a/kubernetes/infrastructure/observability/vector/base/vector-aggregator.toml
+++ b/kubernetes/infrastructure/observability/vector/base/vector-aggregator.toml
@@ -137,12 +137,15 @@ if !exists(.timestamp) {
   .timestamp = now()
 }
 
-# Standardize log level
+# Standardize log level.
+# Frueher ein Substring-Test auf "ERROR" — dadurch galt CoreDNS' NOERROR-Rcode als
+# Fehler und produzierte 39k falsche error-Zeilen/h. Jetzt nur explizite
+# Level-Marker: [ERROR], level=error, "level":"error", klog E0806.
 if exists(.level) {
   .level = downcase(to_string(.level) ?? "info")
-} else if contains(to_string(.message) ?? "", "ERROR") || contains(to_string(.message) ?? "", "error") {
+} else if match(to_string(.message) ?? "", r'(?i)(\[(error|fatal)\]|\blevel="?(error|fatal)\b|"level"\s*:\s*"(error|fatal)"|^E[0-9]{4} )') {
   .level = "error"
-} else if contains(to_string(.message) ?? "", "WARN") || contains(to_string(.message) ?? "", "warn") {
+} else if match(to_string(.message) ?? "", r'(?i)(\[warn(ing)?\]|\blevel="?warn(ing)?\b|"level"\s*:\s*"warn(ing)?"|^W[0-9]{4} )') {
   .level = "warn"
 } else {
   .level = "info"


### PR DESCRIPTION
Die Level-Erkennung in Vector war ein Substring-Test auf 'ERROR'. CoreDNS' NOERROR-Rcode enthaelt diesen String — dadurch galten 39.539 erfolgreiche DNS-Abfragen pro Stunde als Fehler. Jetzt werden nur explizite Level-Marker gematcht: [ERROR], level=error, "level":"error", klog E0806. Gegen 12 echte Logzeilen getestet, 0 Fehlklassifikationen.

CoreDNS loggte mit class all jede einzelne Abfrage — 39k Zeilen/h nach Loki, fast alles NOERROR. Auf class denial umgestellt: NXDOMAIN, SERVFAIL und REFUSED bleiben, das Rauschen faellt weg.