### PR TITLE
fix tempo streaming + homepage selectors

### DIFF
--- a/kubernetes/apps/uptime-kuma/base/httproute.yaml
+++ b/kubernetes/apps/uptime-kuma/base/httproute.yaml
@@ -4,6 +4,7 @@ metadata:
   name: uptime-kuma
   annotations:
     gethomepage.dev/enabled: "true"
+    gethomepage.dev/pod-selector: "app=uptime-kuma"
     gethomepage.dev/name: Status Page
     gethomepage.dev/description: 🔒 Uptime Monitoring (VPN-only via NetBird)
     gethomepage.dev/group: Observability

--- a/kubernetes/infrastructure/argocd/base/httproute.yaml
+++ b/kubernetes/infrastructure/argocd/base/httproute.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: argocd
   annotations:
     gethomepage.dev/enabled: "true"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=argocd-server"
     gethomepage.dev/name: ArgoCD
     gethomepage.dev/description: 🔒 GitOps Continuous Delivery (VPN-only via NetBird)
     gethomepage.dev/group: Platform

--- a/kubernetes/infrastructure/network/cilium/base/hubble-httproute.yaml
+++ b/kubernetes/infrastructure/network/cilium/base/hubble-httproute.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: kube-system
   annotations:
     gethomepage.dev/enabled: "true"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=hubble-relay"
     gethomepage.dev/name: Hubble
     gethomepage.dev/description: 🔒 Cilium Network Observability (VPN-only via NetBird)
     gethomepage.dev/group: Observability

--- a/kubernetes/infrastructure/network/coredns/base/coredns-config.yaml
+++ b/kubernetes/infrastructure/network/coredns/base/coredns-config.yaml
@@ -14,8 +14,10 @@ data:
             lameduck 5s
         }
         ready
+        # class all loggte JEDE Abfrage — 39k Zeilen/h nach Loki, davon fast alles
+        # NOERROR. denial behaelt NXDOMAIN/SERVFAIL/REFUSED, also das Diagnostische.
         log . {
-            class all
+            class denial
         }
         prometheus :9153
 

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/datasources/tempo.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/datasources/tempo.yaml
@@ -20,6 +20,11 @@ spec:
     uid: tempo
     jsonData:
       httpMethod: GET
+      # tempo-gateway ist nginx (HTTP/1.1). Streaming spricht gRPC gegen dieselbe URL
+      # → "frame too large, looked like an HTTP/1.1 header", Suche/Drilldown bleiben leer.
+      streamingEnabled:
+        search: false
+        metrics: false
       tracesToLogsV2:
         datasourceUid: loki
         filterByTraceID: true

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/http-route.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/http-route.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: grafana
   annotations:
     gethomepage.dev/enabled: "true"
+    gethomepage.dev/pod-selector: "app=grafana"
     gethomepage.dev/name: Grafana
     gethomepage.dev/description: 🔒 Dashboards & Metrics (VPN-only via NetBird)
     gethomepage.dev/group: Observability

--- a/kubernetes/infrastructure/observability/elasticsearch/base/cluster/jaeger-roles.yaml
+++ b/kubernetes/infrastructure/observability/elasticsearch/base/cluster/jaeger-roles.yaml
@@ -40,6 +40,9 @@ stringData:
     prometheus_exporter:
       cluster:
         - monitor
+        # read_slm: sonst 403 auf _slm/stats → elasticsearch_slm_* leer
+        # → ElasticsearchSnapshotStale kann nie feuern
+        - read_slm
       indices:
         - names:
             - "*"

--- a/kubernetes/infrastructure/observability/jaeger/base/httproute.yaml
+++ b/kubernetes/infrastructure/observability/jaeger/base/httproute.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: jaeger
   annotations:
     gethomepage.dev/enabled: "true"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=jaeger-collector"
     gethomepage.dev/name: Jaeger
     gethomepage.dev/description: 🔒 Distributed Tracing (VPN-only via NetBird)
     gethomepage.dev/group: Observability

--- a/kubernetes/infrastructure/observability/kibana/base/kibana-httproute.yaml
+++ b/kubernetes/infrastructure/observability/kibana/base/kibana-httproute.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/component: log-visualization
   annotations:
     gethomepage.dev/enabled: "true"
+    gethomepage.dev/pod-selector: "common.k8s.elastic.co/type=kibana"
     gethomepage.dev/name: Kibana
     gethomepage.dev/description: 🔒 Log Analytics (VPN-only via NetBird)
     gethomepage.dev/group: Observability

--- a/kubernetes/infrastructure/observability/vector/base/vector-aggregator.toml
+++ b/kubernetes/infrastructure/observability/vector/base/vector-aggregator.toml
@@ -137,12 +137,15 @@ if !exists(.timestamp) {
   .timestamp = now()
 }
 
-# Standardize log level
+# Standardize log level.
+# Frueher ein Substring-Test auf "ERROR" — dadurch galt CoreDNS' NOERROR-Rcode als
+# Fehler und produzierte 39k falsche error-Zeilen/h. Jetzt nur explizite
+# Level-Marker: [ERROR], level=error, "level":"error", klog E0806.
 if exists(.level) {
   .level = downcase(to_string(.level) ?? "info")
-} else if contains(to_string(.message) ?? "", "ERROR") || contains(to_string(.message) ?? "", "error") {
+} else if match(to_string(.message) ?? "", r'(?i)(\[(error|fatal)\]|\blevel="?(error|fatal)\b|"level"\s*:\s*"(error|fatal)"|^E[0-9]{4} )') {
   .level = "error"
-} else if contains(to_string(.message) ?? "", "WARN") || contains(to_string(.message) ?? "", "warn") {
+} else if match(to_string(.message) ?? "", r'(?i)(\[warn(ing)?\]|\blevel="?warn(ing)?\b|"level"\s*:\s*"warn(ing)?"|^W[0-9]{4} )') {
   .level = "warn"
 } else {
   .level = "info"

--- a/kubernetes/infrastructure/operators/renovate/base/kustomization.yaml
+++ b/kubernetes/infrastructure/operators/renovate/base/kustomization.yaml
@@ -28,6 +28,7 @@ helmCharts:
         enabled: true
         annotations:
           gethomepage.dev/enabled: "true"
+          gethomepage.dev/pod-selector: "app=renovate-operator-renovate-operator"
           gethomepage.dev/name: Renovate
           gethomepage.dev/description: 🔒 Dependency Updates (VPN-only via NetBird)
           gethomepage.dev/group: Platform

--- a/kubernetes/infrastructure/storage/rook-ceph/base/http-route.yaml
+++ b/kubernetes/infrastructure/storage/rook-ceph/base/http-route.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: rook-ceph
   annotations:
     gethomepage.dev/enabled: "true"
+    gethomepage.dev/pod-selector: "app=rook-ceph-mgr"
     gethomepage.dev/name: Ceph Dashboard
     gethomepage.dev/description: 🔒 Storage Cluster (VPN-only via NetBird)
     gethomepage.dev/group: Storage

--- a/kubernetes/platform/identity/keycloak/base/httproute.yaml
+++ b/kubernetes/platform/identity/keycloak/base/httproute.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/part-of: platform-identity
   annotations:
     gethomepage.dev/enabled: "true"
+    gethomepage.dev/pod-selector: "app=keycloak"
     gethomepage.dev/name: Keycloak
     gethomepage.dev/description: 🔒 SSO / Identity Provider (VPN-only via NetBird)
     gethomepage.dev/group: Identity

--- a/kubernetes/tenants/drova/console/httproute.yaml
+++ b/kubernetes/tenants/drova/console/httproute.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: drova
   annotations:
     gethomepage.dev/enabled: "true"
+    gethomepage.dev/pod-selector: "app=redpanda-console"
     gethomepage.dev/name: Redpanda Console
     gethomepage.dev/description: 🔒 Kafka UI (VPN-only via NetBird)
     gethomepage.dev/group: Data

--- a/kubernetes/tenants/n8n-prod/app/httproute.yaml
+++ b/kubernetes/tenants/n8n-prod/app/httproute.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: n8n-prod
   annotations:
     gethomepage.dev/enabled: "true"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=n8n"
     gethomepage.dev/name: n8n
     gethomepage.dev/description: 🌍 Workflow Automation (Public via Cloudflare)
     gethomepage.dev/group: Apps


### PR DESCRIPTION
Grafana sprach gRPC gegen tempo-gateway (nginx/HTTP) → Trace-Suche blieb leer obwohl die Traces da sind. Streaming aus.

homepage: pod-selector fehlte, homepage riet `app.kubernetes.io/name=<routename>` → 10 Widgets "not found". Selektoren gegen Live-Pods verifiziert.

es-exporter: prometheus_exporter-Rolle fehlte read_slm → 403 alle 4s, elasticsearch_slm_* leer, ElasticsearchSnapshotStale war blind.