### PR TITLE
fix tempo overrides schema

### DIFF
--- a/kubernetes/infrastructure/observability/tempo/base/values.yaml
+++ b/kubernetes/infrastructure/observability/tempo/base/values.yaml
@@ -90,36 +90,44 @@ tempo:
 
   # per_tenant_overrides at root level feeds tempo-runtime ConfigMap
 
-# Enables metrics-generator processors for all tenants via tempo-runtime ConfigMap.
-# The chart template uses `.Values.per_tenant_overrides` → `overrides:` in the runtime YAML.
-# Without this the ConfigMap renders `overrides: null` and the distributor sends 0
-# spans to the metrics-generator (tempo_distributor_metrics_generator_clients stays 0).
+# Tempo 2.9 kennt zwei Overrides-Schemas. Flache Keys (metrics_generator_processors)
+# sind "legacy", verschachtelte sind "new". Statisch und per-tenant MUESSEN dasselbe
+# sein, sonst: 'Overrides config type mismatch' (config_type=legacy static_config_type=new)
+# und Tempo verwirft die per-tenant-Overrides KOMPLETT — still, nur eine warn-Zeile
+# beim Start. Folge: 0 aktive Prozessoren, keine span-metrics/service-graphs/local-blocks,
+# TraceQL-Metrics liefern leere Serien und Traces Drilldown bleibt leer.
 #
-# ⚠ Battle-tested 2026-05-16: tenant-key MUSS "single-tenant" sein, NICHT "" (empty).
-# Mit multitenancy_enabled: false nutzt Tempo "single-tenant" als default tenant
-# (sichtbar in tempo_distributor_spans_received_total{tenant="single-tenant"}).
-# Empty-string-key wird ignoriert → kein Effekt.
+# tenant-key MUSS "single-tenant" sein (Tempo-Default bei multitenancy_enabled: false),
+# NICHT "" — sichtbar in tempo_distributor_spans_received_total{tenant="single-tenant"}.
+#
+# `global_overrides` gab es in diesem Chart nie — der Key wird nirgends gelesen.
+# Statische Defaults gehoeren unter `overrides.defaults`.
+overrides:
+  defaults:
+    metrics_generator:
+      processors:
+        - service-graphs
+        - span-metrics
+        - local-blocks
+      max_active_series: 50000
+    ingestion:
+      rate_limit_bytes: 20000000
+      burst_size_bytes: 30000000
+      max_traces_per_user: 50000
+  per_tenant_override_config: /runtime-config/overrides.yaml
+
 per_tenant_overrides:
   "single-tenant":
-    metrics_generator_processors:
-      - service-graphs
-      - span-metrics
-      - local-blocks
-    metrics_generator_max_active_series: 50000
-    ingestion_rate_limit_bytes: 20000000
-    ingestion_burst_size_bytes: 30000000
-    max_traces_per_user: 50000
-
-global_overrides:
-  defaults:
-    metrics_generator_processors:
-      - service-graphs
-      - span-metrics
-      - local-blocks
-    metrics_generator_max_active_series: 50000
-    ingestion_rate_limit_bytes: 20000000
-    ingestion_burst_size_bytes: 30000000
-    max_traces_per_user: 50000
+    metrics_generator:
+      processors:
+        - service-graphs
+        - span-metrics
+        - local-blocks
+      max_active_series: 50000
+    ingestion:
+      rate_limit_bytes: 20000000
+      burst_size_bytes: 30000000
+      max_traces_per_user: 50000
 
 # Distributor - Ingests traces and forwards to ingesters
 distributor:


### PR DESCRIPTION
Tempo 2.9 verwarf die per-tenant-Overrides komplett: runtime-Datei war legacy-Format, statische Config new — 'Overrides config type mismatch, config_type=legacy static_config_type=new', nur eine warn-Zeile beim Start.

Folge: 0 aktive Prozessoren. Kein span-metrics, kein service-graphs, kein local-blocks. registry active_series=0 bei 1.53 Spans/s. TraceQL-Metrics lieferten leere Serien, Traces Drilldown blieb leer (Suche ging, deshalb fiel es nicht auf).

Zusaetzlich: global_overrides wird von diesem Chart nirgends gelesen — war tote Config, daher overrides.defaults leer. Statische Defaults gehoeren unter overrides.defaults.