### PR TITLE
remove dead alert rules

### DIFF
--- a/.github/tests/alerts/tempo_generator_test.yaml
+++ b/.github/tests/alerts/tempo_generator_test.yaml
@@ -1,0 +1,52 @@
+# promtool unit tests — Tempo metrics-generator Watchdog (Fire + Negativ).
+# Run: python3 .github/scripts/test-alerts.py
+rule_files:
+  - .rules.generated.yaml
+evaluation_interval: 1m
+tests:
+  # ── FIRES: Spans kommen an, active_series bleibt 0 (Zustand vom 2026-08-06) ──
+  # Counter linear steigend => rate()>0 durchgehend. active_series flach auf 0.
+  # eval_time=25m liegt weit im "for: 15m" und weg vom Datenrand.
+  - interval: 1m
+    input_series:
+      - series: 'tempo_metrics_generator_registry_active_series{pod="tempo-metrics-generator-a"}'
+        values: '0x40'
+      - series: 'tempo_metrics_generator_spans_received_total{tenant="single-tenant"}'
+        values: '0+90x40'
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: TempoMetricsGeneratorNotProcessing
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: tempo
+              priority: P2
+            exp_annotations:
+              dashboard_url: "/d/tempo-service-graph"
+              summary: "Tempo metrics-generator bekommt Spans, erzeugt aber keine Serien"
+              description: "active_series=0 bei laufendem Span-Eingang — span-metrics/service-graphs/local-blocks liefern nichts. TraceQL-Metrics geben leere Serien zurueck, Traces Drilldown bleibt leer. Trace-SUCHE funktioniert weiter, deshalb faellt es sonst nicht auf."
+              action: "kubectl -n monitoring logs deploy/tempo-metrics-generator | grep -i 'type mismatch'; kubectl -n monitoring get --raw /status/overrides/single-tenant (processors darf nicht leer sein); Schema in tempo/base/values.yaml pruefen — overrides.defaults und per_tenant_overrides muessen BEIDE verschachtelt sein."
+
+  # ── NICHT: Prozessoren arbeiten (active_series > 0) ──
+  - interval: 1m
+    input_series:
+      - series: 'tempo_metrics_generator_registry_active_series{pod="tempo-metrics-generator-a"}'
+        values: '1200x40'
+      - series: 'tempo_metrics_generator_spans_received_total{tenant="single-tenant"}'
+        values: '0+90x40'
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: TempoMetricsGeneratorNotProcessing
+        exp_alerts: []
+
+  # ── NICHT: keine Spans (idle) — 0 Serien sind dann korrekt, kein Defekt ──
+  - interval: 1m
+    input_series:
+      - series: 'tempo_metrics_generator_registry_active_series{pod="tempo-metrics-generator-a"}'
+        values: '0x40'
+      - series: 'tempo_metrics_generator_spans_received_total{tenant="single-tenant"}'
+        values: '500x40'
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: TempoMetricsGeneratorNotProcessing
+        exp_alerts: []

--- a/kubernetes/infrastructure/observability/alerting/alerts/base/dead-alert-check.yaml
+++ b/kubernetes/infrastructure/observability/alerting/alerts/base/dead-alert-check.yaml
@@ -1,0 +1,105 @@
+# Kreuzprobe: feuert jeder Alert-Rule auf Metriken, die es wirklich gibt?
+# Ein Alert auf einer nicht existierenden Metrik ist stiller als gar keiner — er
+# suggeriert Abdeckung. Am 2026-08-06 waren so 20 von 295 Rules tot, darunter
+# ElasticsearchSnapshotStale (403 auf _slm) und der Tempo-Generator-Blindspot.
+#
+# Laeuft nicht in CI, weil dort kein Prometheus mit Live-Metriknamen existiert.
+# Bei Fund exit 1 -> Job failed -> upstream KubeJobFailed alertet (gleiches Muster
+# wie die DR-Verify-CronJobs).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dead-alert-check
+data:
+  check.py: |
+    import json, re, sys, urllib.request
+
+    PROM = "http://kube-prometheus-stack-prometheus.monitoring.svc:9090/api/v1"
+
+    def get(path):
+        with urllib.request.urlopen(PROM + path, timeout=60) as r:
+            return json.load(r)
+
+    known = set(get("/label/__name__/values")["data"])
+    rules = []
+    for g in get("/rules")["data"]["groups"]:
+        for r in g["rules"]:
+            if r.get("type") == "alerting":
+                rules.append((r["name"], r.get("query", "")))
+
+    # PromQL-Funktionen/Keywords rausfiltern, damit nur Metriknamen uebrig bleiben.
+    KW = {
+        "by","on","without","group_left","group_right","and","or","unless","offset","bool","ignoring",
+        "rate","irate","sum","avg","min","max","count","increase","absent","absent_over_time","delta",
+        "idelta","predict_linear","histogram_quantile","clamp_max","clamp_min","topk","bottomk","time",
+        "vector","scalar","count_over_time","avg_over_time","max_over_time","min_over_time","sum_over_time",
+        "stddev","stdvar","quantile","label_replace","label_join","changes","resets","deriv","floor",
+        "ceil","round","abs","sgn","last_over_time","present_over_time","quantile_over_time",
+        "stddev_over_time","group","le","e",
+    }
+    tok = re.compile(r"\b([a-zA-Z_:][a-zA-Z0-9_:]*)\s*(?:\{|\[|\)|\s|$)")
+
+    dead = []
+    for name, q in rules:
+        used = {m for m in tok.findall(q) if m not in KW and not m.isdigit()}
+        used = {m for m in used if "_" in m or m.startswith("up")}
+        missing = sorted(m for m in used if m not in known)
+        # nur melden wenn ALLE Metriken fehlen — sonst false-positives bei
+        # optionalen Joins (z.B. kube_pod_labels).
+        if used and len(missing) == len(used):
+            dead.append((name, missing))
+
+    print(f"{len(rules)} alert rules, {len(known)} metric names in Prometheus")
+    if not dead:
+        print("OK — jede Rule hat mindestens eine existierende Metrik")
+        sys.exit(0)
+    print(f"\n{len(dead)} tote Rule(s) — koennen nie feuern:")
+    for n, m in sorted(dead):
+        print(f"  {n}: {', '.join(m)}")
+    print("\nEntweder Metrikname korrigieren, Exporter installieren, oder Rule "
+          "bewusst deaktivieren/als DORMANT dokumentieren.")
+    sys.exit(1)
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: dead-alert-check
+spec:
+  schedule: "17 6 * * 1"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: check
+              image: docker.io/library/python:3.14-alpine@sha256:5a824eb82cc75361f98611f3cfc5091ea33f10a6ccea4d4ebdabbc523b9a1614
+              command: ["python3", "/scripts/check.py"]
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              resources:
+                requests:
+                  cpu: 20m
+                  memory: 64Mi
+                limits:
+                  cpu: 200m
+                  memory: 128Mi
+          volumes:
+            - name: scripts
+              configMap:
+                name: dead-alert-check

--- a/kubernetes/infrastructure/observability/alerting/alerts/base/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/alerting/alerts/base/kustomization.yaml
@@ -15,5 +15,6 @@ resources:
   - slack-webhook-sealed.yaml           # Alertmanager Slack webhook (monitoring namespace, active)
   - slack-webhook-critical-sealed.yaml  # -> #alerts-critical
   - slack-webhook-security-sealed.yaml  # -> #alerts-security
+  - dead-alert-check.yaml               # woechentliche Kreuzprobe Rules <-> existierende Metriken
   # NOTE: argocd-slack-webhook-sealed.yaml moved to controllers/argocd/ (namespace must be argocd)
   # NOTE: All PrometheusRule files migrated to kube-prometheus-stack/base/alerts/ (Golden Pattern: component-organized).

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/istio.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/network/istio.yaml
@@ -57,14 +57,18 @@ spec:
             summary: "istiod stellt Workload-Certs nicht aus"
             description: "CSRs kommen an, aber Issuance schlaegt fehl — neue Pods kriegen keine mTLS-Identity, Rotation stockt."
             action: "kubectl -n istio-system logs deploy/istiod | grep -i csr; ztunnel↔istiod-Verbindung pruefen."
-        - alert: IstioXdsConfigRejected
-          expr: rate(pilot_total_xds_rejects[10m]) > 0
-          for: 10m
+        # War IstioXdsConfigRejected auf pilot_total_xds_rejects — die Metrik hat Istio
+        # entfernt (1.30 kennt sie nicht mehr), der Alert konnte nie feuern. Ersatz sind
+        # die Konflikt-Zaehler, die istiod heute wirklich exportiert: sie zeigen Config,
+        # die zu doppelten/kollidierenden Envoy-Ressourcen fuehrt. Baseline live = 0.
+        - alert: IstioConfigConflicts
+          expr: pilot_duplicate_envoy_clusters > 0 or pilot_conflict_inbound_listener > 0
+          for: 15m
           labels:
             severity: warning
             component: network
             priority: P2
           annotations:
-            summary: "Proxies lehnen istiod-Config ab (xDS reject)"
-            description: "Ausgerollte Mesh-Config ist fuer ztunnel/waypoints ungueltig — Daten-Ebene laeuft auf alter Config weiter."
-            action: "kubectl -n istio-system logs deploy/istiod | grep -i reject; letzte Istio-/mesh-Config-Aenderung pruefen."
+            summary: "istiod erzeugt kollidierende Envoy-Config"
+            description: "Doppelte Cluster oder kollidierende Inbound-Listener — Mesh-Routing wird unvorhersehbar, betroffene Proxies koennen auf alter Config haengen bleiben."
+            action: "istioctl analyze -A; kubectl -n istio-system logs deploy/istiod | grep -iE 'conflict|duplicate'; letzte VirtualService-/Gateway-Aenderung pruefen."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/observability/tempo.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/observability/tempo.yaml
@@ -23,3 +23,23 @@ spec:
             summary: "Tempo distributor down — traces being dropped"
             description: "Apps cannot push traces; OTel-Collector queue grows. (Tracing only — no user impact.)"
             action: "kubectl -n tempo get pod -l app.kubernetes.io/component=distributor + logs; the OTel queue grows until restored (tracing only)."
+
+        # Spans kommen an, aber kein Prozessor erzeugt Serien. Genau der Zustand vom
+        # 2026-08-06: Overrides-Schema-Mismatch (legacy vs new) → Tempo verwarf die
+        # per-tenant-Overrides still, 0 Prozessoren, TraceQL-Metrics leer, Traces
+        # Drilldown blind. Sichtbar war das nur in einer warn-Zeile beim Generator-Start.
+        - alert: TempoMetricsGeneratorNotProcessing
+          expr: |
+            sum(tempo_metrics_generator_registry_active_series) == 0
+            and
+            sum(rate(tempo_metrics_generator_spans_received_total[15m])) > 0
+          for: 15m
+          labels:
+            severity: warning
+            component: tempo
+            priority: P2
+          annotations:
+            dashboard_url: "/d/tempo-service-graph"
+            summary: "Tempo metrics-generator bekommt Spans, erzeugt aber keine Serien"
+            description: "active_series=0 bei laufendem Span-Eingang — span-metrics/service-graphs/local-blocks liefern nichts. TraceQL-Metrics geben leere Serien zurueck, Traces Drilldown bleibt leer. Trace-SUCHE funktioniert weiter, deshalb faellt es sonst nicht auf."
+            action: "kubectl -n monitoring logs deploy/tempo-metrics-generator | grep -i 'type mismatch'; kubectl -n monitoring get --raw /status/overrides/single-tenant (processors darf nicht leer sein); Schema in tempo/base/values.yaml pruefen — overrides.defaults und per_tenant_overrides muessen BEIDE verschachtelt sein."

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/observability/tracing.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/observability/tracing.yaml
@@ -12,7 +12,9 @@ spec:
       interval: 60s
       rules:
         - alert: OtelCollectorExportFailing
-          expr: rate(otelcol_exporter_send_failed_spans_total[5m]) > 0
+          # OTel-Collector exportiert diese Counter OHNE _total-Suffix.
+          # Mit _total gab es die Serie nicht → Alert konnte nie feuern.
+          expr: rate(otelcol_exporter_send_failed_spans[5m]) > 0
           for: 10m
           labels:
             severity: warning

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
@@ -174,6 +174,28 @@ defaultRules:
     CPUThrottlingHigh: true             # upstream fires at 25% — ContainerCPUThrottlingHigh@75% is the tuned one
     KubeCPUOvercommit: true             # homelab is deliberately overcommitted (nipogi)
     KubeMemoryOvercommit: true
+    # ── Tote Alerts: Metrik existiert hier nicht, koennen also nie feuern (2026-08-06) ──
+    # Ein Alert auf einer nicht existierenden Metrik ist stiller als gar keiner — er
+    # suggeriert Abdeckung. Gefunden per Kreuzprobe aller Rules gegen /label/__name__/values.
+    # Talos hat kein systemd und kein MD-RAID:
+    NodeSystemdServiceFailed: true
+    NodeSystemdServiceCrashlooping: true
+    NodeRAIDDegraded: true
+    NodeRAIDDiskFailure: true
+    # Talos-Kubelet exponiert weder Cert-Manager- noch PLEG-Quantile-Metriken:
+    KubeletServerCertificateExpiration: true
+    KubeletServerCertificateRenewalErrors: true
+    KubeletPlegDurationHigh: true
+    # kube-state-metrics Self-Metrics werden nicht gescrapet:
+    KubeStateMetricsListErrors: true
+    KubeStateMetricsWatchErrors: true
+    KubeStateMetricsShardingMismatch: true
+    KubeStateMetricsShardsMissing: true
+    # Prometheus schreibt hier nicht remote (nur remote-write-RECEIVER fuer OTel):
+    PrometheusRemoteStorageFailures: true
+    PrometheusRemoteWriteBehind: true
+    PrometheusRemoteWriteDesiredShards: true
+    PrometheusSDRefreshFailure: true
   rules:
     alertmanager: true
     configReloaders: true


### PR DESCRIPTION
Kreuzprobe aller 295 geladenen Alert-Rules gegen die 6698 real existierenden Metriknamen in Prometheus: 20 Rules referenzieren ausschliesslich Metriken, die es hier nicht gibt — sie koennen nie feuern und suggerieren trotzdem Abdeckung.

15 davon sind kube-prometheus-stack defaultRules (Talos hat kein systemd/MD-RAID, Kubelet exponiert die Cert-Metriken nicht, KSM-Self-Metrics ungescrapet, kein remote-write-Sender) -> defaultRules.disabled.

2 echte Fixes:
- OtelCollectorExportFailing: otelcol_exporter_send_failed_spans_total -> ohne _total (Collector exportiert diese Counter ohne Suffix)
- IstioXdsConfigRejected: pilot_total_xds_rejects gibt es seit Istio 1.30 nicht mehr -> IstioConfigConflicts auf pilot_duplicate_envoy_clusters/pilot_conflict_inbound_listener (Baseline live 0)

TrivyCriticalCVEFound bleibt unveraendert — ist als DORMANT bis Task #23 dokumentiert, bewusste Entscheidung.
ElasticsearchSnapshotStale heilt mit #601 (read_slm).

Plus CronJob dead-alert-check (woechentlich): faehrt dieselbe Kreuzprobe live, exit 1 bei Fund -> KubeJobFailed alertet. In CI nicht moeglich, dort gibt es kein Prometheus.