### PR TITLE
es exporter needs manage_slm

### DIFF
--- a/kubernetes/infrastructure/observability/elasticsearch/base/cluster/jaeger-roles.yaml
+++ b/kubernetes/infrastructure/observability/elasticsearch/base/cluster/jaeger-roles.yaml
@@ -40,9 +40,12 @@ stringData:
     prometheus_exporter:
       cluster:
         - monitor
-        # read_slm: sonst 403 auf _slm/stats → elasticsearch_slm_* leer
-        # → ElasticsearchSnapshotStale kann nie feuern
-        - read_slm
+        # manage_slm, nicht read_slm: der Exporter ruft GET /_slm/stats, das ist
+        # cluster:admin/slm/stats. read_slm deckt nur slm/get + slm/status ab,
+        # stats faellt raus -> 403 -> elasticsearch_slm_* leer -> der einzige
+        # Waechter ueber die ES-Snapshots (ElasticsearchSnapshotStale) ist blind.
+        # Schreibrechte werden dadurch nicht genutzt, indices bleibt auf monitor.
+        - manage_slm
       indices:
         - names:
             - "*"


### PR DESCRIPTION
Der Exporter ruft GET /_slm/stats = cluster:admin/slm/stats. read_slm deckt nur slm/get + slm/status ab, stats faellt raus -> 403 alle 4s -> elasticsearch_slm_* bleibt leer.

Folge: ElasticsearchSnapshotStale kann nie feuern. Das ist der einzige Waechter ueber die ES-Snapshots (SLM daily-snapshots -> Ceph RGW S3); Velero sichert elastic-system nicht.

manage_slm deckt cluster:admin/slm/* ab. Schreibpfade werden nicht genutzt, indices bleibt monitor.

Greift erst nach ES-Pod-Neustart: ECK kopiert roles.yml per Init-Container nach config/, Secret-Aenderungen erreichen ES nicht zur Laufzeit.