### PR TITLE
disable ksm rule group not members

### DIFF
--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
@@ -186,11 +186,10 @@ defaultRules:
     KubeletServerCertificateExpiration: true
     KubeletServerCertificateRenewalErrors: true
     KubeletPlegDurationHigh: true
-    # kube-state-metrics Self-Metrics werden nicht gescrapet:
-    KubeStateMetricsListErrors: true
-    KubeStateMetricsWatchErrors: true
-    KubeStateMetricsShardingMismatch: true
-    KubeStateMetricsShardsMissing: true
+    # kube-state-metrics: siehe rules.kubeStateMetrics unten — die Gruppe besteht
+    # NUR aus diesen 4 Rules. Einzeln deaktiviert rendert der Chart die Gruppe mit
+    # rules: null, das CRD lehnt das ab ("must be of type array") und ArgoCDs
+    # server-side dry-run scheitert -> ComparisonError -> App diffed GAR NICHTS mehr.
     # Prometheus schreibt hier nicht remote (nur remote-write-RECEIVER fuer OTel):
     PrometheusRemoteStorageFailures: true
     PrometheusRemoteWriteBehind: true
@@ -204,7 +203,7 @@ defaultRules:
     kubernetesResources: true
     kubernetesStorage: true
     kubernetesSystem: true
-    kubeStateMetrics: true
+    kubeStateMetrics: false   # Self-Metrics ungescrapet — ganze Gruppe aus
     kubePrometheusGeneral: true
     kubePrometheusNodeRecording: true
     nodeExporterAlerting: true


### PR DESCRIPTION
Regression aus #604: dort wurden die 4 KubeStateMetrics*-Rules einzeln in defaultRules.disabled gesetzt. Die Chart-Gruppe kube-state-metrics besteht aber GENAU aus diesen 4 — uebrig blieb eine Gruppe mit rules: null.

Das CRD lehnt das ab ('spec.groups[0].rules must be of type array'), ArgoCDs server-side dry-run scheitert daran und die App kippt in ComparisonError. Folge: kube-prometheus-stack-in-cluster stand auf Unknown und hat GAR NICHTS mehr appliziert — auch die uebrigen Fixes aus #604 nicht.

Richtig ist defaultRules.rules.kubeStateMetrics: false (ganze Gruppe), nicht die Mitglieder einzeln.

Gerendert verifiziert: 0 Gruppen mit rules: null, 0 kube-state-metrics-PrometheusRule. Die anderen deaktivierten Rules betreffen Gruppen mit vielen weiteren Mitgliedern (node-exporter 23, kubelet 7, prometheus 29) — dort tritt das Problem nicht auf.