### PR TITLE
worm backups via object lock

### DIFF
--- a/kubernetes/infrastructure/storage/velero-schedules/kustomization.yaml
+++ b/kubernetes/infrastructure/storage/velero-schedules/kustomization.yaml
@@ -9,5 +9,6 @@ resources:
   - backup-schedules.yaml
   - tier0-databases-6h-schedule.yaml
   - keycloak-schedule.yaml
+  - worm-weekly-schedule.yaml
   - restore-verify-cronjob.yaml
   - quartal-drill-reminder.yaml

--- a/kubernetes/infrastructure/storage/velero-schedules/worm-weekly-schedule.yaml
+++ b/kubernetes/infrastructure/storage/velero-schedules/worm-weekly-schedule.yaml
@@ -1,0 +1,36 @@
+# WORM-Wochenbackup der Tier-0-Daten in den Object-Lock-Bucket.
+#
+# Ergaenzt tier0-databases-6h, ersetzt es nicht: der 6h-Schedule deckt den
+# normalen RPO ab und darf rotieren. Dieser hier ist die Kopie, die auch ein
+# uebernommener Cluster nicht loeschen kann.
+#
+# ttl 336h == 14d == die COMPLIANCE-Retention des Buckets. Kuerzer waere
+# sinnlos (Velero darf ohnehin nicht loeschen), laenger wuerde Velero
+# aufraeumen wollen, waehrend S3 es verweigert — unnoetiges Fehlerrauschen.
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: worm-weekly
+  namespace: velero
+  labels:
+    backup.tier: tier0
+    backup.type: immutable
+  annotations:
+    description: "Unveraenderliches Wochenbackup (S3 Object Lock COMPLIANCE 14d)"
+    rpo: "7 days"
+spec:
+  # Sonntag 03:30 — ausserhalb des Backup-Fensters der AppProject-Sync-Windows
+  # (deny 02:00-05:00) liegt es bewusst NICHT: hier laeuft kein Deployment,
+  # sondern nur ein Lesevorgang, und die Nacht ist die lastaermste Zeit.
+  schedule: "30 3 * * 0"
+  template:
+    storageLocation: worm-backups
+    ttl: 336h
+    includedNamespaces:
+      - n8n-prod
+      - drova
+      - keycloak
+    includedResources:
+      - '*'
+    includeClusterResources: true
+    defaultVolumesToFsBackup: true

--- a/kubernetes/infrastructure/storage/velero/base/init-velero-buckets-job.yaml
+++ b/kubernetes/infrastructure/storage/velero/base/init-velero-buckets-job.yaml
@@ -133,6 +133,34 @@ spec:
 
           echo "Creating velero-pv-backups bucket..."
           aws s3api create-bucket --bucket velero-pv-backups --endpoint-url=$ENDPOINT 2>&1 || echo "Bucket may already exist"
+          # WORM-Bucket: S3 Object Lock im COMPLIANCE-Modus.
+          # Velero besitzt Loeschrechte auf die anderen Buckets — ein uebernommener
+          # Cluster koennte Backup UND Produktion in einem Zug entfernen. Hier nicht:
+          # COMPLIANCE verweigert das Loeschen fuer die Retention-Dauer JEDEM, auch dem
+          # Bucket-Owner. GOVERNANCE waere per BypassGovernanceRetention umgehbar und
+          # schuetzt nur gegen Versehen.
+          # Object Lock ist NUR bei der Erstellung aktivierbar -> eigener Bucket.
+          echo "Creating velero-worm-backups bucket (Object Lock)..."
+          if aws s3api head-bucket --bucket velero-worm-backups --endpoint-url=$ENDPOINT 2>/dev/null; then
+            echo "velero-worm-backups exists"
+          else
+            aws s3api create-bucket --bucket velero-worm-backups --object-lock-enabled-for-bucket --endpoint-url=$ENDPOINT
+          fi
+          aws s3api put-object-lock-configuration --bucket velero-worm-backups --endpoint-url=$ENDPOINT \
+            --object-lock-configuration '{"ObjectLockEnabled":"Enabled","Rule":{"DefaultRetention":{"Mode":"COMPLIANCE","Days":14}}}'
+          aws s3api get-object-lock-configuration --bucket velero-worm-backups --endpoint-url=$ENDPOINT
+
+          # Selbsttest: schreiben, loeschen versuchen. Der Delete MUSS scheitern — sonst
+          # ist die Sperre wirkungslos und der Job soll rot werden, statt eine
+          # Immutability vorzutaeuschen, die es nicht gibt.
+          echo "worm-selftest" > /tmp/probe
+          aws s3 cp /tmp/probe s3://velero-worm-backups/.worm-selftest --endpoint-url=$ENDPOINT
+          VID=$(aws s3api list-object-versions --bucket velero-worm-backups --prefix .worm-selftest --endpoint-url=$ENDPOINT --query 'Versions[0].VersionId' --output text)
+          if aws s3api delete-object --bucket velero-worm-backups --key .worm-selftest --version-id "$VID" --endpoint-url=$ENDPOINT 2>/dev/null; then
+            echo "ERROR: WORM-Objekt liess sich loeschen - Object Lock wirkt NICHT"
+            exit 1
+          fi
+          echo " Object Lock verifiziert: Loeschen wurde verweigert"
 
           # Verify buckets
           echo "=== Verifying buckets ==="
@@ -141,6 +169,7 @@ spec:
           echo "=== Testing access to buckets ==="
           aws s3 ls s3://velero-cluster-backups --endpoint-url=$ENDPOINT && echo " velero-cluster-backups OK"
           aws s3 ls s3://velero-pv-backups --endpoint-url=$ENDPOINT && echo " velero-pv-backups OK"
+          aws s3 ls s3://velero-worm-backups --endpoint-url=$ENDPOINT && echo " velero-worm-backups OK"
 
           # Restart Velero to pick up new credentials
           echo "Restarting Velero deployment..."

--- a/kubernetes/infrastructure/storage/velero/base/kustomization.yaml
+++ b/kubernetes/infrastructure/storage/velero/base/kustomization.yaml
@@ -46,6 +46,18 @@ helmCharts:
               s3Url: http://rook-ceph-rgw-homelab-objectstore.rook-ceph.svc:80
               insecureSkipTLSVerify: "true"
               checksumAlgorithm: ""  # Ceph RGW rejects SDK-v2 CRC32 checksums
+          # WORM: S3 Object Lock COMPLIANCE 14d. Velero kann hier NICHT loeschen —
+          # das ist der Zweck. Expired-Backup-Reaper laeuft trotzdem und loggt
+          # AccessDenied; das ist erwartet, kein Defekt.
+          - name: worm-backups
+            provider: aws
+            bucket: velero-worm-backups
+            config:
+              region: us-east-1
+              s3ForcePathStyle: "true"
+              s3Url: http://rook-ceph-rgw-homelab-objectstore.rook-ceph.svc:80
+              insecureSkipTLSVerify: "true"
+              checksumAlgorithm: ""
           - name: pv-backups
             provider: aws
             bucket: velero-pv-backups


### PR DESCRIPTION
Velero besitzt S3-Credentials mit Loeschrecht auf seine eigenen Buckets. Ein uebernommener Cluster kann damit Backup UND Produktion in einem Zug entfernen — das ist aktuell die groesste DR-Luecke.

Neuer Bucket velero-worm-backups mit S3 Object Lock, Modus COMPLIANCE, 14d Default-Retention. COMPLIANCE statt GOVERNANCE: GOVERNANCE ist per s3:BypassGovernanceRetention umgehbar und schuetzt nur gegen Versehen, nicht gegen einen uebernommenen Account. In COMPLIANCE kann niemand loeschen, auch der Bucket-Owner nicht.

Object Lock ist nur BEI der Bucket-Erstellung aktivierbar, nicht nachtraeglich — daher ein eigener Bucket statt Umbau der bestehenden. Rooks ObjectBucketClaim unterstuetzt das nicht, deshalb im bestehenden init-velero-buckets-Job statt per OBC. Gleicher Ceph-User: die Unveraenderlichkeit kommt vom Object Lock, nicht von getrennten Credentials.

Selbsttest im Job: Objekt schreiben, loeschen versuchen. Schlaegt der Delete NICHT fehl, exit 1 — sonst wuerde der Job eine Immutability vortaeuschen, die es nicht gibt.

Neuer Schedule worm-weekly (So 03:30, ttl 336h = Retention) auf n8n-prod/drova/keycloak. Ergaenzt tier0-databases-6h, ersetzt es nicht: der 6h-Schedule deckt den RPO ab und darf rotieren.

Kapazitaet: Ceph steht bei 48.8% RAW (671 GiB frei). 14d + woechentlich = max 2 unloeschbare Generationen. Bewusst knapp — WORM-Objekte lassen sich bei Platznot NICHT vorzeitig entfernen.

Erwartet: Veleros Reaper loggt AccessDenied beim Aufraeumen abgelaufener Backups in diesem BSL. Das ist der Zweck, kein Defekt.