### PR TITLE
cp scrape via static configs

### DIFF
--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
@@ -112,16 +112,7 @@ prometheus:
 # surfaces as ClusterAPIServerDown + ControlPlaneNodeDown (symptom, not cause).
 # Re-enable needs proper Talos metrics-exposure (+ etcd client-cert for kubeEtcd).
 kubeControllerManager:
-  enabled: true
-  endpoints:
-    - 192.168.0.101
-  service:
-    enabled: true
-    port: 10257
-    targetPort: 10257
-  serviceMonitor:
-    https: true
-    insecureSkipVerify: true  # self-signed serving cert; authn via SA-Bearer-Token
+  enabled: false  # via additionalScrapeConfigs (job kube-controller-manager)
 
 # 2026-08-07: Direkt-Scrape AKTIV. Der alte Blocker (kein Client-Cert) ist
 # geloest: server.crt aus /system/secrets/etcd traegt die ClientAuth-EKU und
@@ -129,36 +120,15 @@ kubeControllerManager:
 # (mTLS bleibt erzwungen). serverName localhost: das Cert hat CN=ctrl-0, aber
 # SAN localhost — Prometheus validiert dagegen.
 kubeEtcd:
-  enabled: true
-  endpoints:
-    - 192.168.0.101
-  service:
-    enabled: true
-    port: 2379
-    targetPort: 2379
-  serviceMonitor:
-    scheme: https
-    insecureSkipVerify: false
-    serverName: localhost
-    caFile: /etc/prometheus/secrets/etcd-client-cert/ca.crt
-    certFile: /etc/prometheus/secrets/etcd-client-cert/server.crt
-    keyFile: /etc/prometheus/secrets/etcd-client-cert/server.key
+  enabled: false  # SM+Endpoints-Weg tot: ArgoCD excludiert Endpoints (siehe pve-exporter scrape-config: job kube-etcd)
 
 kubeProxy:
   # Cilium replaces Kube Proxy
   enabled: false
 
 kubeScheduler:
-  enabled: true
-  endpoints:
-    - 192.168.0.101
-  service:
-    enabled: true
-    port: 10259
-    targetPort: 10259
+  enabled: false  # via additionalScrapeConfigs (job kube-scheduler)
   serviceMonitor:
-    https: true
-    insecureSkipVerify: true
     relabelings:
       - sourceLabels: [ __meta_kubernetes_pod_node_name ]
         separator: ;

--- a/kubernetes/infrastructure/observability/pve-exporter/base/scrape-config.yaml
+++ b/kubernetes/infrastructure/observability/pve-exporter/base/scrape-config.yaml
@@ -44,3 +44,36 @@ stringData:
       static_configs:
         - targets:
             - prometheus-edge.monitoring.svc.cluster.local:9090
+      # Control-Plane als static_configs statt chart-kubeEtcd: der Chart-Weg
+      # erzeugt manuelle Endpoints-Objekte, und die stehen in ArgoCDs
+      # resource.exclusions (ExcludedResourceWarning) — sie werden NIE angelegt,
+      # der headless-Service bleibt leer, 0 Targets. Statische Jobs brauchen
+      # weder Service noch Endpoints. Job-Namen = upstream-Konvention, damit
+      # Community-Dashboards und Rules greifen.
+      - job_name: kube-etcd
+        scheme: https
+        static_configs:
+          - targets:
+              - 192.168.0.101:2379
+        tls_config:
+          ca_file: /etc/prometheus/secrets/etcd-client-cert/ca.crt
+          cert_file: /etc/prometheus/secrets/etcd-client-cert/server.crt
+          key_file: /etc/prometheus/secrets/etcd-client-cert/server.key
+          # Cert hat CN=ctrl-0, SAN localhost — dagegen validieren
+          server_name: localhost
+      - job_name: kube-controller-manager
+        scheme: https
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        tls_config:
+          insecure_skip_verify: true
+        static_configs:
+          - targets:
+              - 192.168.0.101:10257
+      - job_name: kube-scheduler
+        scheme: https
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        tls_config:
+          insecure_skip_verify: true
+        static_configs:
+          - targets:
+              - 192.168.0.101:10259


### PR DESCRIPTION
Nachbesserung zu #646: der chart-kubeEtcd-Weg erzeugt manuelle Endpoints-Objekte — und Endpoints stehen in ArgoCDs default resource.exclusions (ExcludedResourceWarning an der App). Sie werden nie angelegt, der headless-Service bleibt leer, 0 Targets. Sichtbar nur als Warning-Condition, die App meldet trotzdem Synced/Healthy.

Fix: die 3 Jobs als static_configs im bestehenden additionalScrapeConfigs-Secret (gleiches Muster wie proxmox/federate-edge). Statische Targets brauchen weder Service noch Endpoints.

- kube-etcd: mTLS mit dem gemounteten etcd-client-cert (aus #646), server_name localhost
- kube-controller-manager / kube-scheduler: https + SA-Bearer-Token, insecure_skip_verify (self-signed serving certs)

Job-Namen = upstream-Konvention, damit Dashboards/Rules greifen. Chart-Sektionen zurueck auf enabled:false mit Verweis; der secrets-Mount aus #646 bleibt.