### PR TITLE
homepage dachs style

### DIFF
--- a/kubernetes/apps/uptime-kuma/base/httproute.yaml
+++ b/kubernetes/apps/uptime-kuma/base/httproute.yaml
@@ -6,7 +6,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: "app=uptime-kuma"
     gethomepage.dev/name: Status Page
-    gethomepage.dev/description: 🔒 Uptime Monitoring (VPN-only via NetBird)
+    gethomepage.dev/description: Uptime Monitoring
     gethomepage.dev/group: Observability
     gethomepage.dev/icon: uptime-kuma.png
 spec:

--- a/kubernetes/infrastructure/argocd/base/httproute.yaml
+++ b/kubernetes/infrastructure/argocd/base/httproute.yaml
@@ -7,7 +7,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: "app.kubernetes.io/name=argocd-server"
     gethomepage.dev/name: ArgoCD
-    gethomepage.dev/description: 🔒 GitOps Continuous Delivery (VPN-only via NetBird)
+    gethomepage.dev/description: GitOps Continuous Delivery
     gethomepage.dev/group: Platform
     gethomepage.dev/icon: argo-cd.png
 spec:

--- a/kubernetes/infrastructure/network/cilium/base/hubble-httproute.yaml
+++ b/kubernetes/infrastructure/network/cilium/base/hubble-httproute.yaml
@@ -8,7 +8,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: "app.kubernetes.io/name=hubble-relay"
     gethomepage.dev/name: Hubble
-    gethomepage.dev/description: 🔒 Cilium Network Observability (VPN-only via NetBird)
+    gethomepage.dev/description: Cilium Network Observability
     gethomepage.dev/group: Observability
     gethomepage.dev/icon: cilium.png
 spec:

--- a/kubernetes/infrastructure/observability/blackbox-exporter/base/probes.yaml
+++ b/kubernetes/infrastructure/observability/blackbox-exporter/base/probes.yaml
@@ -58,7 +58,7 @@ spec:
     staticConfig:
       static:
         - https://argo.timourhomelab.org
-        - https://audiobookshelf.timourhomelab.org
+        # - https://audiobookshelf.timourhomelab.org  # geparkt 2026-08-04 — Probe feuerte als Dauer-down
         - https://ceph.timourhomelab.org
         - https://drova.timourhomelab.org
         - https://grafana.timourhomelab.org
@@ -68,7 +68,7 @@ spec:
         - https://kiali.timourhomelab.org
         - https://kibana.timourhomelab.org
         - https://lldap.timourhomelab.org
-        - https://mlflow.timourhomelab.org
+        # - https://mlflow.timourhomelab.org  # geparkt 2026-08-04 — Probe feuerte als Dauer-down
         - https://n8n.timourhomelab.org
         - https://redpanda.timourhomelab.org
         - https://renovate.timourhomelab.org

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/http-route.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/http-route.yaml
@@ -7,7 +7,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: "app=grafana"
     gethomepage.dev/name: Grafana
-    gethomepage.dev/description: 🔒 Dashboards & Metrics (VPN-only via NetBird)
+    gethomepage.dev/description: Dashboards & Metrics
     gethomepage.dev/group: Observability
     gethomepage.dev/icon: grafana.png
 spec:

--- a/kubernetes/infrastructure/observability/dashboards/homepage/base/configmap.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/homepage/base/configmap.yaml
@@ -7,7 +7,9 @@ metadata:
     app.kubernetes.io/name: homepage
 data:
   settings.yaml: |
-    title: homelab
+    title: Tims Homelab
+    headerStyle: boxed
+    hideVersion: true
     theme: dark
     color: slate
     layout:
@@ -43,6 +45,14 @@ data:
     gateway: true
 
   widgets.yaml: |
+    # DACHS-Layout: Titel links, Uhr + Wetter rechts.
+    - openmeteo:
+        label: Duesseldorf
+        latitude: 51.2277
+        longitude: 6.7735
+        timezone: Europe/Berlin
+        units: metric
+        cache: 10
     - kubernetes:
         cluster:
           show: true
@@ -69,6 +79,16 @@ data:
         - GitHub Repo:
             - icon: github.png
               href: https://github.com/Tim275/talos-homelab
+        - Excalidraw:
+            - icon: excalidraw.png
+              href: https://excalidraw.com
+        - Mermaid Live:
+            - icon: si-mermaid
+              href: https://mermaid.live
+    - NetBird:
+        - VPN Dashboard:
+            - icon: netbird.png
+              href: https://app.netbird.io
 
   services.yaml: |
     []

--- a/kubernetes/infrastructure/observability/dashboards/kiali/httproute.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/kiali/httproute.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: Kiali
-    gethomepage.dev/description: 🔒 Istio Service Mesh (VPN-only via NetBird)
+    gethomepage.dev/description: Istio Service Mesh
     gethomepage.dev/group: Observability
 spec:
   parentRefs:

--- a/kubernetes/infrastructure/observability/jaeger/base/httproute.yaml
+++ b/kubernetes/infrastructure/observability/jaeger/base/httproute.yaml
@@ -7,7 +7,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: "app.kubernetes.io/name=jaeger-collector"
     gethomepage.dev/name: Jaeger
-    gethomepage.dev/description: 🔒 Distributed Tracing (VPN-only via NetBird)
+    gethomepage.dev/description: Distributed Tracing
     gethomepage.dev/group: Observability
     gethomepage.dev/icon: jaeger.png
 spec:

--- a/kubernetes/infrastructure/observability/kibana/base/kibana-httproute.yaml
+++ b/kubernetes/infrastructure/observability/kibana/base/kibana-httproute.yaml
@@ -10,7 +10,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: "common.k8s.elastic.co/type=kibana"
     gethomepage.dev/name: Kibana
-    gethomepage.dev/description: 🔒 Log Analytics (VPN-only via NetBird)
+    gethomepage.dev/description: Log Analytics
     gethomepage.dev/group: Observability
     gethomepage.dev/icon: kibana.png
 spec:

--- a/kubernetes/infrastructure/operators/renovate/base/kustomization.yaml
+++ b/kubernetes/infrastructure/operators/renovate/base/kustomization.yaml
@@ -30,7 +30,7 @@ helmCharts:
           gethomepage.dev/enabled: "true"
           gethomepage.dev/pod-selector: "app=renovate-operator-renovate-operator"
           gethomepage.dev/name: Renovate
-          gethomepage.dev/description: 🔒 Dependency Updates (VPN-only via NetBird)
+          gethomepage.dev/description: Dependency Updates
           gethomepage.dev/group: Platform
           gethomepage.dev/icon: renovate.png
         hostnames:

--- a/kubernetes/infrastructure/storage/rook-ceph/base/http-route.yaml
+++ b/kubernetes/infrastructure/storage/rook-ceph/base/http-route.yaml
@@ -7,7 +7,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: "app=rook-ceph-mgr"
     gethomepage.dev/name: Ceph Dashboard
-    gethomepage.dev/description: 🔒 Storage Cluster (VPN-only via NetBird)
+    gethomepage.dev/description: Storage Cluster
     gethomepage.dev/group: Storage
     gethomepage.dev/icon: ceph.png
 spec:

--- a/kubernetes/platform/identity/keycloak/base/httproute.yaml
+++ b/kubernetes/platform/identity/keycloak/base/httproute.yaml
@@ -12,7 +12,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: "app=keycloak"
     gethomepage.dev/name: Keycloak
-    gethomepage.dev/description: 🔒 SSO / Identity Provider (VPN-only via NetBird)
+    gethomepage.dev/description: SSO / Identity Provider
     gethomepage.dev/group: Identity
     gethomepage.dev/icon: keycloak.png
 spec:

--- a/kubernetes/platform/identity/lldap/base/httproute.yaml
+++ b/kubernetes/platform/identity/lldap/base/httproute.yaml
@@ -14,7 +14,7 @@ metadata:
   annotations:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: LLDAP
-    gethomepage.dev/description: 🔒 User Directory (VPN-only via NetBird)
+    gethomepage.dev/description: User Directory
     gethomepage.dev/group: Identity
     gethomepage.dev/icon: lldap.png
 spec:

--- a/kubernetes/tenants/drova/console/httproute.yaml
+++ b/kubernetes/tenants/drova/console/httproute.yaml
@@ -7,7 +7,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: "app=redpanda-console"
     gethomepage.dev/name: Redpanda Console
-    gethomepage.dev/description: 🔒 Kafka UI (VPN-only via NetBird)
+    gethomepage.dev/description: Kafka UI
     gethomepage.dev/group: Data
 spec:
   parentRefs:


### PR DESCRIPTION
Homepage nach dem DACHS-IT-Layout: Titel 'Tims Homelab', headerStyle boxed, Uhr + Wetter (Duesseldorf, open-meteo) rechts oben. Bookmarks ergaenzt: Excalidraw, Mermaid Live, NetBird-Dashboard (echtes Logo).

Schloss-Emojis aus allen 14 Beschreibungen raus — der VPN-Marker ist das netbird.png am Gruppen-Header (Homepage kann pro Kachel nur EIN Icon, und da sitzt das App-Icon; im Beschreibungstext sind Bilder nicht moeglich). Public bleibt 🌍.

Dazu die zwei Dauer-Alerts entschaerft: audiobookshelf + mlflow sind seit 2026-08-04 geparkt, die Blackbox-Probe wusste das nicht und feuerte HomelabPublicServiceDown rund um die Uhr -> auskommentiert mit Marker.