### PR TITLE
business kpi layer

### DIFF
--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/custom-dashboards/business/business-kpis.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/custom-dashboards/business/business-kpis.yaml
@@ -1,0 +1,236 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: business-kpis
+  namespace: grafana
+spec:
+  uid: business-kpis
+  instanceSelector:
+    matchLabels:
+      app: grafana
+  allowCrossNamespaceImport: true
+  folder: Business
+  json: |
+    {
+      "uid": "business-kpis",
+      "title": "Business KPIs",
+      "tags": [
+        "business"
+      ],
+      "timezone": "browser",
+      "schemaVersion": 39,
+      "refresh": "1m",
+      "time": {
+        "from": "now-24h",
+        "to": "now"
+      },
+      "panels": [
+        {
+          "id": 1,
+          "title": "Trip-Events (alle Topics)",
+          "type": "timeseries",
+          "gridPos": {
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 8
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "cps",
+              "custom": {
+                "fillOpacity": 12,
+                "lineWidth": 2
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "business:trip_events:rate5m",
+              "refId": "A",
+              "legendFormat": "Trip-Events (alle Topics)"
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "title": "Edge: erfolgreiche Requests",
+          "type": "timeseries",
+          "gridPos": {
+            "x": 12,
+            "y": 0,
+            "w": 12,
+            "h": 8
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps",
+              "custom": {
+                "fillOpacity": 12,
+                "lineWidth": 2
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "business:edge_success_requests:rate5m",
+              "refId": "A",
+              "legendFormat": "Edge: erfolgreiche Requests"
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "title": "Trips completed /h",
+          "type": "stat",
+          "gridPos": {
+            "x": 0,
+            "y": 8,
+            "w": 8,
+            "h": 6
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "business:trips_completed:rate1h * 3600",
+              "refId": "A",
+              "legendFormat": "Trips completed /h"
+            }
+          ],
+          "options": {
+            "graphMode": "area",
+            "colorMode": "value",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            }
+          }
+        },
+        {
+          "id": 4,
+          "title": "Trips cancelled /h",
+          "type": "stat",
+          "gridPos": {
+            "x": 8,
+            "y": 8,
+            "w": 8,
+            "h": 6
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "business:trips_cancelled:rate1h * 3600",
+              "refId": "A",
+              "legendFormat": "Trips cancelled /h"
+            }
+          ],
+          "options": {
+            "graphMode": "area",
+            "colorMode": "value",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            }
+          }
+        },
+        {
+          "id": 5,
+          "title": "Payments succeeded /h",
+          "type": "stat",
+          "gridPos": {
+            "x": 16,
+            "y": 8,
+            "w": 8,
+            "h": 6
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "business:payments_succeeded:rate1h * 3600",
+              "refId": "A",
+              "legendFormat": "Payments succeeded /h"
+            }
+          ],
+          "options": {
+            "graphMode": "area",
+            "colorMode": "value",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            }
+          }
+        },
+        {
+          "id": 6,
+          "title": "drova API-Requests",
+          "type": "timeseries",
+          "gridPos": {
+            "x": 0,
+            "y": 14,
+            "w": 24,
+            "h": 8
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps",
+              "custom": {
+                "fillOpacity": 12,
+                "lineWidth": 2
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "business:drova_api_requests:rate5m",
+              "refId": "A",
+              "legendFormat": "drova API-Requests"
+            }
+          ]
+        }
+      ]
+    }

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/kustomization.yaml
@@ -23,6 +23,9 @@ resources:
   - datasources/tempo.yaml
   - datasources/elasticsearch.yaml
 
+  # Business-Schicht (7)
+  - custom-dashboards/business/business-kpis.yaml
+
   # Community Dashboards (24) — spec.url + spec.datasources pattern
   # Kubernetes (6)
   - community-dashboards/kubernetes/k8s-apiserver.yaml

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/business/kpis.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/business/kpis.yaml
@@ -1,0 +1,34 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: business-kpis
+  labels:
+    release: kube-prometheus-stack
+spec:
+  # Schicht 7: Geschaefts-Signale statt Technik-Signale. Quelle sind die Kafka-
+  # Topic-Offsets (Offset-Wachstum = Events) und der Envoy-Edge. drova ist ohne
+  # Load-Generator idle — die Serien zeigen dann ehrlich 0. BEWUSST kein
+  # "flow stalled"-Alert: der wuerde auf einem idle Demo-System dauerfeuern.
+  # Topics existieren in zwei Namensschemata (trip-event-x und trip.event.x).
+  groups:
+    - name: business.kpis
+      interval: 60s
+      rules:
+        - record: business:trip_events:rate5m
+          expr: |
+            sum(rate(kafka_topic_partition_current_offset{topic=~"trip-event-.*|trip\\.event\\..*"}[5m]))
+        - record: business:trips_completed:rate1h
+          expr: |
+            sum(rate(kafka_topic_partition_current_offset{topic=~"trip-event-completed|trip\\.event\\.completed"}[1h]))
+        - record: business:trips_cancelled:rate1h
+          expr: |
+            sum(rate(kafka_topic_partition_current_offset{topic=~"trip-event-cancelled|trip\\.event\\.cancelled"}[1h]))
+        - record: business:payments_succeeded:rate1h
+          expr: |
+            sum(rate(kafka_topic_partition_current_offset{topic=~"payment-event-success|payment\\.event\\.success"}[1h]))
+        - record: business:edge_success_requests:rate5m
+          expr: |
+            sum(rate(envoy_cluster_upstream_rq_xx{envoy_response_code_class="2"}[5m]))
+        - record: business:drova_api_requests:rate5m
+          expr: |
+            sum(rate(http_server_request_duration_seconds_count[5m]))

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/business/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/business/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kpis.yaml

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/kustomization.yaml
@@ -17,7 +17,8 @@ resources:
   - storage
   - data
   - network
-  - apps           # multi-tenant app alerts (n8n, keycloak)
+  - apps
+  - business           # multi-tenant app alerts (n8n, keycloak)
   - platform
   - observability
   - compliance


### PR DESCRIPTION
Schicht 7 des Monitoring-Modells: Geschaefts-Signale statt Technik-Signale.

6 Recording-Rules business:* aus real existierenden Serien (heute gelernt: erst /label/__name__/values pruefen): Kafka-Topic-Offset-Wachstum = Event-Rate (trip-events, completed, cancelled, payment-success — beide Topic-Namensschemata), Envoy-Edge-2xx als erfolgreiche User-Requests, drova-API-Rate.

Dashboard 'Business KPIs' (folder Business, uid business-kpis).

BEWUSST kein Stall-Alert: alle Topics stehen ohne Load-Generator auf 0 events/h — ein Alert darauf wuerde auf dem idle Demo-System dauerfeuern. Die Rules zeigen ehrlich 0 und springen mit Demo-Traffic an.