### PR TITLE
standard group icons

### DIFF
--- a/kubernetes/infrastructure/observability/dashboards/homepage/base/configmap.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/homepage/base/configmap.yaml
@@ -13,30 +13,30 @@ data:
     theme: dark
     color: slate
     layout:
-      # icon: netbird.png markiert Gruppen, die nur via NetBird-VPN erreichbar sind
-      # (Beschreibungstext pro Kachel traegt zusaetzlich 🔒/🌍 — Homepage kann nur
-      # 1 Icon pro Kachel, aber pro GRUPPE, darum hier statt auf jeder einzelnen Karte).
+      # Standard-Icons je Domaene (DACHS-Stil). VPN-Zugang ist Cluster-Realitaet,
+      # kein Header-Thema — dafuer gibt es die NetBird-Kachel unter Bookmarks.
       Platform:
-        icon: netbird.png
+        icon: mdi-rocket-launch
         style: row
         columns: 2
       Observability:
-        icon: netbird.png
+        icon: mdi-chart-line
         style: row
         columns: 3
       Identity:
-        icon: netbird.png
+        icon: mdi-account-key
         style: row
         columns: 2
       Storage:
-        icon: netbird.png
+        icon: mdi-database
         style: row
         columns: 2
       Data:
-        icon: netbird.png
+        icon: mdi-table
         style: row
         columns: 2
       Apps:
+        icon: mdi-apps
         style: row
         columns: 2
 


### PR DESCRIPTION
Gruppen-Header auf neutrale mdi-Icons (DACHS-Stil) statt 5x netbird.png. Der NetBird-Bezug lebt in der Bookmarks-Kachel mit echtem Logo.