### PR TITLE
homepage vpn labels calendar

### DIFF
--- a/kubernetes/apps/uptime-kuma/base/httproute.yaml
+++ b/kubernetes/apps/uptime-kuma/base/httproute.yaml
@@ -6,7 +6,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: "app=uptime-kuma"
     gethomepage.dev/name: Status Page
-    gethomepage.dev/description: Uptime Monitoring
+    gethomepage.dev/description: Uptime Monitoring (VPN)
     gethomepage.dev/group: Observability
     gethomepage.dev/icon: uptime-kuma.png
 spec:

--- a/kubernetes/infrastructure/argocd/base/httproute.yaml
+++ b/kubernetes/infrastructure/argocd/base/httproute.yaml
@@ -7,7 +7,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: "app.kubernetes.io/name=argocd-server"
     gethomepage.dev/name: ArgoCD
-    gethomepage.dev/description: GitOps Continuous Delivery
+    gethomepage.dev/description: GitOps Continuous Delivery (VPN)
     gethomepage.dev/group: Platform
     gethomepage.dev/icon: argo-cd.png
 spec:

--- a/kubernetes/infrastructure/network/cilium/base/hubble-httproute.yaml
+++ b/kubernetes/infrastructure/network/cilium/base/hubble-httproute.yaml
@@ -8,7 +8,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: "app.kubernetes.io/name=hubble-relay"
     gethomepage.dev/name: Hubble
-    gethomepage.dev/description: Cilium Network Observability
+    gethomepage.dev/description: Cilium Network Observability (VPN)
     gethomepage.dev/group: Observability
     gethomepage.dev/icon: cilium.png
 spec:

--- a/kubernetes/infrastructure/observability/blackbox-exporter/base/probes.yaml
+++ b/kubernetes/infrastructure/observability/blackbox-exporter/base/probes.yaml
@@ -73,6 +73,8 @@ spec:
         - https://redpanda.timourhomelab.org
         - https://renovate.timourhomelab.org
         - https://status.timourhomelab.org
+        - https://n8n.timourhomelab.org  # PUBLIC — war nie geprobt
+        - https://homepage.timourhomelab.org
       labels:
         env: prod
         type: public

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/http-route.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/http-route.yaml
@@ -7,7 +7,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: "app=grafana"
     gethomepage.dev/name: Grafana
-    gethomepage.dev/description: Dashboards & Metrics
+    gethomepage.dev/description: Dashboards & Metrics (VPN)
     gethomepage.dev/group: Observability
     gethomepage.dev/icon: grafana.png
 spec:

--- a/kubernetes/infrastructure/observability/dashboards/homepage/base/configmap.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/homepage/base/configmap.yaml
@@ -15,8 +15,12 @@ data:
     layout:
       # Standard-Icons je Domaene (DACHS-Stil). VPN-Zugang ist Cluster-Realitaet,
       # kein Header-Thema — dafuer gibt es die NetBird-Kachel unter Bookmarks.
-      Platform:
+      Init:
         icon: mdi-rocket-launch
+        style: row
+        columns: 1
+      Platform:
+        icon: mdi-server
         style: row
         columns: 2
       Observability:
@@ -91,7 +95,14 @@ data:
               href: https://app.netbird.io
 
   services.yaml: |
-    []
+    # Init-Spalte wie beim DACHS-Vorbild: Monatskalender oben links.
+    - Init:
+        - Calendar:
+            icon: mdi-calendar-month
+            widget:
+              type: calendar
+              view: monthly
+              maxEvents: 10
 
   # docker.yaml + proxmox.yaml: Homepage haelt BEIDE fuer Pflicht (verifiziert via
   # /app/src/skeleton/ im Image, v1.13.2 — die offizielle Doku nennt nur 8 von 9

--- a/kubernetes/infrastructure/observability/dashboards/homepage/base/httproute.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/homepage/base/httproute.yaml
@@ -6,8 +6,8 @@ metadata:
   annotations:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: Homepage
-    gethomepage.dev/description: This dashboard
-    gethomepage.dev/group: Platform
+    gethomepage.dev/description: 🌍 This dashboard (Public via Cloudflare)
+    gethomepage.dev/group: Apps
     gethomepage.dev/icon: homepage.png
 spec:
   hostnames:

--- a/kubernetes/infrastructure/observability/dashboards/kiali/httproute.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/kiali/httproute.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: Kiali
-    gethomepage.dev/description: Istio Service Mesh
+    gethomepage.dev/description: Istio Service Mesh (VPN)
     gethomepage.dev/group: Observability
 spec:
   parentRefs:

--- a/kubernetes/infrastructure/observability/jaeger/base/httproute.yaml
+++ b/kubernetes/infrastructure/observability/jaeger/base/httproute.yaml
@@ -7,7 +7,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: "app.kubernetes.io/name=jaeger-collector"
     gethomepage.dev/name: Jaeger
-    gethomepage.dev/description: Distributed Tracing
+    gethomepage.dev/description: Distributed Tracing (VPN)
     gethomepage.dev/group: Observability
     gethomepage.dev/icon: jaeger.png
 spec:

--- a/kubernetes/infrastructure/observability/kibana/base/kibana-httproute.yaml
+++ b/kubernetes/infrastructure/observability/kibana/base/kibana-httproute.yaml
@@ -10,7 +10,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: "common.k8s.elastic.co/type=kibana"
     gethomepage.dev/name: Kibana
-    gethomepage.dev/description: Log Analytics
+    gethomepage.dev/description: Log Analytics (VPN)
     gethomepage.dev/group: Observability
     gethomepage.dev/icon: kibana.png
 spec:

--- a/kubernetes/infrastructure/operators/renovate/base/kustomization.yaml
+++ b/kubernetes/infrastructure/operators/renovate/base/kustomization.yaml
@@ -30,7 +30,7 @@ helmCharts:
           gethomepage.dev/enabled: "true"
           gethomepage.dev/pod-selector: "app=renovate-operator-renovate-operator"
           gethomepage.dev/name: Renovate
-          gethomepage.dev/description: Dependency Updates
+          gethomepage.dev/description: Dependency Updates (VPN)
           gethomepage.dev/group: Platform
           gethomepage.dev/icon: renovate.png
         hostnames:

--- a/kubernetes/infrastructure/storage/rook-ceph/base/http-route.yaml
+++ b/kubernetes/infrastructure/storage/rook-ceph/base/http-route.yaml
@@ -7,7 +7,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: "app=rook-ceph-mgr"
     gethomepage.dev/name: Ceph Dashboard
-    gethomepage.dev/description: Storage Cluster
+    gethomepage.dev/description: Storage Cluster (VPN)
     gethomepage.dev/group: Storage
     gethomepage.dev/icon: ceph.png
 spec:

--- a/kubernetes/platform/identity/keycloak/base/httproute.yaml
+++ b/kubernetes/platform/identity/keycloak/base/httproute.yaml
@@ -12,7 +12,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: "app=keycloak"
     gethomepage.dev/name: Keycloak
-    gethomepage.dev/description: SSO / Identity Provider
+    gethomepage.dev/description: SSO / Identity Provider (VPN)
     gethomepage.dev/group: Identity
     gethomepage.dev/icon: keycloak.png
 spec:

--- a/kubernetes/platform/identity/lldap/base/httproute.yaml
+++ b/kubernetes/platform/identity/lldap/base/httproute.yaml
@@ -14,7 +14,7 @@ metadata:
   annotations:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: LLDAP
-    gethomepage.dev/description: User Directory
+    gethomepage.dev/description: User Directory (VPN)
     gethomepage.dev/group: Identity
     gethomepage.dev/icon: lldap.png
 spec:

--- a/kubernetes/tenants/drova/console/httproute.yaml
+++ b/kubernetes/tenants/drova/console/httproute.yaml
@@ -7,7 +7,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: "app=redpanda-console"
     gethomepage.dev/name: Redpanda Console
-    gethomepage.dev/description: Kafka UI
+    gethomepage.dev/description: Kafka UI (VPN)
     gethomepage.dev/group: Data
 spec:
   parentRefs:


### PR DESCRIPTION
Round 2 nach Feedback:

- Alle 19 HTTPRoute-Hosts durchgeprobt: 15/15 unique Hosts erreichbar (200/302 offen, 401/403 auth-gated, 0 tot).
- Jede Kachel traegt jetzt die Zugriffs-Bemerkung: '(VPN)' bzw. '🌍 (Public via Cloudflare)'.
- homepage: von Platform nach Apps (zu n8n) + als public markiert.
- Kalender-Widget (Monatsansicht) als Init-Spalte wie beim DACHS-Vorbild; Platform-Gruppe auf mdi-server.
- Blackbox-Luecke geschlossen: n8n (PUBLIC!) und homepage wurden nie geprobt — beide aufgenommen.