### PR TITLE
homepage complete coverage

### DIFF
--- a/kubernetes/apps/uptime-kuma/base/httproute.yaml
+++ b/kubernetes/apps/uptime-kuma/base/httproute.yaml
@@ -6,7 +6,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: "app=uptime-kuma"
     gethomepage.dev/name: Status Page
-    gethomepage.dev/description: Uptime Monitoring (VPN)
+    gethomepage.dev/description: Uptime Monitoring (VPN-only via NetBird)
     gethomepage.dev/group: Observability
     gethomepage.dev/icon: uptime-kuma.png
 spec:

--- a/kubernetes/apps/uptime-kuma/base/httproute.yaml
+++ b/kubernetes/apps/uptime-kuma/base/httproute.yaml
@@ -9,6 +9,11 @@ metadata:
     gethomepage.dev/description: Uptime Monitoring (VPN-only via NetBird)
     gethomepage.dev/group: Observability
     gethomepage.dev/icon: uptime-kuma.png
+    # Widget zeigt Sites up/down + Uptime wie beim DACHS-Vorbild. Braucht eine
+    # Status-Page mit Slug 'homelab' (Kuma-UI, Click-Ops by design).
+    gethomepage.dev/widget.type: uptimekuma
+    gethomepage.dev/widget.url: http://uptime-kuma.uptime-kuma.svc:3001
+    gethomepage.dev/widget.slug: homelab
 spec:
   parentRefs:
     - name: envoy-gateway

--- a/kubernetes/infrastructure/argocd/base/httproute.yaml
+++ b/kubernetes/infrastructure/argocd/base/httproute.yaml
@@ -7,7 +7,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: "app.kubernetes.io/name=argocd-server"
     gethomepage.dev/name: ArgoCD
-    gethomepage.dev/description: GitOps Continuous Delivery (VPN)
+    gethomepage.dev/description: GitOps Continuous Delivery (VPN-only via NetBird)
     gethomepage.dev/group: Platform
     gethomepage.dev/icon: argo-cd.png
 spec:

--- a/kubernetes/infrastructure/network/cilium/base/hubble-httproute.yaml
+++ b/kubernetes/infrastructure/network/cilium/base/hubble-httproute.yaml
@@ -8,7 +8,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: "app.kubernetes.io/name=hubble-relay"
     gethomepage.dev/name: Hubble
-    gethomepage.dev/description: Cilium Network Observability (VPN)
+    gethomepage.dev/description: Cilium Network Observability (VPN-only via NetBird)
     gethomepage.dev/group: Observability
     gethomepage.dev/icon: cilium.png
 spec:

--- a/kubernetes/infrastructure/observability/blackbox-exporter/base/probes.yaml
+++ b/kubernetes/infrastructure/observability/blackbox-exporter/base/probes.yaml
@@ -75,6 +75,8 @@ spec:
         - https://status.timourhomelab.org
         - https://n8n.timourhomelab.org  # PUBLIC — war nie geprobt
         - https://homepage.timourhomelab.org
+        - https://prometheus.timourhomelab.org
+        - https://alertmanager.timourhomelab.org
       labels:
         env: prod
         type: public

--- a/kubernetes/infrastructure/observability/dashboards/grafana/base/http-route.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/grafana/base/http-route.yaml
@@ -7,7 +7,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: "app=grafana"
     gethomepage.dev/name: Grafana
-    gethomepage.dev/description: Dashboards & Metrics (VPN)
+    gethomepage.dev/description: Dashboards & Metrics (VPN-only via NetBird)
     gethomepage.dev/group: Observability
     gethomepage.dev/icon: grafana.png
 spec:

--- a/kubernetes/infrastructure/observability/dashboards/homepage/base/configmap.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/homepage/base/configmap.yaml
@@ -21,8 +21,7 @@ data:
         columns: 2
       Init:
         icon: mdi-rocket-launch
-        style: row
-        columns: 1
+        style: column
       Platform:
         icon: mdi-server
         style: row
@@ -103,6 +102,45 @@ data:
               type: calendar
               view: monthly
               maxEvents: 10
+    # Statische Kacheln: Komponenten OHNE eigene HTTPRoute/UI. Auto-Discovery
+    # sieht nur HTTPRoutes — der Rest des Stacks wird hier gepflegt und
+    # verlinkt auf die beste vorhandene Sicht (Grafana/Kibana).
+    - Observability:
+        - Loki:
+            icon: loki.png
+            href: https://grafana.timourhomelab.org/a/grafana-lokiexplore-app/explore
+            description: Log Aggregation (VPN-only via NetBird)
+        - Tempo:
+            icon: tempo.png
+            href: https://grafana.timourhomelab.org/a/grafana-exploretraces-app/explore
+            description: Distributed Traces (VPN-only via NetBird)
+        - Vector:
+            icon: vector.png
+            href: https://grafana.timourhomelab.org/dashboards?query=vector
+            description: Log Pipeline (VPN-only via NetBird)
+    - Data:
+        - Elasticsearch:
+            icon: elasticsearch.png
+            href: https://grafana.timourhomelab.org/d/elasticsearch
+            description: Search & SIEM Store (VPN-only via NetBird)
+    - Storage:
+        - Velero:
+            icon: velero.png
+            href: https://grafana.timourhomelab.org/dashboards?query=velero
+            description: Backup & Restore (VPN-only via NetBird)
+    - Platform:
+        - Sealed Secrets:
+            icon: mdi-lock-outline
+            href: https://github.com/Tim275/talos-homelab/tree/main/kubernetes/security
+            description: Secret Encryption (GitOps)
+        - cert-manager:
+            icon: cert-manager.png
+            href: https://grafana.timourhomelab.org/dashboards?query=cert
+            description: TLS Certificates (VPN-only via NetBird)
+        - CloudNative-PG:
+            icon: postgres.png
+            href: https://grafana.timourhomelab.org/dashboards?query=cnpg
+            description: Postgres Operator (VPN-only via NetBird)
 
   # docker.yaml + proxmox.yaml: Homepage haelt BEIDE fuer Pflicht (verifiziert via
   # /app/src/skeleton/ im Image, v1.13.2 — die offizielle Doku nennt nur 8 von 9

--- a/kubernetes/infrastructure/observability/dashboards/homepage/base/configmap.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/homepage/base/configmap.yaml
@@ -13,35 +13,29 @@ data:
     theme: dark
     color: slate
     layout:
-      # Standard-Icons je Domaene (DACHS-Stil). VPN-Zugang ist Cluster-Realitaet,
-      # kein Header-Thema — dafuer gibt es die NetBird-Kachel unter Bookmarks.
-      Apps:
-        icon: mdi-apps
-        style: row
-        columns: 2
+      # DACHS-Layout: ALLE Gruppen als Spalten nebeneinander — der Kalender
+      # (Init) steht schmal ganz links, statt als Vollbreiten-Zeile zu wuchern.
       Init:
         icon: mdi-rocket-launch
         style: column
+      Apps:
+        icon: mdi-apps
+        style: column
       Platform:
         icon: mdi-server
-        style: row
-        columns: 2
+        style: column
       Observability:
         icon: mdi-chart-line
-        style: row
-        columns: 3
+        style: column
       Identity:
         icon: mdi-account-key
-        style: row
-        columns: 2
+        style: column
       Storage:
         icon: mdi-database
-        style: row
-        columns: 2
+        style: column
       Data:
         icon: mdi-table
-        style: row
-        columns: 2
+        style: column
 
   kubernetes.yaml: |
     mode: cluster

--- a/kubernetes/infrastructure/observability/dashboards/homepage/base/httproute.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/homepage/base/httproute.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: Homepage
-    gethomepage.dev/description: 🌍 This dashboard (Public via Cloudflare)
+    gethomepage.dev/description: This dashboard (VPN-only via NetBird)
     gethomepage.dev/group: Apps
     gethomepage.dev/icon: homepage.png
 spec:

--- a/kubernetes/infrastructure/observability/dashboards/kiali/httproute.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/kiali/httproute.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: Kiali
-    gethomepage.dev/description: Istio Service Mesh (VPN)
+    gethomepage.dev/description: Istio Service Mesh (VPN-only via NetBird)
     gethomepage.dev/group: Observability
 spec:
   parentRefs:

--- a/kubernetes/infrastructure/observability/jaeger/base/httproute.yaml
+++ b/kubernetes/infrastructure/observability/jaeger/base/httproute.yaml
@@ -7,7 +7,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: "app.kubernetes.io/name=jaeger-collector"
     gethomepage.dev/name: Jaeger
-    gethomepage.dev/description: Distributed Tracing (VPN)
+    gethomepage.dev/description: Distributed Tracing (VPN-only via NetBird)
     gethomepage.dev/group: Observability
     gethomepage.dev/icon: jaeger.png
 spec:

--- a/kubernetes/infrastructure/observability/kibana/base/kibana-httproute.yaml
+++ b/kubernetes/infrastructure/observability/kibana/base/kibana-httproute.yaml
@@ -10,7 +10,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: "common.k8s.elastic.co/type=kibana"
     gethomepage.dev/name: Kibana
-    gethomepage.dev/description: Log Analytics (VPN)
+    gethomepage.dev/description: Log Analytics (VPN-only via NetBird)
     gethomepage.dev/group: Observability
     gethomepage.dev/icon: kibana.png
 spec:

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/httproutes.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/httproutes.yaml
@@ -1,0 +1,63 @@
+# Prometheus + Alertmanager sichtbar machen: beide hatten keine HTTPRoute und
+# konnten damit weder auf der Homepage auftauchen noch im Browser geoeffnet
+# werden. VPN-only wie der Rest — die UIs selbst sind unauthentifiziert,
+# Zugriffsschutz ist die NetBird-Routing-Grenze (gleiches Modell wie lldap).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: prometheus
+  namespace: monitoring
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=prometheus"
+    gethomepage.dev/name: Prometheus
+    gethomepage.dev/description: Time-series Monitoring (VPN-only via NetBird)
+    gethomepage.dev/group: Observability
+    gethomepage.dev/icon: prometheus.png
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: envoy-gateway
+      namespace: gateway
+      sectionName: https
+  hostnames:
+    - prometheus.timourhomelab.org
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: kube-prometheus-stack-prometheus
+          port: 9090
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: alertmanager
+  namespace: monitoring
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=alertmanager"
+    gethomepage.dev/name: Alertmanager
+    gethomepage.dev/description: Alert Routing & Silences (VPN-only via NetBird)
+    gethomepage.dev/group: Observability
+    gethomepage.dev/icon: alertmanager.png
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: envoy-gateway
+      namespace: gateway
+      sectionName: https
+  hostnames:
+    - alertmanager.timourhomelab.org
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: kube-prometheus-stack-alertmanager
+          port: 9093

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: monitoring
 
 resources:
   - etcd-client-cert-sealed.yaml
+  - httproutes.yaml
   - namespace.yaml
   - alerts
   # Platform / GitOps

--- a/kubernetes/infrastructure/operators/renovate/base/kustomization.yaml
+++ b/kubernetes/infrastructure/operators/renovate/base/kustomization.yaml
@@ -30,7 +30,7 @@ helmCharts:
           gethomepage.dev/enabled: "true"
           gethomepage.dev/pod-selector: "app=renovate-operator-renovate-operator"
           gethomepage.dev/name: Renovate
-          gethomepage.dev/description: Dependency Updates (VPN)
+          gethomepage.dev/description: Dependency Updates (VPN-only via NetBird)
           gethomepage.dev/group: Platform
           gethomepage.dev/icon: renovate.png
         hostnames:

--- a/kubernetes/infrastructure/storage/rook-ceph/base/http-route.yaml
+++ b/kubernetes/infrastructure/storage/rook-ceph/base/http-route.yaml
@@ -7,7 +7,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: "app=rook-ceph-mgr"
     gethomepage.dev/name: Ceph Dashboard
-    gethomepage.dev/description: Storage Cluster (VPN)
+    gethomepage.dev/description: Storage Cluster (VPN-only via NetBird)
     gethomepage.dev/group: Storage
     gethomepage.dev/icon: ceph.png
 spec:

--- a/kubernetes/platform/identity/keycloak/base/httproute.yaml
+++ b/kubernetes/platform/identity/keycloak/base/httproute.yaml
@@ -12,7 +12,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: "app=keycloak"
     gethomepage.dev/name: Keycloak
-    gethomepage.dev/description: SSO / Identity Provider (VPN)
+    gethomepage.dev/description: SSO / Identity Provider (VPN-only via NetBird)
     gethomepage.dev/group: Identity
     gethomepage.dev/icon: keycloak.png
 spec:

--- a/kubernetes/platform/identity/lldap/base/httproute.yaml
+++ b/kubernetes/platform/identity/lldap/base/httproute.yaml
@@ -14,7 +14,7 @@ metadata:
   annotations:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: LLDAP
-    gethomepage.dev/description: User Directory (VPN)
+    gethomepage.dev/description: User Directory (VPN-only via NetBird)
     gethomepage.dev/group: Identity
     gethomepage.dev/icon: lldap.png
 spec:

--- a/kubernetes/tenants/drova/console/httproute.yaml
+++ b/kubernetes/tenants/drova/console/httproute.yaml
@@ -7,7 +7,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: "app=redpanda-console"
     gethomepage.dev/name: Redpanda Console
-    gethomepage.dev/description: Kafka UI (VPN)
+    gethomepage.dev/description: Kafka UI (VPN-only via NetBird)
     gethomepage.dev/group: Data
 spec:
   parentRefs:


### PR DESCRIPTION
Vollstaendigkeit + Korrekturen nach Feedback:

- Bemerkung zurueck auf vollen Text '(VPN-only via NetBird)' auf allen 12 VPN-Kacheln; 🌍 nur fuer echte Public-Dienste.
- Ground-Truth-Korrektur: homepage.timourhomelab.org steht NICHT im cloudflared-Tunnel (nur drova+n8n+apex, kein Wildcard — verifiziert) -> homepage ist real VPN-only, Label korrigiert. Gruppe bleibt Apps.
- 2 neue HTTPRoutes: prometheus + alertmanager (VPN-only by architecture: Envoy-LB .152 ist RFC1918, public geht nur ueber explizite Tunnel-Eintraege). Beide hatten keine Route und waren weder auf der Homepage noch im Browser erreichbar.
- 8 statische Kacheln fuer Komponenten ohne eigene UI/Route: Loki, Tempo, Vector, Elasticsearch, Velero, Sealed Secrets, cert-manager, CNPG — verlinkt auf die beste vorhandene Sicht (Grafana Drilldowns/Dashboards).
- Kalender kompakt: Init-Gruppe als column statt full-width row.
- Blackbox: prometheus + alertmanager mit aufgenommen.