### PR TITLE
n8n tile reachability

### DIFF
--- a/kubernetes/infrastructure/network/coredns/base/coredns-config.yaml
+++ b/kubernetes/infrastructure/network/coredns/base/coredns-config.yaml
@@ -33,6 +33,9 @@ data:
         # Cluster-internal: rewrite to envoy-gateway (has wildcard TLS + HTTPRoute → KC).
         # Browsers continue using public DNS → CF Tunnel (unaffected).
         rewrite name exact iam.timourhomelab.org envoy-gateway-envoy-gateway-ee418b6e.gateway.svc.cluster.local
+        # n8n: gleiches Muster — Homepage-Statuscheck (Node-Fetch, kein Browser-UA)
+        # lief sonst raus zu Cloudflare und in deren Bot-Score.
+        rewrite name exact n8n.timourhomelab.org envoy-gateway-envoy-gateway-ee418b6e.gateway.svc.cluster.local
 
         forward . 192.168.0.1 8.8.8.8 1.1.1.1 {
            max_concurrent 1000

--- a/kubernetes/tenants/n8n-prod/app/httproute.yaml
+++ b/kubernetes/tenants/n8n-prod/app/httproute.yaml
@@ -10,6 +10,8 @@ metadata:
     gethomepage.dev/description: 🌍 Workflow Automation (Public via Cloudflare)
     gethomepage.dev/group: Apps
     gethomepage.dev/icon: n8n.png
+    gethomepage.dev/href: https://n8n.timourhomelab.org/
+    gethomepage.dev/siteMonitor: https://n8n.timourhomelab.org/
 spec:
   parentRefs:
     - name: envoy-gateway


### PR DESCRIPTION
n8n-Kachel zeigte 'nicht erreichbar': n8n.timourhomelab.org loest clusterintern auf Cloudflare auf (expliziter proxied A-Record) — Homepages Node-Fetch ohne Browser-UA laeuft in den CF-Bot-Score. Gleiches Problem wie beim OIDC-Backchannel (iam), gleiche Loesung: CoreDNS-Rewrite auf envoy-gateway. Dazu expliziter href + siteMonitor auf der Kachel. Talos-Note: nach talosctl upgrade-k8s CoreDNS-Config re-applien (ArgoCD selfHeal stellt sie ohnehin wieder her).