### PR TITLE
observability row productivity group

### DIFF
--- a/kubernetes/infrastructure/observability/dashboards/homepage/base/configmap.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/homepage/base/configmap.yaml
@@ -21,12 +21,16 @@ data:
       Apps:
         icon: mdi-apps
         style: column
+      Productivity:
+        icon: mdi-pencil-ruler
+        style: column
       Platform:
         icon: mdi-server
         style: column
       Observability:
         icon: mdi-chart-line
-        style: column
+        style: row
+        columns: 4
       Identity:
         icon: mdi-account-key
         style: column
@@ -76,12 +80,6 @@ data:
         - GitHub Repo:
             - icon: github.png
               href: https://github.com/Tim275/talos-homelab
-        - Excalidraw:
-            - icon: excalidraw.png
-              href: https://excalidraw.com
-        - Mermaid Live:
-            - icon: si-mermaid
-              href: https://mermaid.live
     - NetBird:
         - VPN Dashboard:
             - icon: netbird.png
@@ -99,6 +97,15 @@ data:
     # Statische Kacheln: Komponenten OHNE eigene HTTPRoute/UI. Auto-Discovery
     # sieht nur HTTPRoutes — der Rest des Stacks wird hier gepflegt und
     # verlinkt auf die beste vorhandene Sicht (Grafana/Kibana).
+    - Productivity:
+        - Excalidraw:
+            icon: excalidraw.png
+            href: https://excalidraw.com
+            description: Drawing & Diagrams
+        - Mermaid Live:
+            icon: si-mermaid
+            href: https://mermaid.live
+            description: Diagramming
     - Observability:
         - Loki:
             icon: loki.png


### PR DESCRIPTION
Observability als volle Reihe mit 4 Spalten (war als schmale Einzelspalte unuebersichtlich — groesste Gruppe). Neue Productivity-Spalte mit Excalidraw + Mermaid Live als Kacheln statt Bookmarks.