### PR TITLE
forgejo app

### DIFF
--- a/kubernetes/applicationsets/apps/apps-stack.yaml
+++ b/kubernetes/applicationsets/apps/apps-stack.yaml
@@ -30,6 +30,7 @@ spec:
                 # - { component: audiobookshelf, appName: audiobookshelf, path: kubernetes/apps/audiobookshelf/overlays/prod,        namespace: audiobookshelf-prod, wave: "60" }
                 - { component: cloudbeaver,    appName: cloudbeaver,    path: kubernetes/apps/cloudbeaver/overlays/prod,           namespace: cloudbeaver,         wave: "60" }
                 - { component: uptime-kuma,    appName: uptime-kuma,    path: kubernetes/apps/uptime-kuma/overlays/prod,           namespace: uptime-kuma,         wave: "60" }
+                - { component: forgejo,        appName: forgejo,        path: kubernetes/apps/forgejo/overlays/prod,               namespace: forgejo,             wave: "60" }
   template:
     metadata:
       name: '{{.appName}}'

--- a/kubernetes/apps/forgejo/base/deployment.yaml
+++ b/kubernetes/apps/forgejo/base/deployment.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: forgejo
+  namespace: forgejo
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate  # RWO-PVC
+  selector:
+    matchLabels:
+      app: forgejo
+  template:
+    metadata:
+      labels:
+        app: forgejo
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: forgejo
+          image: codeberg.org/forgejo/forgejo:12-rootless
+          env:
+            - name: FORGEJO__server__DOMAIN
+              value: git.timourhomelab.org
+            - name: FORGEJO__server__ROOT_URL
+              value: https://git.timourhomelab.org/
+            - name: FORGEJO__server__HTTP_PORT
+              value: "3000"
+            # sqlite bewusst statt CNPG: Single-User-Git, eine Abhaengigkeit
+            # weniger im Restore-Pfad. Daten+app.ini (enthaelt generierte Keys)
+            # liegen BEIDE auf dem PVC — /etc/gitea als emptyDir wuerde bei
+            # jedem Restart neue SECRET_KEYs erzeugen und Sessions/Tokens killen.
+            - name: FORGEJO__database__DB_TYPE
+              value: sqlite3
+            - name: FORGEJO__service__DISABLE_REGISTRATION
+              value: "true"
+            - name: FORGEJO__server__SSH_DOMAIN
+              value: git.timourhomelab.org
+            - name: FORGEJO__server__START_SSH_SERVER
+              value: "false"
+          ports:
+            - name: http
+              containerPort: 3000
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/gitea
+              subPath: data
+            - name: data
+              mountPath: /etc/gitea
+              subPath: config
+          readinessProbe:
+            httpGet:
+              path: /api/healthz
+              port: 3000
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /api/healthz
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: forgejo-data

--- a/kubernetes/apps/forgejo/base/httproute.yaml
+++ b/kubernetes/apps/forgejo/base/httproute.yaml
@@ -1,0 +1,29 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: forgejo
+  namespace: forgejo
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/pod-selector: "app=forgejo"
+    gethomepage.dev/name: Forgejo
+    gethomepage.dev/description: Self-hosted Git (VPN-only via NetBird)
+    gethomepage.dev/group: Apps
+    gethomepage.dev/icon: forgejo.png
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: envoy-gateway
+      namespace: gateway
+      sectionName: https
+  hostnames:
+    - git.timourhomelab.org
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: forgejo
+          port: 3000

--- a/kubernetes/apps/forgejo/base/kustomization.yaml
+++ b/kubernetes/apps/forgejo/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml

--- a/kubernetes/apps/forgejo/base/namespace.yaml
+++ b/kubernetes/apps/forgejo/base/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: forgejo
+  labels:
+    app.kubernetes.io/name: forgejo

--- a/kubernetes/apps/forgejo/base/pvc.yaml
+++ b/kubernetes/apps/forgejo/base/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: forgejo-data
+  namespace: forgejo
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: rook-ceph-block-enterprise
+  resources:
+    requests:
+      storage: 10Gi

--- a/kubernetes/apps/forgejo/base/service.yaml
+++ b/kubernetes/apps/forgejo/base/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: forgejo
+  namespace: forgejo
+spec:
+  selector:
+    app: forgejo
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000

--- a/kubernetes/apps/forgejo/overlays/prod/kustomization.yaml
+++ b/kubernetes/apps/forgejo/overlays/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base

--- a/kubernetes/infrastructure/observability/blackbox-exporter/base/probes.yaml
+++ b/kubernetes/infrastructure/observability/blackbox-exporter/base/probes.yaml
@@ -77,6 +77,7 @@ spec:
         - https://homepage.timourhomelab.org
         - https://prometheus.timourhomelab.org
         - https://alertmanager.timourhomelab.org
+        - https://git.timourhomelab.org
       labels:
         env: prod
         type: public

--- a/kubernetes/projects/apps.yaml
+++ b/kubernetes/projects/apps.yaml
@@ -44,6 +44,8 @@ spec:
       server: 'https://kubernetes.default.svc'
     - namespace: 'uptime-kuma'
       server: 'https://kubernetes.default.svc'
+    - namespace: 'forgejo'
+      server: 'https://kubernetes.default.svc'
 
   # CLUSTER RESOURCES: Application-specific (Security )
   clusterResourceWhitelist:


### PR DESCRIPTION
Forgejo als dritte App neben n8n und homepage: self-hosted Git unter git.timourhomelab.org (VPN-only — Envoy-Route, nicht im cloudflared-Tunnel).

- rootless-Image, restricted securityContext, Recreate-Strategy (RWO-PVC 10Gi auf rook-ceph-block-enterprise)
- sqlite bewusst statt CNPG: Single-User-Git, eine Abhaengigkeit weniger im Restore-Pfad
- Daten UND app.ini auf dem PVC (subPaths data/config) — /etc/gitea als emptyDir wuerde bei jedem Restart neue SECRET_KEYs erzeugen und alle Sessions/Tokens invalidieren
- Registrierung deaktiviert, kein SSH-Server (Git via HTTPS)
- Homepage-Kachel (Apps, forgejo.png), Blackbox-Probe, AppProject-Destination, apps-stack wave 60

Erster Admin-Account: beim ersten Aufruf der Web-UI anlegen (Initial-Setup).