### PR TITLE
honest tile links

### DIFF
--- a/kubernetes/infrastructure/observability/dashboards/homepage/base/configmap.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/homepage/base/configmap.yaml
@@ -122,13 +122,15 @@ data:
     - Data:
         - Elasticsearch:
             icon: elasticsearch.png
-            href: https://grafana.timourhomelab.org/d/elasticsearch
+            # Kibana IST die ES-UI — Grafana-Dashboard fuehlte sich falsch an
+            href: https://kibana.timourhomelab.org
             description: Search & SIEM Store (VPN-only via NetBird)
     - Storage:
         - Velero:
             icon: velero.png
-            href: https://grafana.timourhomelab.org/dashboards?query=velero
-            description: Backup & Restore (VPN-only via NetBird)
+            # Velero hat KEINE Web-UI — ehrlichster Link sind die Schedules im Repo
+            href: https://github.com/Tim275/talos-homelab/tree/main/kubernetes/infrastructure/storage/velero-schedules
+            description: Backup Schedules (GitOps)
     - Platform:
         - Sealed Secrets:
             icon: mdi-lock-outline


### PR DESCRIPTION
Elasticsearch-Kachel fuehrte nach Grafana statt zur ES-UI -> jetzt Kibana (das IST die Oberflaeche von ES). Velero hat keine Web-UI -> Link auf die velero-schedules im Repo statt Grafana-Suche. Loki/Tempo/Vector bleiben auf Grafana-Drilldowns — das ist deren echte UI.