### PR TITLE
redpanda icon drop mermaid

### DIFF
--- a/kubernetes/infrastructure/observability/dashboards/homepage/base/configmap.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/homepage/base/configmap.yaml
@@ -102,10 +102,6 @@ data:
             icon: excalidraw.png
             href: https://excalidraw.com
             description: Drawing & Diagrams
-        - Mermaid Live:
-            icon: si-mermaid
-            href: https://mermaid.live
-            description: Diagramming
     - Observability:
         - Loki:
             icon: loki.png

--- a/kubernetes/tenants/drova/console/httproute.yaml
+++ b/kubernetes/tenants/drova/console/httproute.yaml
@@ -9,6 +9,8 @@ metadata:
     gethomepage.dev/name: Redpanda Console
     gethomepage.dev/description: Kafka UI (VPN-only via NetBird)
     gethomepage.dev/group: Data
+    # kein redpanda in dashboard-icons/simpleicons — offizielles Logo via GitHub-Org-Avatar
+    gethomepage.dev/icon: https://github.com/redpanda-data.png
 spec:
   parentRefs:
     - name: envoy-gateway


### PR DESCRIPTION
Redpanda-Console-Kachel bekam nie ein Icon (existiert weder in dashboard-icons noch simpleicons) -> offizielles Logo via GitHub-Org-Avatar (homepage akzeptiert Icon-URLs). Mermaid-Live-Kachel raus (ungenutzt).