### PR TITLE
forgejo hostname

### DIFF
--- a/kubernetes/apps/forgejo/base/deployment.yaml
+++ b/kubernetes/apps/forgejo/base/deployment.yaml
@@ -27,9 +27,9 @@ spec:
           image: codeberg.org/forgejo/forgejo:12-rootless
           env:
             - name: FORGEJO__server__DOMAIN
-              value: git.timourhomelab.org
+              value: forgejo.timourhomelab.org
             - name: FORGEJO__server__ROOT_URL
-              value: https://git.timourhomelab.org/
+              value: https://forgejo.timourhomelab.org/
             - name: FORGEJO__server__HTTP_PORT
               value: "3000"
             # sqlite bewusst statt CNPG: Single-User-Git, eine Abhaengigkeit
@@ -41,7 +41,7 @@ spec:
             - name: FORGEJO__service__DISABLE_REGISTRATION
               value: "true"
             - name: FORGEJO__server__SSH_DOMAIN
-              value: git.timourhomelab.org
+              value: forgejo.timourhomelab.org
             - name: FORGEJO__server__START_SSH_SERVER
               value: "false"
           ports:

--- a/kubernetes/apps/forgejo/base/httproute.yaml
+++ b/kubernetes/apps/forgejo/base/httproute.yaml
@@ -18,7 +18,7 @@ spec:
       namespace: gateway
       sectionName: https
   hostnames:
-    - git.timourhomelab.org
+    - forgejo.timourhomelab.org
   rules:
     - matches:
         - path:

--- a/kubernetes/infrastructure/observability/blackbox-exporter/base/probes.yaml
+++ b/kubernetes/infrastructure/observability/blackbox-exporter/base/probes.yaml
@@ -77,7 +77,7 @@ spec:
         - https://homepage.timourhomelab.org
         - https://prometheus.timourhomelab.org
         - https://alertmanager.timourhomelab.org
-        - https://git.timourhomelab.org
+        - https://forgejo.timourhomelab.org
       labels:
         env: prod
         type: public


### PR DESCRIPTION
git.timourhomelab.org -> forgejo.timourhomelab.org (Route, ROOT_URL/DOMAIN, Blackbox-Probe). Achtung: ROOT_URL-Aenderung greift erst nach Pod-Neustart; falls der Admin-Account schon unter git.* angelegt wurde, bleiben Repos/Accounts erhalten — nur die URL wechselt.