### PR TITLE
edge monitoring standalone

### DIFF
--- a/kubernetes/applicationsets/infrastructure/observability-stack.yaml
+++ b/kubernetes/applicationsets/infrastructure/observability-stack.yaml
@@ -39,6 +39,7 @@ spec:
                 - { component: prometheus-edge,        appName: prometheus-edge,                  path: kubernetes/infrastructure/observability/prometheus-edge/overlays/prod,        namespace: monitoring,   wave: "40" }
                 - { component: netbird-exporter,       appName: netbird-exporter,                 path: kubernetes/infrastructure/observability/netbird-exporter/overlays/prod,       namespace: monitoring,   wave: "70" }
                 - { component: kiali,                  appName: kiali,                            path: kubernetes/infrastructure/observability/dashboards/kiali,                     namespace: istio-system, wave: "70" }
+                - { component: edge-monitoring,        appName: edge-monitoring,                  path: kubernetes/infrastructure/observability/edge-monitoring/overlays/prod,        namespace: edge-monitoring, wave: "70" }
                 # LOGS — Backends @ 40, shippers @ 70 (after apps exist)
                 - { component: elasticsearch,          appName: elasticsearch,                    path: kubernetes/infrastructure/observability/elasticsearch/overlays/prod,             namespace: elastic-system, wave: "40" }
                 - { component: loki,                   appName: loki,                             path: kubernetes/infrastructure/observability/loki/overlays/prod,                     namespace: monitoring,   wave: "40" }

--- a/kubernetes/infrastructure/observability/edge-monitoring/base/alertmanager.yaml
+++ b/kubernetes/infrastructure/observability/edge-monitoring/base/alertmanager.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alertmanager-edge-alertmanager
+  namespace: edge-monitoring
+stringData:
+  alertmanager.yaml: |
+    route:
+      receiver: local-webhook
+      group_wait: 5s
+      group_interval: 30s
+      repeat_interval: 5m
+    receivers:
+      - name: local-webhook
+        webhook_configs:
+          - url: http://edge-webhook-receiver.edge-monitoring.svc:8080/
+            send_resolved: true
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Alertmanager
+metadata:
+  name: edge-alertmanager
+  namespace: edge-monitoring
+spec:
+  replicas: 1
+  configSecret: alertmanager-edge-alertmanager
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      memory: 64Mi
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault

--- a/kubernetes/infrastructure/observability/edge-monitoring/base/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/edge-monitoring/base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - rbac.yaml
+  - prometheus.yaml
+  - alertmanager.yaml
+  - webhook-receiver.yaml

--- a/kubernetes/infrastructure/observability/edge-monitoring/base/namespace.yaml
+++ b/kubernetes/infrastructure/observability/edge-monitoring/base/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: edge-monitoring
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/kubernetes/infrastructure/observability/edge-monitoring/base/prometheus.yaml
+++ b/kubernetes/infrastructure/observability/edge-monitoring/base/prometheus.yaml
@@ -1,0 +1,75 @@
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: edge-prometheus
+  namespace: edge-monitoring
+spec:
+  replicas: 1
+  serviceAccountName: edge-prometheus
+  serviceMonitorNamespaceSelector: {}
+  serviceMonitorSelector:
+    matchLabels:
+      edge-monitoring/scrape: "true"
+  ruleNamespaceSelector: {}
+  ruleSelector:
+    matchLabels:
+      role: edge-alert-rules
+  alerting:
+    alertmanagers:
+      - namespace: edge-monitoring
+        name: alertmanager-operated
+        port: http-web
+        apiVersion: v2
+  # Kurzes lokales Retention-Fenster: ein echter Fog-Node würde das auf die
+  # erwartete maximale Verbindungsunterbrechung dimensionieren, nicht auf
+  # Monate — hier bewusst klein fuers Homelab.
+  retention: 6h
+  remoteWrite:
+    - url: http://kube-prometheus-stack-prometheus.monitoring.svc:9090/api/v1/write
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: edge-prometheus-self
+  namespace: edge-monitoring
+  labels:
+    edge-monitoring/scrape: "true"
+spec:
+  selector:
+    matchLabels:
+      operated-prometheus: "true"
+  namespaceSelector:
+    matchNames: [edge-monitoring]
+  endpoints:
+    - port: http-web
+      interval: 30s
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: edge-watchdog
+  namespace: edge-monitoring
+  labels:
+    role: edge-alert-rules
+spec:
+  groups:
+    - name: edge.watchdog
+      rules:
+        - alert: EdgeNodeLocalPipelineAlive
+          expr: vector(1)
+          labels:
+            severity: info
+          annotations:
+            summary: "Lokale Alert-Pipeline auf dem Edge-Node lebt"
+            description: "Feuert unabhaengig davon, ob die Verbindung zum zentralen Cluster steht — Beweis, dass Regel-Auswertung + lokale Zustellung ohne zentrale Konnektivitaet funktionieren."

--- a/kubernetes/infrastructure/observability/edge-monitoring/base/rbac.yaml
+++ b/kubernetes/infrastructure/observability/edge-monitoring/base/rbac.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: edge-prometheus
+  namespace: edge-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: edge-prometheus
+  namespace: edge-monitoring
+rules:
+  - apiGroups: [""]
+    resources: [services, endpoints, pods]
+    verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: edge-prometheus
+  namespace: edge-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: edge-prometheus
+subjects:
+  - kind: ServiceAccount
+    name: edge-prometheus
+    namespace: edge-monitoring

--- a/kubernetes/infrastructure/observability/edge-monitoring/base/webhook-receiver.yaml
+++ b/kubernetes/infrastructure/observability/edge-monitoring/base/webhook-receiver.yaml
@@ -1,0 +1,64 @@
+# Stellvertreter fuer "lokale Zustellung ohne zentrale Konnektivitaet" — auf
+# einem echten Fog-Node waere das ein lokales Display/eine Sirene/ein Relais.
+# Haelt empfangene Alerts einfach in einer Datei fest, um den Drill beweisbar
+# zu machen (kubectl exec ... cat /data/alerts.log).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: edge-webhook-receiver
+  namespace: edge-monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: edge-webhook-receiver
+  template:
+    metadata:
+      labels:
+        app: edge-webhook-receiver
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: receiver
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              while true; do
+                { printf 'HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n'; cat >> /data/alerts.log; printf '\n---\n' >> /data/alerts.log; } | nc -l -p 8080
+              done
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 32Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: edge-webhook-receiver
+  namespace: edge-monitoring
+spec:
+  selector:
+    app: edge-webhook-receiver
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/kubernetes/infrastructure/observability/edge-monitoring/overlays/prod/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/edge-monitoring/overlays/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base

--- a/kubernetes/projects/infrastructure.yaml
+++ b/kubernetes/projects/infrastructure.yaml
@@ -136,6 +136,8 @@ spec:
       server: 'https://kubernetes.default.svc'
     - namespace: 'monitoring'
       server: 'https://kubernetes.default.svc'
+    - namespace: 'edge-monitoring'
+      server: 'https://kubernetes.default.svc'
     - namespace: 'elastic-system'
       server: 'https://kubernetes.default.svc'
     - namespace: 'netbird'


### PR DESCRIPTION
standalone prometheus+alertmanager fuer disconnected/air-gap fog-node simulation, lokaler watchdog + webhook-receiver