### PR TITLE
fix edge alertmanager rbac

### DIFF
--- a/kubernetes/infrastructure/observability/prometheus-edge/base/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/prometheus-edge/base/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - recording-rules.yaml
   - alerts.yaml
   - alertmanager.yaml
+  - rbac.yaml

--- a/kubernetes/infrastructure/observability/prometheus-edge/base/rbac.yaml
+++ b/kubernetes/infrastructure/observability/prometheus-edge/base/rbac.yaml
@@ -1,0 +1,25 @@
+# Ohne das: /api/v1/alertmanagers bleibt leer, obwohl Service+Endpoints stimmen —
+# Prometheus braucht Endpoints-Discovery-Rechte fuer alerting.alertmanagers[].
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-edge
+  namespace: monitoring
+rules:
+  - apiGroups: [""]
+    resources: ["services", "endpoints", "pods"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-edge
+  namespace: monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-edge
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-edge
+    namespace: monitoring


### PR DESCRIPTION
prometheus-edge ServiceAccount hatte keine RBAC-Bindings — Alertmanager-Endpoints-Discovery lief ins Leere (/api/v1/alertmanagers blieb leer trotz korrektem Service/CR).

Role+RoleBinding scoped auf monitoring, get/list/watch auf services/endpoints/pods.