### PR TITLE
fix pyroscope retention flag

### DIFF
--- a/kubernetes/infrastructure/observability/pyroscope/base/values.yaml
+++ b/kubernetes/infrastructure/observability/pyroscope/base/values.yaml
@@ -21,7 +21,7 @@ pyroscope:
 
   extraArgs:
     # 14d — Profile sind fuer Regressionsvergleich da, nicht als Langzeitarchiv.
-    pyroscopedb.retention-period: 336h
+    retention-period: 336h
 
   nodeSelector:
     node-pool: stateful


### PR DESCRIPTION
pyroscope-0 crashloopte: -pyroscopedb.retention-period existiert im 2.2.0-Binary nicht, richtiger Flag ist -retention-period.