### PR TITLE
add reloader memory limit

### DIFF
--- a/kubernetes/infrastructure/observability/pyroscope/base/values.yaml
+++ b/kubernetes/infrastructure/observability/pyroscope/base/values.yaml
@@ -39,6 +39,13 @@ alloy:
         memory: 512Mi
   controller:
     type: daemonset
+  configReloader:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 50Mi
+      limits:
+        memory: 100Mi
 
 serviceMonitor:
   enabled: true


### PR DESCRIPTION
config-reloader-Sidecar im Alloy-DaemonSet hatte kein Memory-Limit — Kyverno audit-require-limits flaggte das beim ersten Rollout.