### PR TITLE
exclude worker-6 from alloy daemonset

### DIFF
--- a/kubernetes/infrastructure/observability/pyroscope/base/values.yaml
+++ b/kubernetes/infrastructure/observability/pyroscope/base/values.yaml
@@ -39,6 +39,15 @@ alloy:
         memory: 512Mi
   controller:
     type: daemonset
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: kubernetes.io/hostname
+                  operator: NotIn
+                  values:
+                    - worker-6
   configReloader:
     resources:
       requests:


### PR DESCRIPTION
worker-6 laeuft dauerhaft bei ~99% CPU-Requests, der DaemonSet-Pod dort blieb permanent Pending statt transient und feuerte PodNotReady + KubeDaemonSetRolloutStuck ohne Aussicht auf Besserung.