### PR TITLE
fix container waiting alert phase filter

### DIFF
--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/kubernetes/workloads.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/base/alerts/kubernetes/workloads.yaml
@@ -51,6 +51,21 @@ spec:
             description: "Pod stuck in {{ $labels.phase }} for 15+ min — scheduling failure or PVC unbound."
             action: "kubectl describe pod -n {{ $labels.namespace }} {{ $labels.pod }}; check events — scheduling, PVC-unbound, or failing readiness."
 
+        - alert: ContainerWaitingStuck
+          expr: |
+            kube_pod_container_status_waiting_reason{reason!="CrashLoopBackOff"} == 1
+            and on (namespace, pod) kube_pod_status_phase{phase=~"Pending|Running"} == 1
+          for: 1h
+          labels:
+            severity: warning
+            component: application
+            priority: P2
+          annotations:
+            dashboard_url: "/d/k8s-pod-overview"
+            summary: "{{ $labels.namespace }}/{{ $labels.pod }}/{{ $labels.container }} waiting: {{ $labels.reason }}"
+            description: "Container stuck waiting ({{ $labels.reason }}) for 1h+ while the pod is still Pending/Running."
+            action: "kubectl describe pod -n {{ $labels.namespace }} {{ $labels.pod }}; check image pull, config mount, or init container failures."
+
         - alert: ContainerCPUThrottlingHigh
           # A container pinned against its CPU limit >75% of CFS periods = busy-loop or under-
           # sized limit. Blind spot before: the argocd redis-ha sentinel busy-looped at ~1 core

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/values-prod.yaml
@@ -171,6 +171,9 @@ defaultRules:
     # Noisy on a Ceph cluster — rbd/OSD disks are IO-busy by design (aqu-sq>10 false-fires).
     # Replaced by the service-level CephSlowOps alert (base/alerts/storage/rook-ceph.yaml).
     NodeDiskIOSaturation: true
+    # Doesn't filter pod phase — dead Failed pods report stale waiting-state forever.
+    # Replaced by ContainerWaitingStuck (base/alerts/kubernetes/workloads.yaml).
+    KubeContainerWaiting: true
     # ── Dedup vs curated tree (2026-07-14) ──
     TargetDown: true                    # = PrometheusTargetDown
     KubeAPIDown: true                   # = ClusterAPIServerDown


### PR DESCRIPTION
Upstream KubeContainerWaiting filtert keine Pod-Phase — Failed-Pods, die nie garbage-collected wurden, melden ihren letzten Container-Status fuer immer weiter. Ein Node-Drain (worker-3/4/5 RAM-Resize) hinterliess 327 tote rook-ceph-Pods, die 18h lang PodNotReady/KubeContainerWaiting feuerten obwohl alles laengst wieder gesund war.

ContainerWaitingStuck ersetzt sie mit Phase-Filter (nur Pending/Running zaehlt), Upstream-Regel disabled.