### PR TITLE
chore(deps): update otel-opentelemetry-collector-contrib to v0 - autoclosed

### DIFF
--- a/kubernetes/infrastructure/observability/opentelemetry/base/collector.yaml
+++ b/kubernetes/infrastructure/observability/opentelemetry/base/collector.yaml
@@ -36,7 +36,7 @@ metadata:
     prometheus.io/scrape: "false"
 spec:
   mode: daemonset
-  image: otel/opentelemetry-collector-contrib:0.157.0@sha256:f2f01157055a9b2aab9df7118e1f1c9abf345e99b23bc7a2bc791db374a7d0f6
+  image: otel/opentelemetry-collector-contrib:0.158.0@sha256:c5918f78992ee73b0d6f0e599423ac5ec52dd5d9726733114d6eca53d5a32ed5
   podAnnotations:
     prometheus.io/scrape: "false"
   resources:

--- a/kubernetes/infrastructure/observability/opentelemetry/base/gateway.yaml
+++ b/kubernetes/infrastructure/observability/opentelemetry/base/gateway.yaml
@@ -36,7 +36,7 @@ spec:
       labelSelector:
         matchLabels:
           app.kubernetes.io/instance: opentelemetry.otel-gateway
-  image: otel/opentelemetry-collector-contrib:0.157.0@sha256:f2f01157055a9b2aab9df7118e1f1c9abf345e99b23bc7a2bc791db374a7d0f6
+  image: otel/opentelemetry-collector-contrib:0.158.0@sha256:c5918f78992ee73b0d6f0e599423ac5ec52dd5d9726733114d6eca53d5a32ed5
   resources:
     requests:
       memory: 512Mi


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/otel-opentelemetry-collector-contrib-0.x`
Filter passed: <24h old, <5 commits ahead.