### PR TITLE
chore(deps): update pyroscope to v2.2 - autoclosed

### DIFF
--- a/kubernetes/infrastructure/observability/pyroscope/base/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/pyroscope/base/kustomization.yaml
@@ -6,7 +6,7 @@ commonAnnotations:
 helmCharts:
   - name: pyroscope
     repo: https://grafana.github.io/helm-charts
-    version: "2.2.0"
+    version: "2.2.1"
     releaseName: pyroscope
     namespace: monitoring
     valuesFile: values.yaml


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/pyroscope-2.2.x`
Filter passed: <24h old, <5 commits ahead.