### PR TITLE
PSA warn/audit=restricted on app namespaces

### DIFF
--- a/kubernetes/apps/cloudbeaver/base/namespace.yaml
+++ b/kubernetes/apps/cloudbeaver/base/namespace.yaml
@@ -5,5 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cloudbeaver
     platform.tier: tools
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted
   annotations:
-    argocd.argoproj.io/sync-wave: "1"  # Namespace first
+    argocd.argoproj.io/sync-wave: "1" # Namespace first

--- a/kubernetes/apps/forgejo/base/namespace.yaml
+++ b/kubernetes/apps/forgejo/base/namespace.yaml
@@ -4,3 +4,5 @@ metadata:
   name: forgejo
   labels:
     app.kubernetes.io/name: forgejo
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/kubernetes/apps/uptime-kuma/base/namespace.yaml
+++ b/kubernetes/apps/uptime-kuma/base/namespace.yaml
@@ -2,3 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: uptime-kuma
+  labels:
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/kubernetes/infrastructure/observability/dashboards/homepage/base/namespace.yaml
+++ b/kubernetes/infrastructure/observability/dashboards/homepage/base/namespace.yaml
@@ -2,3 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: homepage
+  labels:
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/kubernetes/infrastructure/operators/grafana/base/namespace.yaml
+++ b/kubernetes/infrastructure/operators/grafana/base/namespace.yaml
@@ -5,5 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: grafana
     app.kubernetes.io/component: operator
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted
   annotations:
     argocd.argoproj.io/sync-wave: "-5"

--- a/kubernetes/infrastructure/operators/strimzi/base/namespace.yaml
+++ b/kubernetes/infrastructure/operators/strimzi/base/namespace.yaml
@@ -5,5 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: strimzi-kafka
     app.kubernetes.io/component: operator
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted
   annotations:
     argocd.argoproj.io/sync-wave: "-5"

--- a/kubernetes/platform/identity/keycloak/base/namespace.yaml
+++ b/kubernetes/platform/identity/keycloak/base/namespace.yaml
@@ -4,3 +4,6 @@ metadata:
   name: keycloak
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/kubernetes/platform/identity/lldap/base/namespace.yaml
+++ b/kubernetes/platform/identity/lldap/base/namespace.yaml
@@ -6,3 +6,5 @@ metadata:
     name: lldap
     tier: platform
     component: identity
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/kubernetes/tenants/drova/namespace.yaml
+++ b/kubernetes/tenants/drova/namespace.yaml
@@ -5,5 +5,7 @@ metadata:
   labels:
     istio.io/dataplane-mode: ambient
     istio.io/use-waypoint: waypoint
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted
   annotations:
     argocd.argoproj.io/sync-wave: "-1"

--- a/kubernetes/tenants/ml/namespace.yaml
+++ b/kubernetes/tenants/ml/namespace.yaml
@@ -4,3 +4,6 @@ metadata:
   name: ml
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/kubernetes/tenants/n8n-prod/namespace.yaml
+++ b/kubernetes/tenants/n8n-prod/namespace.yaml
@@ -7,3 +7,5 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: argocd
     platform.homelab/tenant: n8n-prod
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted


### PR DESCRIPTION
warn+audit=restricted auf 11 App-NS (enforce bleibt baseline → non-breaking). PolicyReport zeigt dann, was bei restricted bräche, bevor man enforce schaltet. Teil #52.