### PR TITLE
chore(deps): update openbao to v0 - autoclosed

### DIFF
--- a/kubernetes/infrastructure/secrets/openbao/base/kustomization.yaml
+++ b/kubernetes/infrastructure/secrets/openbao/base/kustomization.yaml
@@ -23,7 +23,7 @@ patches:
 helmCharts:
   - name: openbao
     repo: https://openbao.github.io/openbao-helm
-    version: 0.28.6
+    version: 0.29.0
     releaseName: openbao
     namespace: openbao
     includeCRDs: true


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/openbao-0.x`
Filter passed: <24h old, <5 commits ahead.