### PR TITLE
chore(deps): update redis-operator to v0 - autoclosed

### DIFF
--- a/kubernetes/infrastructure/operators/redis/base/kustomization.yaml
+++ b/kubernetes/infrastructure/operators/redis/base/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   # OpsTree Redis Operator (handles Redis, RedisCluster, RedisReplication, RedisSentinel CRDs)
   - name: redis-operator
     repo: https://ot-container-kit.github.io/helm-charts/
-    version: "0.23.0"
+    version: "0.25.0"
     releaseName: redis-operator
     namespace: redis-operator-system
     includeCRDs: true


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/redis-operator-0.x`
Filter passed: <24h old, <5 commits ahead.