### PR TITLE
chore(deps): update velero to v12 - autoclosed

### DIFF
--- a/kubernetes/infrastructure/storage/velero/base/kustomization.yaml
+++ b/kubernetes/infrastructure/storage/velero/base/kustomization.yaml
@@ -15,7 +15,7 @@ resources:
 helmCharts:
   - name: velero
     repo: https://vmware-tanzu.github.io/helm-charts
-    version: 11.4.0
+    version: 12.1.0
     releaseName: velero
     namespace: velero
     includeCRDs: true


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/velero-12.x`
Filter passed: <24h old, <5 commits ahead.