### PR TITLE
chore(deps): update docker.io-prompve-prometheus-pve-exporter to v3 - autoclosed

### DIFF
--- a/kubernetes/infrastructure/observability/pve-exporter/base/deployment.yaml
+++ b/kubernetes/infrastructure/observability/pve-exporter/base/deployment.yaml
@@ -22,7 +22,7 @@ spec:
           # PVE_TOKEN_VALUE from env (via config_from_env in cli.py). When --config.file
           # is set, env vars are silently ignored — that's how the previous setup got
           # "401 invalid token value": the file had no token_value field.
-          image: docker.io/prompve/prometheus-pve-exporter:3.9.0@sha256:78a58df7a31c9fbee94962cd06422672668529de6421892df9aed4b6cee0757f
+          image: docker.io/prompve/prometheus-pve-exporter:3.10.0@sha256:4867684c0a937716f11f770a32d32958bded507cf570fc334f774392afcb2f37
           args:
             - --web.listen-address=:9221
           env:


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/docker.io-prompve-prometheus-pve-exporter-3.x`
Filter passed: <24h old, <5 commits ahead.