### PR TITLE
chore(deps): update strimzi-kafka-operator to v1 - autoclosed

### DIFF
--- a/kubernetes/infrastructure/operators/strimzi/base/kustomization.yaml
+++ b/kubernetes/infrastructure/operators/strimzi/base/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 helmCharts:
   - name: strimzi-kafka-operator
     repo: https://strimzi.io/charts
-    version: "0.51.0"
+    version: "1.1.0"
     releaseName: strimzi-kafka-operator
     namespace: kafka
     includeCRDs: true


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/strimzi-kafka-operator-1.x`
Filter passed: <24h old, <5 commits ahead.