### PR TITLE
chore(deps): update kube-prometheus-stack to v87 - autoclosed

### DIFF
--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/overlays/prod/kustomization.yaml
@@ -12,6 +12,6 @@ helmCharts:
     repo: https://prometheus-community.github.io/helm-charts
     includeCRDs: true
     namespace: monitoring
-    version: 87.10.0
+    version: 87.21.0
     releaseName: kube-prometheus-stack
     valuesFile: ./values-prod.yaml


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/kube-prometheus-stack-87.x`
Filter passed: <24h old, <5 commits ahead.