### PR TITLE
chore(deps): update gateway-helm to v1

### DIFF
--- a/kubernetes/infrastructure/ingress/gateway/base/kustomization.yaml
+++ b/kubernetes/infrastructure/ingress/gateway/base/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: gateway
 helmCharts:
   - name: gateway-helm
     repo: oci://docker.io/envoyproxy
-    version: 1.6.7
+    version: 1.8.3
     releaseName: eg
     namespace: gateway
     includeCRDs: true


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/gateway-helm-1.x`
Filter passed: <24h old, <5 commits ahead.