### PR TITLE
chore(deps): update prometheus-blackbox-exporter to v11 - autoclosed

### DIFF
--- a/kubernetes/infrastructure/observability/blackbox-exporter/base/kustomization.yaml
+++ b/kubernetes/infrastructure/observability/blackbox-exporter/base/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 helmCharts:
   - name: prometheus-blackbox-exporter
     repo: https://prometheus-community.github.io/helm-charts
-    version: 9.8.0
+    version: 11.17.2
     releaseName: blackbox-exporter
     namespace: monitoring
     valuesFile: values.yaml


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/prometheus-blackbox-exporter-11.x`
Filter passed: <24h old, <5 commits ahead.