### PR TITLE
chore(deps): update argo-project

### DIFF
--- a/kubernetes/infrastructure/argocd/base/kustomization.yaml
+++ b/kubernetes/infrastructure/argocd/base/kustomization.yaml
@@ -34,7 +34,7 @@ resources:
 helmCharts:
   - name: argo-cd
     repo: https://argoproj.github.io/argo-helm
-    version: 10.0.0
+    version: 10.2.1
     releaseName: "argocd"
     namespace: argocd
     valuesFile: values.yaml


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/argo-project`
Filter passed: <24h old, <5 commits ahead.