### PR TITLE
chore(deps): update cilium to v1 - autoclosed

### DIFF
--- a/kubernetes/infrastructure/network/cilium/base/kustomization.yaml
+++ b/kubernetes/infrastructure/network/cilium/base/kustomization.yaml
@@ -11,7 +11,7 @@ resources:
 helmCharts:
   - name: cilium
     repo: https://helm.cilium.io
-    version: 1.19.6
+    version: 1.20.0
     releaseName: "cilium"
     namespace: kube-system
     includeCRDs: true


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/cilium-1.x`
Filter passed: <24h old, <5 commits ahead.