### PR TITLE
chore(deps): update cert-manager to v1.21 - autoclosed

### DIFF
--- a/kubernetes/infrastructure/certificates/cert-manager/base/kustomization.yaml
+++ b/kubernetes/infrastructure/certificates/cert-manager/base/kustomization.yaml
@@ -16,7 +16,7 @@ resources:
 helmCharts:
   - name: cert-manager
     repo: https://charts.jetstack.io
-    version: v1.21.0
+    version: v1.21.1
     releaseName: cert-manager
     namespace: cert-manager
     valuesFile: values.yaml


### PR DESCRIPTION
Auto-PR for orphan Renovate branch (v43 quirk workaround).

Branch: `renovate/cert-manager-1.21.x`
Filter passed: <24h old, <5 commits ahead.